### PR TITLE
RFC 6530-32 - Email Address Internationalization

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Universal
 gcc gcc-c++ make autoconf automaake libtool pkgconfig
 sed findutils diffutils gzip binutils coreutils grep
 glibc glibc-devel procps openssl openssl-devel mysql-devel
-libqmail-devel libqmail
+libqmail-devel libqmail libidn2-devel
 
 opensuse - openldap2-devel instead of openldap-devel
 ```
@@ -60,12 +60,18 @@ Install the following packages using apt
 ```
 Universal
 cdbs debhelper gcc g++ automake autoconf libtool libqmail-dev libqmail
-libldap2-dev libssl-dev mime-support m4 gawk openssl procps sed
-findutils diffutils readline gzip binutils coreutils grep
+libldap2-dev libssl-dev libidn2-0-dev mime-support m4 gawk openssl 
+procps sed findutils diffutils readline gzip binutils coreutils grep
 
 Debian 9, Debian 10 - default-libmysqlclient-dev
 Remaining - libmysqlclient-dev
 Ubuntu 16.04 - libcom-err2 libmysqlclient-dev
+```
+
+NOTE: for Darwin
+
+```
+# port install libidn2
 ```
 
 ## Download / clone libqmail

--- a/indimail-mta-x/.gitignore
+++ b/indimail-mta-x/.gitignore
@@ -619,3 +619,4 @@ sslerator
 sslerator.o
 queue-fix.8
 PKGBUILD.proto
+hassmtputf8.h

--- a/indimail-mta-x/Makefile
+++ b/indimail-mta-x/Makefile
@@ -1537,6 +1537,20 @@ rrt.1: rrt.9 conf-sysconfdir
 qr_digest_md5.o: compile qr_digest_md5.c
 	./compile qr_digest_md5.c
 
+hassmtputf8.h: \
+tryidn2.c compile load conf-smtputf8
+	((./compile `grep -h -v "^#" conf-smtputf8` tryidn2.c \
+		&& ./load tryidn2 -lidn2) >/dev/null 2>&1 \
+	&& echo \#define SMTPUTF8 1 || echo "WARNING!!! Not compiled with -DSMTPUTF8" 1<&2) > hassmtputf8.h
+	rm -f tryidn2.o tryidn2
+
+idn2.lib: \
+tryidn2.c compile load conf-smtputf8
+	((./compile `grep -h -v "^#" conf-smtputf8` tryidn2.c \
+		&& ./load tryidn2 -lidn2) >/dev/null 2>&1 \
+	&& echo "-lidn2" || echo "WARNING!!! Not linked with libidn2" 1>&2) > idn2.lib
+	rm -f tryidn2.o tryidn2
+
 qmail-remote: \
 load qmail-remote.o control.o timeoutconn.o tcpto.o dns.o ip.o \
 ipalloc.o strsalloc.o ipme.o quote.o variables.o tls.o \
@@ -1559,20 +1573,6 @@ qmail-remote.9 conf-qmail conf-sysconfdir conf-libexec
 	| sed s}LIBEXEC}"`head -1 conf-libexec`"}g \
 	| sed s}@sysconfdir\@}"`head -1 conf-sysconfdir`"}g \
 	> qmail-remote.8
-
-hassmtputf8.h: \
-tryinotify.c compile load conf-smtputf8
-	((./compile `grep -h -v "^#" conf-smtputf8` tryidn2.c \
-		&& ./load tryidn2 -lidn2) >/dev/null 2>&1 \
-	&& echo \#define SMTPUTF8 1 || echo "WARNING!!! Not compiled with -DSMTPUTF8" 1<&2) > hassmtputf8.h
-	rm -f tryidn2.o tryidn2
-
-idn2.lib: \
-tryinotify.c compile load conf-smtputf8
-	((./compile `grep -h -v "^#" conf-smtputf8` tryidn2.c \
-		&& ./load tryidn2 -lidn2) >/dev/null 2>&1 \
-	&& echo "-lidn2" || echo "WARNING!!! Not linked with libidn2" 1>&2) > idn2.lib
-	rm -f tryidn2.o tryidn2
 
 qmail-remote.o: \
 compile qmail-remote.c tls.h ssl_timeoutio.h auth_cram.h \

--- a/indimail-mta-x/Makefile
+++ b/indimail-mta-x/Makefile
@@ -1548,7 +1548,7 @@ fn_handler.o query_skt.o tlsacheck.o auto_qmail.o dns.lib socket.lib tls.lib
 	socket_v6any.o ipalloc.o socket_v4mappedprefix.o strsalloc.o \
 	ipme.o quote.o fn_handler.o qr_digest_md5.o query_skt.o \
 	tlsarralloc.o variables.o socket_tcp.o socket_tcp6.o tls.o \
-	auto_qmail.o `cat dns.lib socket.lib tls.lib` -lqmail
+	auto_qmail.o `cat dns.lib socket.lib tls.lib` -lqmail -lidn2
 
 qmail-remote.8: \
 qmail-remote.9 conf-qmail conf-sysconfdir conf-libexec
@@ -1558,15 +1558,23 @@ qmail-remote.9 conf-qmail conf-sysconfdir conf-libexec
 	| sed s}@sysconfdir\@}"`head -1 conf-sysconfdir`"}g \
 	> qmail-remote.8
 
+hassmtputf8.h: \
+tryinotify.c compile load conf-smtputf8
+	((./compile `grep -h -v "^#" conf-smtputf8` tryidn2.c \
+		&& ./load tryidn2 -lidn2) >/dev/null 2>&1 \
+	&& echo \#define SMTPUTF8 1 || exit 0) > hassmtputf8.h
+	rm -f tryidn2.o tryidn2
+
 qmail-remote.o: \
 compile qmail-remote.c tls.h ssl_timeoutio.h auth_cram.h \
 auto_qmail.h control.h dns.h quote.h ip.h ipalloc.h \
 query_skt.h ipme.h tcpto.h timeoutconn.h haveip6.h socket.h \
 variables.h hastlsv1_1_client.h hastlsv1_2_client.h \
 auto_control.h hastlsa.h tlsacheck.h fn_handler.h \
-tlsarralloc.h conf-tls conf-ip conf-batv conf-mxps
-	./compile `grep -h -v "^#" conf-tls conf-ip conf-mxps conf-batv` \
-		qmail-remote.c
+tlsarralloc.h hassmtputf8.h conf-tls conf-ip conf-batv conf-mxps \
+conf-smtputf8
+	./compile `grep -h -v "^#" conf-tls conf-ip conf-mxps \
+		conf-batv` qmail-remote.c
 
 qmail-rspawn: \
 load qmail-rspawn.o spawn.o tcpto_clean.o get_uid.o \
@@ -1657,15 +1665,16 @@ compile plugtest.c auto_qmail.h auto_prefix.h smtp_plugin.h
 	./compile plugtest.c
 
 qmail_smtpd.so: \
-smtpd.o rcpthosts.o recipients.o indimail_stub.o \
-ip.o ipme.o ipalloc.o strsalloc.o control.o etrn.o atrn.o \
-received.o date822fmt.o wildmat.o qmail.o variables.o tls.o \
-envrules.o bodycheck.o sqlmatch.o matchregex.o qcount_dir.o \
+smtpd.o rcpthosts.o recipients.o indimail_stub.o ip.o ipme.o \
+ipalloc.o strsalloc.o control.o etrn.o atrn.o received.o \
+date822fmt.o wildmat.o qmail.o variables.o tls.o envrules.o \
+bodycheck.o sqlmatch.o matchregex.o qcount_dir.o mail_acl.o \
 socket_ip4loopback.o socket_v6loopback.o socket_v4mappedprefix.o \
-socket_v6any.o mail_acl.o spf.o dns.o auto_qmail.o auto_uids.o \
-qregex_sql.o tablematch.o greylist.o query_skt.o fn_handler.o load_mysql.o \
-auto_break.o auto_control.o auto_assign.o auto_prefix.o auto_sysconfdir.o \
-socket.lib dns.lib tls.lib mysql_config conf-sql conf-ld-$(SYSTEM)
+socket_v6any.o spf.o dns.o auto_qmail.o auto_uids.o qregex_sql.o \
+tablematch.o greylist.o query_skt.o fn_handler.o load_mysql.o \
+auto_break.o auto_control.o auto_assign.o auto_prefix.o \
+auto_sysconfdir.o socket.lib dns.lib tls.lib \
+mysql_config conf-ld-$(SYSTEM)
 	if test $(SYSTEM) = DARWIN ; then \
 		$(LD) -bundle -undefined dynamic_lookup -o qmail_smtpd.so \
 		smtpd.o rcpthosts.o recipients.o indimail_stub.o load_mysql.o \
@@ -1802,8 +1811,8 @@ matchregex.o variables.h rcpthosts.h etrn.h date822fmt.h \
 envrules.h tablematch.h matchregex.h qregex.h sqlmatch.h \
 smtp_plugin.h auto_prefix.h hastlsv1_1_server.h \
 hastlsv1_2_server.h hasmysql.h indimail_stub.h \
-auto_control.h dns.h conf-tls conf-spf conf-ip \
-conf-plugin conf-batv mysql_config mysql_inc
+auto_control.h dns.h hassmtputf8.h conf-tls conf-spf conf-ip \
+conf-plugin conf-batv conf-smtputf8 mysql_config mysql_inc
 	./compile `grep -h -v "^#" conf-tls conf-spf \
 	conf-ip conf-batv conf-plugin mysql_inc` smtpd.c
 
@@ -3468,7 +3477,7 @@ trytlsv1_2_client.c compile load
 
 hasinotify.h: \
 tryinotify.c compile load
-	( ( ./compile tryinotify.c && ./load tryinotify ) >/dev/null \
+	(( ./compile tryinotify.c && ./load tryinotify ) >/dev/null \
 	2>&1 \
 	&& echo \#define HASINOTIFY 1 || exit 0 ) > hasinotify.h
 	rm -f tryinotify.o tryinotify

--- a/indimail-mta-x/Makefile
+++ b/indimail-mta-x/Makefile
@@ -1540,15 +1540,17 @@ qr_digest_md5.o: compile qr_digest_md5.c
 qmail-remote: \
 load qmail-remote.o control.o timeoutconn.o tcpto.o dns.o ip.o \
 ipalloc.o strsalloc.o ipme.o quote.o variables.o tls.o \
-auto_control.o socket_ip4loopback.o socket_v6loopback.o socket_v6any.o \
-tlsarralloc.o qr_digest_md5.o socket_v4mappedprefix.o socket_tcp.o socket_tcp6.o \
-fn_handler.o query_skt.o tlsacheck.o auto_qmail.o dns.lib socket.lib tls.lib 
-	./load qmail-remote control.o tlsacheck.o auto_control.o timeoutconn.o \
-	tcpto.o dns.o ip.o socket_ip4loopback.o socket_v6loopback.o \
-	socket_v6any.o ipalloc.o socket_v4mappedprefix.o strsalloc.o \
-	ipme.o quote.o fn_handler.o qr_digest_md5.o query_skt.o \
-	tlsarralloc.o variables.o socket_tcp.o socket_tcp6.o tls.o \
-	auto_qmail.o `cat dns.lib socket.lib tls.lib` -lqmail -lidn2
+auto_control.o socket_ip4loopback.o socket_v6loopback.o \
+socket_v6any.o tlsarralloc.o qr_digest_md5.o fn_handler.o \
+query_skt.o tlsacheck.o auto_qmail.o dns.lib socket.lib tls.lib \
+socket_v4mappedprefix.o socket_tcp.o socket_tcp6.o idn2.lib
+	./load qmail-remote control.o tlsacheck.o auto_control.o \
+	timeoutconn.o tcpto.o dns.o ip.o socket_ip4loopback.o \
+	socket_v6loopback.o socket_v6any.o ipalloc.o \
+	socket_v4mappedprefix.o strsalloc.o ipme.o quote.o fn_handler.o \
+	qr_digest_md5.o query_skt.o tlsarralloc.o variables.o \
+	socket_tcp.o socket_tcp6.o tls.o auto_qmail.o `cat dns.lib \
+	socket.lib tls.lib idn2.lib` -lqmail
 
 qmail-remote.8: \
 qmail-remote.9 conf-qmail conf-sysconfdir conf-libexec
@@ -1562,7 +1564,14 @@ hassmtputf8.h: \
 tryinotify.c compile load conf-smtputf8
 	((./compile `grep -h -v "^#" conf-smtputf8` tryidn2.c \
 		&& ./load tryidn2 -lidn2) >/dev/null 2>&1 \
-	&& echo \#define SMTPUTF8 1 || exit 0) > hassmtputf8.h
+	&& echo \#define SMTPUTF8 1 || echo "WARNING!!! Not compiled with -DSMTPUTF8" 1<&2) > hassmtputf8.h
+	rm -f tryidn2.o tryidn2
+
+idn2.lib: \
+tryinotify.c compile load conf-smtputf8
+	((./compile `grep -h -v "^#" conf-smtputf8` tryidn2.c \
+		&& ./load tryidn2 -lidn2) >/dev/null 2>&1 \
+	&& echo "-lidn2" || echo "WARNING!!! Not linked with libidn2" 1>&2) > idn2.lib
 	rm -f tryidn2.o tryidn2
 
 qmail-remote.o: \
@@ -2178,7 +2187,7 @@ tlsarralloc.o dns.lib socket.lib
 
 tcp-env.o: \
 compile tcp-env.c strsalloc.h ip.h dns.h remoteinfo.h \
-socket.h haveip6.h conf-spf conf-ip
+hassalen.h socket.h haveip6.h conf-spf conf-ip
 	./compile `grep -h -v "^#" conf-spf conf-ip` tcp-env.c
 
 tcpto.o: \

--- a/indimail-mta-x/TARGETS
+++ b/indimail-mta-x/TARGETS
@@ -1138,3 +1138,4 @@ run_init.o
 sslerator
 sslerator.o
 queue-fix.8
+hassmtputf8.h

--- a/indimail-mta-x/TARGETS
+++ b/indimail-mta-x/TARGETS
@@ -1139,3 +1139,4 @@ sslerator
 sslerator.o
 queue-fix.8
 hassmtputf8.h
+idn2.lib

--- a/indimail-mta-x/conf-smtputf8
+++ b/indimail-mta-x/conf-smtputf8
@@ -1,0 +1,1 @@
+-DSMTPUTF8

--- a/indimail-mta-x/create_services.in
+++ b/indimail-mta-x/create_services.in
@@ -23,7 +23,7 @@ cp=$(which cp)
 # End USER Configuration OPTIONS
 #
 
-# $Id: create_services.in,v 2.91 2020-10-07 19:21:23+05:30 Cprogrammer Exp mbhangui $
+# $Id: create_services.in,v 2.92 2020-12-03 17:28:17+05:30 Cprogrammer Exp mbhangui $
 
 usage()
 {
@@ -412,20 +412,16 @@ fi
 for port in 465 25 587
 do
   if [ $port -eq 465 ] ; then
-    e_opt="--skipsend --authsmtp --ssl"
+    e_opt="--skipsend --authsmtp --ssl --utf8"
     e_opt="$e_opt --rbl=-rzen.spamhaus.org --rbl=-rdnsbl-1.uceprotect.net"
   elif [ $port -eq 587 ] ; then
     nobogofilter=1
-    e_opt="--skipsend --forceauthsmtp --antispoof --forcetls"
+    e_opt="--skipsend --forceauthsmtp --antispoof --forcetls --utf8"
   else
-    if [ $port -eq 25 ] ; then
     e_opt="--remote-authsmtp=plain --localfilter --remotefilter"
-    e_opt="--dmemory=$send_soft_mem"
-    else
-    e_opt="--authsmtp"
-    fi
     e_opt="$e_opt --deliverylimit-count=-1 --deliverylimit-size=-1"
     e_opt="$e_opt --rbl=-rzen.spamhaus.org --rbl=-rdnsbl-1.uceprotect.net"
+    e_opt="$e_opt --dmemory=$send_soft_mem --utf8"
   fi
   if [ $tcpserver_plugin -eq 1 ] ; then
     e_opt="$e_opt --shared-objects=1 --use-dlmopen=1"

--- a/indimail-mta-x/debian/Makefile.in
+++ b/indimail-mta-x/debian/Makefile.in
@@ -16,10 +16,10 @@ all: rules indimail-mta.prerm indimail-mta.preinst \
 indimail-mta.postrm indimail-mta.postinst \
 indimail-mini.prerm indimail-mini.preinst \
 indimail-mini.postrm indimail-mini.postinst \
-indimail-mta.install \
-indimail-mta.dsc indimail-mta-Debian_9.0.dsc \
-indimail-mta-Debian_10.dsc indimail-mta-xUbuntu_18.04.dsc \
-debian.tar.gz
+indimail-mta.install indimail-mta.dsc \
+indimail-mta-Debian_9.0.dsc indimail-mta-Debian_10.dsc \
+indimail-mta-xUbuntu_18.04.dsc indimail-mta-Raspbian_10.dsc \
+indimail-mta-Raspbian_9.0.dsc debian.tar.gz
 
 edit = sed \
 	-e 's,@version\@,$(version),g' \
@@ -66,6 +66,10 @@ changelog: changelog.in ../conf-version ../conf-release
 indimail-mta.install: indimail-mta.install.in Makefile
 	$(edit) $@.in > $@
 indimail-mta.dsc: indimail-mta.dsc.in Makefile ../conf-version ../conf-release
+	$(edit) $@.in > $@
+indimail-mta-Raspbian_10.dsc: indimail-mta-Raspbian_10.dsc.in Makefile ../conf-version ../conf-release
+	$(edit) $@.in > $@
+indimail-mta-Raspbian_9.0.dsc: indimail-mta-Raspbian_9.0.dsc.in Makefile ../conf-version ../conf-release
 	$(edit) $@.in > $@
 indimail-mta-Debian_10.dsc: indimail-mta-Debian_10.dsc.in Makefile ../conf-version ../conf-release
 	$(edit) $@.in > $@

--- a/indimail-mta-x/debian/changelog.in
+++ b/indimail-mta-x/debian/changelog.in
@@ -87,6 +87,7 @@ indimail-mta (@version@-@release@) unstable; urgency=low
   * preinst/postinst: modified service shutdown/startup during upgrade by using /run, /var/run
   * smtpd.c: refactored batv code
   * 822field.c, 822fields.c: +HeaderName feature by Erwin Hoffman: display all headers which have HeaderName as the initial text
-  * qmail-remote: fixed smtpcode() to handle in case remote smtp server returns improper codes
+  * qmail-remote: fixed smtpcode() handle cases where remote smtp server returns improper codes
   * queue-fix: replaced stdio with substdio and added option to specify queue subdirectory split
   * hier.c: moved README.logselect to daemontools
+  * smtpd.c, qmail-remote.c: Added EAI RFC 6530-32 - unicode address support

--- a/indimail-mta-x/debian/indimail-mta-Debian_10.dsc.in
+++ b/indimail-mta-x/debian/indimail-mta-Debian_10.dsc.in
@@ -11,4 +11,4 @@ Debtransform-Release: 1
 Debtransform-Tar: indimail-mta-@version@.tar.gz
 Debtransform-Files-Tar: debian.tar.gz
 Standards-Version: 3.9.1
-Build-Depends: cdbs, debhelper (>= 10), gcc, g++, binutils, automake, libqmail-dev, libdkim-dev, libsrs2-dev, libldap2-dev, libssl-dev, default-libmysqlclient-dev, mime-support, m4, gawk
+Build-Depends: cdbs, debhelper (>= 10), gcc, g++, binutils, automake, libqmail-dev, libdkim-dev, libsrs2-dev, libldap2-dev, libssl-dev, libidn2-0-dev, default-libmysqlclient-dev, mime-support, m4, gawk

--- a/indimail-mta-x/debian/indimail-mta-Debian_10.dsc.in
+++ b/indimail-mta-x/debian/indimail-mta-Debian_10.dsc.in
@@ -11,4 +11,4 @@ Debtransform-Release: 1
 Debtransform-Tar: indimail-mta-@version@.tar.gz
 Debtransform-Files-Tar: debian.tar.gz
 Standards-Version: 3.9.1
-Build-Depends: cdbs, debhelper (>= 10), gcc, g++, binutils, automake, libqmail-dev, libdkim-dev, libsrs2-dev, libldap2-dev, libssl-dev, libidn2-0-dev, default-libmysqlclient-dev, mime-support, m4, gawk
+Build-Depends: cdbs, debhelper (>= 10), gcc, g++, coreutils, automake, libqmail-dev, libdkim-dev, libsrs2-dev, libldap2-dev, libssl-dev, libidn2-0-dev, default-libmysqlclient-dev, mime-support, m4, gawk

--- a/indimail-mta-x/debian/indimail-mta-Debian_9.0.dsc.in
+++ b/indimail-mta-x/debian/indimail-mta-Debian_9.0.dsc.in
@@ -11,4 +11,4 @@ Debtransform-Release: 1
 Debtransform-Tar: indimail-mta-@version@.tar.gz
 Debtransform-Files-Tar: debian.tar.gz
 Standards-Version: 3.9.1
-Build-Depends: cdbs, debhelper (>= 10), gcc, g++, binutils, automake, libqmail-dev, libdkim-dev, libsrs2-dev, libldap2-dev, libssl-dev, default-libmysqlclient-dev, mime-support, m4, gawk
+Build-Depends: cdbs, debhelper (>= 10), gcc, g++, binutils, automake, libqmail-dev, libdkim-dev, libsrs2-dev, libldap2-dev, libssl-dev, libidn2-0-dev, default-libmysqlclient-dev, mime-support, m4, gawk

--- a/indimail-mta-x/debian/indimail-mta-Debian_9.0.dsc.in
+++ b/indimail-mta-x/debian/indimail-mta-Debian_9.0.dsc.in
@@ -11,4 +11,4 @@ Debtransform-Release: 1
 Debtransform-Tar: indimail-mta-@version@.tar.gz
 Debtransform-Files-Tar: debian.tar.gz
 Standards-Version: 3.9.1
-Build-Depends: cdbs, debhelper (>= 10), gcc, g++, binutils, automake, libqmail-dev, libdkim-dev, libsrs2-dev, libldap2-dev, libssl-dev, libidn2-0-dev, default-libmysqlclient-dev, mime-support, m4, gawk
+Build-Depends: cdbs, debhelper (>= 10), gcc, g++, coreutils, automake, libqmail-dev, libdkim-dev, libsrs2-dev, libldap2-dev, libssl-dev, libidn2-0-dev, default-libmysqlclient-dev, mime-support, m4, gawk

--- a/indimail-mta-x/debian/indimail-mta-Raspbian_10.dsc.in
+++ b/indimail-mta-x/debian/indimail-mta-Raspbian_10.dsc.in
@@ -1,0 +1,14 @@
+Format: 1.0
+Source: indimail-mta
+Section: Misc
+Priority: extra
+Binary: indimail-mta
+Architecture: any
+Version: @version@-@release@
+Maintainer: Manvendra Bhangui <indimail-mta@indimail.org>
+Homepage: https://github.com/mbhangui/indimail-mta
+Debtransform-Release: 1
+Debtransform-Tar: indimail-mta-@version@.tar.gz
+Debtransform-Files-Tar: debian.tar.gz
+Standards-Version: 3.9.1
+Build-Depends: cdbs, debhelper (>= 10), gcc, g++, coreutils, automake, libqmail-dev, libdkim-dev, libsrs2-dev, libldap2-dev, libssl-dev, libidn2-0-dev, default-libmysqlclient-dev, mime-support, m4, gawk

--- a/indimail-mta-x/debian/indimail-mta-Raspbian_9.0.dsc.in
+++ b/indimail-mta-x/debian/indimail-mta-Raspbian_9.0.dsc.in
@@ -1,0 +1,14 @@
+Format: 1.0
+Source: indimail-mta
+Section: Misc
+Priority: extra
+Binary: indimail-mta
+Architecture: any
+Version: @version@-@release@
+Maintainer: Manvendra Bhangui <indimail-mta@indimail.org>
+Homepage: https://github.com/mbhangui/indimail-mta
+Debtransform-Release: 1
+Debtransform-Tar: indimail-mta-@version@.tar.gz
+Debtransform-Files-Tar: debian.tar.gz
+Standards-Version: 3.9.1
+Build-Depends: cdbs, debhelper (>= 10), gcc, g++, coreutils, automake, libqmail-dev, libdkim-dev, libsrs2-dev, libldap2-dev, libssl-dev, libidn2-0-dev, default-libmysqlclient-dev, mime-support, m4, gawk

--- a/indimail-mta-x/debian/indimail-mta-xUbuntu_18.04.dsc.in
+++ b/indimail-mta-x/debian/indimail-mta-xUbuntu_18.04.dsc.in
@@ -11,4 +11,4 @@ Debtransform-Release: 1
 Debtransform-Tar: indimail-mta-@version@.tar.gz
 Debtransform-Files-Tar: debian.tar.gz
 Standards-Version: 3.9.1
-Build-Depends: cdbs, debhelper (>= 10), gcc, g++, binutils, automake, libqmail-dev, libdkim-dev, libsrs2-dev, libldap2-dev, libssl-dev, libmysqlclient-dev, libcom-err2, mime-support, m4, gawk
+Build-Depends: cdbs, debhelper (>= 10), gcc, g++, binutils, automake, libqmail-dev, libdkim-dev, libsrs2-dev, libldap2-dev, libssl-dev, libidn2-0-dev, libmysqlclient-dev, libcom-err2, mime-support, m4, gawk

--- a/indimail-mta-x/debian/indimail-mta-xUbuntu_18.04.dsc.in
+++ b/indimail-mta-x/debian/indimail-mta-xUbuntu_18.04.dsc.in
@@ -11,4 +11,4 @@ Debtransform-Release: 1
 Debtransform-Tar: indimail-mta-@version@.tar.gz
 Debtransform-Files-Tar: debian.tar.gz
 Standards-Version: 3.9.1
-Build-Depends: cdbs, debhelper (>= 10), gcc, g++, binutils, automake, libqmail-dev, libdkim-dev, libsrs2-dev, libldap2-dev, libssl-dev, libidn2-0-dev, libmysqlclient-dev, libcom-err2, mime-support, m4, gawk
+Build-Depends: cdbs, debhelper (>= 10), gcc, g++, coreutils, automake, libqmail-dev, libdkim-dev, libsrs2-dev, libldap2-dev, libssl-dev, libidn2-0-dev, libmysqlclient-dev, libcom-err2, mime-support, m4, gawk

--- a/indimail-mta-x/debian/indimail-mta.dsc.in
+++ b/indimail-mta-x/debian/indimail-mta.dsc.in
@@ -11,4 +11,4 @@ Debtransform-Release: 1
 Debtransform-Tar: indimail-mta-@version@.tar.gz
 Debtransform-Files-Tar: debian.tar.gz
 Standards-Version: 3.9.1
-Build-Depends: cdbs, debhelper (>= 9), gcc, g++, binutils, automake, libqmail-dev, libdkim-dev, libsrs2-dev, libldap2-dev, libssl-dev, libmysqlclient-dev, mime-support, m4, gawk
+Build-Depends: cdbs, debhelper (>= 9), gcc, g++, binutils, automake, libqmail-dev, libdkim-dev, libsrs2-dev, libldap2-dev, libssl-dev, libidn2-0-dev, libmysqlclient-dev, mime-support, m4, gawk

--- a/indimail-mta-x/debian/indimail-mta.dsc.in
+++ b/indimail-mta-x/debian/indimail-mta.dsc.in
@@ -11,4 +11,4 @@ Debtransform-Release: 1
 Debtransform-Tar: indimail-mta-@version@.tar.gz
 Debtransform-Files-Tar: debian.tar.gz
 Standards-Version: 3.9.1
-Build-Depends: cdbs, debhelper (>= 9), gcc, g++, binutils, automake, libqmail-dev, libdkim-dev, libsrs2-dev, libldap2-dev, libssl-dev, libidn2-0-dev, libmysqlclient-dev, mime-support, m4, gawk
+Build-Depends: cdbs, debhelper (>= 9), gcc, g++, coreutils, automake, libqmail-dev, libdkim-dev, libsrs2-dev, libldap2-dev, libssl-dev, libidn2-0-dev, libmysqlclient-dev, mime-support, m4, gawk

--- a/indimail-mta-x/debian/indimail-mta.postinst.in
+++ b/indimail-mta-x/debian/indimail-mta.postinst.in
@@ -290,7 +290,7 @@ for port in 465 25 587
 do
 	extra_opt=""
 	if [ $port -eq 465 ] ; then
-		extra_opt="--skipsend --ssl"
+		extra_opt="--skipsend --authsmtp --ssl --utf8"
 		extra_opt="$extra_opt --rbl=-rzen.spamhaus.org --rbl=-rdnsbl-1.uceprotect.net"
 	elif [ $port -eq 587 ] ; then
 		# local authenticated users
@@ -298,12 +298,12 @@ do
 		# if you do, then you have a serious
 		# problem with your organization, not
 		# with IndiMail
-		extra_opt="--skipsend --authsmtp --antispoof --forcetls"
+    	extra_opt="--skipsend --forceauthsmtp --antispoof --forcetls --utf8"
 	else
 		extra_opt="--remote-authsmtp=plain --localfilter --remotefilter"
 		extra_opt="$extra_opt --deliverylimit-count=-1 --deliverylimit-size=-1"
 		extra_opt="$extra_opt --rbl=-rzen.spamhaus.org --rbl=-rdnsbl-1.uceprotect.net"
-		extra_opt="$extra_opt --dmemory=$send_soft_mem"
+		extra_opt="$extra_opt --dmemory=$send_soft_mem --utf8"
 	fi
 	if [ $tcpserver_plugin -eq 1 ] ; then
 		extra_opt="$extra_opt --shared-objects=1 --use-dlmopen=1"

--- a/indimail-mta-x/doc/CREDITS
+++ b/indimail-mta-x/doc/CREDITS
@@ -167,3 +167,4 @@ The site http://qmail.org and the qmail mailing list for wealth of information
 106.Rolf Eike Beer <eike@sf-mail.de> gen_allocdefs.h, GEN_ALLOC refactoring
     changes to fix memory overflow
 107.Fefe - felix-libowfat@fefe.de for functions taken from libowfat & ipv6 in ucspi-tcp
+108.RFC 6530-32 EAI - Adapted from Arnt Gulbrandsen unicode address support patch for qmail.

--- a/indimail-mta-x/doc/CREDITS
+++ b/indimail-mta-x/doc/CREDITS
@@ -167,4 +167,5 @@ The site http://qmail.org and the qmail mailing list for wealth of information
 106.Rolf Eike Beer <eike@sf-mail.de> gen_allocdefs.h, GEN_ALLOC refactoring
     changes to fix memory overflow
 107.Fefe - felix-libowfat@fefe.de for functions taken from libowfat & ipv6 in ucspi-tcp
-108.RFC 6530-32 EAI - Adapted from Arnt Gulbrandsen unicode address support patch for qmail.
+108.RFC 6530-32 EAI - Adapted from Arnt Gulbrandsen / EH Hoffman unicode address
+    support patch for qmail.

--- a/indimail-mta-x/doc/ChangeLog
+++ b/indimail-mta-x/doc/ChangeLog
@@ -160,9 +160,11 @@ creation
 - 28/11/2020
 92. 822field.c, 822fields.c: +HeaderName feature by Erwin Hoffman: display all
     headers which have HeaderName as the initial text
-93. qmail-remote: fixed smtpcode() to handle in case remote smtp server returns
+93. qmail-remote: fixed smtpcode() handle cases where remote smtp server returns
     improper codes
 - 29/11/2020
 94. queue-fix: replaced stdio with substdio and added option to specify queue
     subdirectory split
 95. hier.c: moved README.logselect to daemontools
+- 03/12/2020
+96. smtpd.c, qmail-remote.c: Added EAI RFC 6530-32 - unicode address support

--- a/indimail-mta-x/indimail-mta.spec.in
+++ b/indimail-mta-x/indimail-mta.spec.in
@@ -1,6 +1,6 @@
 #
 #
-# $Id: indimail-mta.spec.in,v 1.292 2020-12-03 17:28:45+05:30 Cprogrammer Exp mbhangui $
+# $Id: indimail-mta.spec.in,v 1.293 2020-12-03 20:59:44+05:30 Cprogrammer Exp mbhangui $
 %undefine _missing_build_ids_terminate_build
 %global _unpackaged_files_terminate_build 1
 
@@ -106,7 +106,7 @@ Conflicts: indimail-mta < 2.0
 Obsoletes: indimail-mta < 2.0
 BuildRequires: gcc gcc-c++ make autoconf automake libtool pkgconfig
 BuildRequires: sed findutils diffutils gzip coreutils grep
-BuildRequires: glibc glibc-devel binutils
+BuildRequires: glibc glibc-devel binutils libidn2-devel
 BuildRequires: openssl openssl-devel mysql-devel
 BuildRequires: libqmail-devel libdkim-devel libsrs2-devel
 

--- a/indimail-mta-x/indimail-mta.spec.in
+++ b/indimail-mta-x/indimail-mta.spec.in
@@ -1,6 +1,6 @@
 #
 #
-# $Id: indimail-mta.spec.in,v 1.291 2020-12-02 19:07:57+05:30 Cprogrammer Exp mbhangui $
+# $Id: indimail-mta.spec.in,v 1.292 2020-12-03 17:28:45+05:30 Cprogrammer Exp mbhangui $
 %undefine _missing_build_ids_terminate_build
 %global _unpackaged_files_terminate_build 1
 
@@ -1173,19 +1173,15 @@ for port in 465 25 587
 do
   extra_opt=""
   if [ $port -eq 465 ] ; then
-    extra_opt="--skipsend --authsmtp --ssl"
+    extra_opt="--skipsend --authsmtp --ssl --utf8"
     extra_opt="$extra_opt --rbl=-rzen.spamhaus.org --rbl=-rdnsbl-1.uceprotect.net"
   elif [ $port -eq 587 ] ; then
-    extra_opt="--skipsend --forceauthsmtp --antispoof --forcetls"
+    extra_opt="--skipsend --forceauthsmtp --antispoof --forcetls --utf8"
   else
-    if [ $port -eq 25 ] ; then
-      extra_opt="--remote-authsmtp=plain --localfilter --remotefilter"
-      extra_opt="--dmemory=%{send_soft_mem}"
-    else
-      extra_opt="--authsmtp"
-    fi
+    extra_opt="--remote-authsmtp=plain --localfilter --remotefilter"
     extra_opt="$extra_opt --deliverylimit-count=-1 --deliverylimit-size=-1"
     extra_opt="$extra_opt --rbl=-rzen.spamhaus.org --rbl=-rdnsbl-1.uceprotect.net"
+    extra_opt="$extra_opt --dmemory=%{send_soft_mem} --utf8"
   fi
 %if %{tcpserver_plugin} == 1
     extra_opt="$extra_opt --shared-objects=1 --use-dlmopen=1"

--- a/indimail-mta-x/qmail-remote.9
+++ b/indimail-mta-x/qmail-remote.9
@@ -26,7 +26,7 @@ or an IP address enclosed in brackets:
 .EX
      [128.32.183.163]
 .EE
- 
+
 The size parameter is only used if the remote host uses the ESMTP SIZE extension defined in
 \fIRFC- 1870\fR. It gives the size of the message in bytes. \fBqmail-remote\fR does not use
 this value to process the mail, the value is only passed to the remote mailserver.
@@ -35,8 +35,10 @@ The envelope recipient addresses are listed as \fIrecip\fR arguments to \fBqmail
 
 The envelope sender address is listed as \fIsender\fR.
 
-qmail-remote respects SMTPUTF8 and EAI addresses. If message is utf8, qmail-remote will
-use idn2_lookup_u8(3) to perform IDNA2008 lookup string conversion on \fIhost\fR.
+If the environment variable UTF8 is defined, qmail-remote will respect
+SMTPUTF8 and EAI addresses. If message is utf8, qmail-remote will
+use idn2_lookup_u8(3) to perform IDNA2008 lookup string conversion
+on \fIhost\fR.
 
 Any Qmail Queue Extra Header (QQEH) information passed to \fBqmail-queue(8)\fR is passed in
 \fIqqeh\fR.
@@ -114,17 +116,17 @@ K
 no supported AUTH method found, continuing without authentication.
 .TP 5
 Z
-Connected to 
+Connected to
 .I host
 but authentication was rejected (AUTH PLAIN).
 .TP 5
 Z
-Connected to 
-.I host 
+Connected to
+.I host
 but unable to base64encode (plain).
 .TP 5
 Z
-Connected to 
+Connected to
 .I host
 but authentication was rejected (plain)."
 .TP 5
@@ -134,23 +136,23 @@ Connected to
 but authentication was rejected (AUTH LOGIN).
 .TP 5
 Z
-Connected to 
+Connected to
 .I host
 but unable to base64encode user.
 .TP 5
 Z
-Connected to 
-.I host 
+Connected to
+.I host
 but authentication was rejected (username).
 .TP 5
 Z
-Connected to 
-.I host 
+Connected to
+.I host
 but unable to base64encode pass.
 .TP 5
 Z
-Connected to 
-.I host 
+Connected to
+.I host
 but authentication was rejected (password).
 .TP 5
 Z
@@ -159,28 +161,28 @@ Connected to
 but authentication was rejected (AUTH CRAM-MD5/CRAM-SHA1/CRAM-SHA256/CRAM-RIPEMD/DIGEST-MD5).
 .TP 5
 Z
-Connected to 
+Connected to
 .I host
 but unable to base64decode challenge.
 .TP 5
 Z
-Connected to 
+Connected to
 .I host
 but got no challenge.
 .TP 5
 Z
-Connected to 
+Connected to
 .I host
 but unable to base64encode username+digest.
 .TP 5
 Z
-Connected to 
-.I host 
+Connected to
+.I host
 but authentication was rejected (username+digest).
 
 .SH "RESULTS"
 .B qmail-remote
-prints some number of 
+prints some number of
 .I recipient reports\fP,
 followed by a
 .I message report\fR.
@@ -335,11 +337,11 @@ while envelope senders in
 (but not
 .B user1@example.com
 itself)
-are bound to 
+are bound to
 .BR 5.6.7.8 ,
 and senders in
 .B heaven.af.mil
-are bound to 
+are bound to
 .BR 1.2.3.4 .
 Connection for message with an envelope sender address of \fBuser1@example.com\fR gets
 bound to
@@ -474,7 +476,7 @@ you are always safe using
 .I smtproutes
 if you do not accept mail from the network.
 Additionally,
-.I smtproutes 
+.I smtproutes
 allows to forward bounces (with a 'Nullsender' MAIL FROM: <>)
 literally expressed as '!@'
 to a particular bounce host:
@@ -505,11 +507,11 @@ without any extra spaces. If the environment variable
 .B AUTH_SMTP
 is set,
 .B qmail-remote
-will use 
+will use
 .B username
 and
 .B password
-to relay out mails through server 
+to relay out mails through server
 .B relay
 using authenticated SMTP. <sp> is a single space character. AUTH_SMTP can also have the values
 DIGEST-MD5, CRAM-RIPEMD, CRAM-SHA1, CRAM-SHA256, CRAM-MD5, LOGIN or PLAIN to use
@@ -529,20 +531,20 @@ of the following environment variables
 If you set the environment variable \fBSECURE_AUTH\fR, AUTH LOGIN and AUTH PLAIN gets disabled, unless qmail-remote
 has opened a TLS session wth the remote host. See the control file \fIclientcert.pem\fR
 
-If all connections to the 
+If all connections to the
 .I relay
-server fail for a 
+server fail for a
 .I max_tolerance
 seconds, further connections to the same server are avoided for a period of at least
 .I penalty
 seconds.
-The default maximum period of failures that will be tolerated - 
-.I max_tolerance 
-is 120 seconds and the minimum penalty - 
-.I penalty 
+The default maximum period of failures that will be tolerated -
+.I max_tolerance
+is 120 seconds and the minimum penalty -
+.I penalty
 is 1 hour.
-By setting the 
-.I penalty 
+By setting the
+.I penalty
 to 0, connections to the server will be attempted inspite of failures. The default values of 1
 hour for minimum penalty, can be changed by setting the environment variable
 .IR MIN_PENALTY .
@@ -582,7 +584,7 @@ without any extra spaces.
 .I qmtproutes
 follows the same syntax as
 .IR smtproutes .
-By default, 
+By default,
 .B qmail-remote
 connects to QMTP service port 209. However
 you can chose a dedicated high-port for QMTP communication
@@ -692,8 +694,8 @@ this option may cause mail to be delayed, bounced, doublebounced, or lost.
 .B qmail-remote
 will not try TLS on servers for which this file exists
 .RB ( <FQDN>
-is the fully-qualified domain name of the remote SMTP server). 
-.IR (tlshosts/<FQDN>.pem 
+is the fully-qualified domain name of the remote SMTP server).
+.IR (tlshosts/<FQDN>.pem
 takes precedence over this file however).
 The default location of @sysconfdir@/control can be overriden by environment variable CERTDIR
 
@@ -702,8 +704,8 @@ The default location of @sysconfdir@/control can be overriden by environment var
 .B qmail-remote
 will not try TLS on servers for which this file exists
 .RB ( host
-is the domain name of the recipient). 
-.IR (tlshosts/<FQDN>.pem 
+is the domain name of the recipient).
+.IR (tlshosts/<FQDN>.pem
 takes precedence over this file however).
 The default location of @sysconfdir@/control can be overriden by environment variable CERTDIR
 
@@ -729,4 +731,5 @@ qmail-qmtpd(8),
 qmail-daned(8),
 tlsacheck(3),
 qmail-tcpok(8),
-qmail-tcpto(8)
+qmail-tcpto(8),
+idn2_lookup_u8(3)

--- a/indimail-mta-x/qmail-remote.9
+++ b/indimail-mta-x/qmail-remote.9
@@ -14,7 +14,7 @@ qmail-remote \- send mail via SMTP / ESMTP or QMTP
 recipients at a remote host. The remote host \fIhost\fR is \fBqmail-remote\fR's first argument.
 \fBqmail-remote\fR sends the message to \fIhost\fR, or to a mail exchanger for \fIhost\fR
 listed in the Domain Name System, via the Simple Mail Transfer Protocol (SMTP/ESMTP) or the
-Quick Mail Transfer Protocol (QMTP).  QMTP is implemented by \fBqmail-qmtpd\fR. \fIhost\fR can
+Quick Mail Transfer Protocol (QMTP). QMTP is implemented by \fBqmail-qmtpd\fR. \fIhost\fR can
 be either a fully-qualified domain name:
 
 .EX
@@ -34,6 +34,9 @@ this value to process the mail, the value is only passed to the remote mailserve
 The envelope recipient addresses are listed as \fIrecip\fR arguments to \fBqmail-remote\fR.
 
 The envelope sender address is listed as \fIsender\fR.
+
+qmail-remote respects SMTPUTF8 and EAI addresses. If message is utf8, qmail-remote will
+use idn2_lookup_u8(3) to perform IDNA2008 lookup string conversion on \fIhost\fR.
 
 Any Qmail Queue Extra Header (QQEH) information passed to \fBqmail-queue(8)\fR is passed in
 \fIqqeh\fR.

--- a/indimail-mta-x/qmail-remote.c
+++ b/indimail-mta-x/qmail-remote.c
@@ -1,6 +1,6 @@
 /*-
  * RCS log at bottom
- * $Id: qmail-remote.c,v 1.138 2020-12-03 17:29:29+05:30 Cprogrammer Exp mbhangui $
+ * $Id: qmail-remote.c,v 1.139 2020-12-03 23:11:54+05:30 Cprogrammer Exp mbhangui $
  */
 #include "cdb.h"
 #include "open.h"
@@ -1985,12 +1985,13 @@ mailfrom_xtext(int use_size)
 	substdio_puts(&smtpto, "MAIL FROM:<");
 	substdio_put(&smtpto, sender.s, sender.len);
 	if (use_size) {
-		substdio_puts(&smtpto, "> SIZE=");
+		substdio_put(&smtpto, "> SIZE=", 7);
 		substdio_puts(&smtpto, msgsize);
-		substdio_puts(&smtpto, " AUTH=");
+		substdio_put(&smtpto, " AUTH=<", 7);
 	} else
-		substdio_puts(&smtpto, "> AUTH=");
+		substdio_put(&smtpto, "> AUTH=<", 8);
 	substdio_put(&smtpto, xuser.s, xuser.len);
+	substdio_put(&smtpto, ">", 1);
 #ifdef SMTPUTF8
 	if (enable_utf8 && smtputf8 && utf8message)
 		substdio_put(&smtpto, " SMTPUTF8", 9);
@@ -3692,7 +3693,7 @@ main(int argc, char **argv)
 void
 getversion_qmail_remote_c()
 {
-	static char    *x = "$Id: qmail-remote.c,v 1.138 2020-12-03 17:29:29+05:30 Cprogrammer Exp mbhangui $";
+	static char    *x = "$Id: qmail-remote.c,v 1.139 2020-12-03 23:11:54+05:30 Cprogrammer Exp mbhangui $";
 	x = sccsidauthcramh;
 	x = sccsidqrdigestmd5h;
 	x++;
@@ -3700,6 +3701,9 @@ getversion_qmail_remote_c()
 
 /*
  * $Log: qmail-remote.c,v $
+ * Revision 1.139  2020-12-03 23:11:54+05:30  Cprogrammer
+ * quote AUTH address
+ *
  * Revision 1.138  2020-12-03 17:29:29+05:30  Cprogrammer
  * added EAI - RFC 6530-32 - unicode address support
  *

--- a/indimail-mta-x/qmail-remote.c
+++ b/indimail-mta-x/qmail-remote.c
@@ -1,6 +1,6 @@
 /*-
  * RCS log at bottom
- * $Id: qmail-remote.c,v 1.139 2020-12-03 23:11:54+05:30 Cprogrammer Exp mbhangui $
+ * $Id: qmail-remote.c,v 1.140 2020-12-07 12:05:49+05:30 Cprogrammer Exp mbhangui $
  */
 #include "cdb.h"
 #include "open.h"
@@ -3694,7 +3694,7 @@ main(int argc, char **argv)
 void
 getversion_qmail_remote_c()
 {
-	static char    *x = "$Id: qmail-remote.c,v 1.139 2020-12-03 23:11:54+05:30 Cprogrammer Exp mbhangui $";
+	static char    *x = "$Id: qmail-remote.c,v 1.140 2020-12-07 12:05:49+05:30 Cprogrammer Exp mbhangui $";
 	x = sccsidauthcramh;
 	x = sccsidqrdigestmd5h;
 	x++;
@@ -3702,6 +3702,9 @@ getversion_qmail_remote_c()
 
 /*
  * $Log: qmail-remote.c,v $
+ * Revision 1.140  2020-12-07 12:05:49+05:30  Cprogrammer
+ * renamed utf8message to flagutf8, firstpart to header
+ *
  * Revision 1.139  2020-12-03 23:11:54+05:30  Cprogrammer
  * quote AUTH address
  *

--- a/indimail-mta-x/qmail-remote.c
+++ b/indimail-mta-x/qmail-remote.c
@@ -163,8 +163,8 @@ struct constmap maptlsadomains;
 #ifdef SMTPUTF8
 static stralloc firstpart = { 0 };
 static stralloc asciihost = { 0 };
-static int      smtputf8 = 0;
-static char    *enable_utf8 = 0;
+static int      smtputf8 = 0; /*- if remove has SMTPUTF8 capability */
+static char    *enable_utf8 = 0; /*- enable utf8 */
 #endif
 
 void            temp_nomem();
@@ -3492,8 +3492,9 @@ main(int argc, char **argv)
 			default:
 				perm_dns();
 			}
-			if (!stralloc_copys(&asciihost, ascii))
+			if (!stralloc_copys(&asciihost, ascii) || !stralloc_0(&asciihost))
 				temp_nomem();
+			asciihost.len--;
 		}
 #endif
 	}

--- a/indimail-mta-x/qmail-remote.c
+++ b/indimail-mta-x/qmail-remote.c
@@ -1,6 +1,6 @@
 /*-
  * RCS log at bottom
- * $Id: qmail-remote.c,v 1.137 2020-11-29 10:13:00+05:30 Cprogrammer Exp mbhangui $
+ * $Id: qmail-remote.c,v 1.138 2020-12-03 17:29:29+05:30 Cprogrammer Exp mbhangui $
  */
 #include "cdb.h"
 #include "open.h"
@@ -3692,7 +3692,7 @@ main(int argc, char **argv)
 void
 getversion_qmail_remote_c()
 {
-	static char    *x = "$Id: qmail-remote.c,v 1.137 2020-11-29 10:13:00+05:30 Cprogrammer Exp mbhangui $";
+	static char    *x = "$Id: qmail-remote.c,v 1.138 2020-12-03 17:29:29+05:30 Cprogrammer Exp mbhangui $";
 	x = sccsidauthcramh;
 	x = sccsidqrdigestmd5h;
 	x++;
@@ -3700,6 +3700,9 @@ getversion_qmail_remote_c()
 
 /*
  * $Log: qmail-remote.c,v $
+ * Revision 1.138  2020-12-03 17:29:29+05:30  Cprogrammer
+ * added EAI - RFC 6530-32 - unicode address support
+ *
  * Revision 1.137  2020-11-29 10:13:00+05:30  Cprogrammer
  * use get1(), get3() functions to read smtp code
  *

--- a/indimail-mta-x/qmail-smtpd.9
+++ b/indimail-mta-x/qmail-smtpd.9
@@ -48,6 +48,14 @@ normally on port 465). Otherwise, if you set the \fBSTARTTLS\fR environment vari
 .B qmail-smtpd
 offers the STARTTLS extension to ESMTP.
 
+If the environment variable
+.B UTF8
+is non-empty
+.B qmail-smtpd
+offers RFC 5336 SMTP Email Address Internationalization support and will advertize the
+capability in the EHLO greeting. Since qmail-smtpd is 8 bit clean, setting of UTF8 has no real
+consequences except for displaying this setting in the received headers as \fBUTF8(E)SMTP\fR.
+
 If the environment variable \fBLOGFILTER\fR is defined, \fBqmail-smtpd\fR will open a fifo 
 defined by \fBLOGFILTER\fR environment variable in O_WRONLY mode. It will write
 the SMTP transaction log to the fifo. This makes it possible for \fBqmail-smtpd\fR to push

--- a/indimail-mta-x/smtpd.c
+++ b/indimail-mta-x/smtpd.c
@@ -106,7 +106,7 @@ int             secure_auth = 0;
 int             ssl_rfd = -1, ssl_wfd = -1;	/*- SSL_get_Xfd() are broken */
 char           *servercert, *clientca, *clientcrl;
 #endif
-char           *revision = "$Revision: 1.231 $";
+char           *revision = "$Revision: 1.232 $";
 char           *protocol = "SMTP";
 stralloc        proto = { 0 };
 static stralloc Revision = { 0 };
@@ -6112,6 +6112,9 @@ addrrelay()
 
 /*
  * $Log: smtpd.c,v $
+ * Revision 1.232  2020-12-03 17:29:59+05:30  Cprogrammer
+ * added EAI - RFC 6530-32 - unicode address support
+ *
  * Revision 1.231  2020-11-26 14:01:08+05:30  Cprogrammer
  * refactored batv code
  *
@@ -6243,7 +6246,7 @@ addrrelay()
 void
 getversion_smtpd_c()
 {
-	static char    *x = "$Id: smtpd.c,v 1.231 2020-11-26 14:01:08+05:30 Cprogrammer Exp mbhangui $";
+	static char    *x = "$Id: smtpd.c,v 1.232 2020-12-03 17:29:59+05:30 Cprogrammer Exp mbhangui $";
 
 	if (x)
 		x++;

--- a/indimail-mta-x/smtpd.c
+++ b/indimail-mta-x/smtpd.c
@@ -3066,8 +3066,7 @@ mailfrom_parms(char *arg)
 	int             len;
 
 	len = str_len(arg);
-	if (!stralloc_copys(&mfparms, ""))
-		die_nomem();
+	mfparms.len = 0;
 	i = byte_chr(arg, len, '>');
 	if (i > 4 && i < len) {
 		while (len) {
@@ -3075,17 +3074,22 @@ mailfrom_parms(char *arg)
 			len--;
 			if (*arg == ' ' || *arg == '\0') {
 #ifdef SMTPUTF8
-				if (smtputf8_enable && case_starts(mfparms.s, "SMTPUTF8"))
+				if (smtputf8_enable && case_starts(mfparms.s, "SMTPUTF8")) {
 					smtputf8 = 1;
+				} else
 #endif
-				if (case_starts(mfparms.s, "SIZE=") && mailfrom_size(mfparms.s + 5)) {
-					flagsize = 1;
-					return;
-				}
-				if (case_starts(mfparms.s, "AUTH="))
+				if (case_starts(mfparms.s, "SIZE=")) {
+					mfparms.s[mfparms.len] = 0;
+					if (mailfrom_size(mfparms.s + 5)) {
+						flagsize = 1;
+						return;
+					}
+				} else
+				if (case_starts(mfparms.s, "AUTH=")) {
+					mfparms.s[mfparms.len] = 0;
 					mailfrom_auth(mfparms.s + 5, mfparms.len - 5);
-				if (!stralloc_copys(&mfparms, ""))
-					die_nomem();
+				}
+				mfparms.len = 0;
 			} else
 			if (!stralloc_catb(&mfparms, arg, 1))
 				die_nomem();

--- a/indimail-mta-x/smtpd.c
+++ b/indimail-mta-x/smtpd.c
@@ -106,7 +106,7 @@ int             secure_auth = 0;
 int             ssl_rfd = -1, ssl_wfd = -1;	/*- SSL_get_Xfd() are broken */
 char           *servercert, *clientca, *clientcrl;
 #endif
-char           *revision = "$Revision: 1.232 $";
+char           *revision = "$Revision: 1.233 $";
 char           *protocol = "SMTP";
 stralloc        proto = { 0 };
 static stralloc Revision = { 0 };
@@ -6116,6 +6116,9 @@ addrrelay()
 
 /*
  * $Log: smtpd.c,v $
+ * Revision 1.233  2020-12-07 12:06:27+05:30  Cprogrammer
+ * refactored mailfrom_parms()
+ *
  * Revision 1.232  2020-12-03 17:29:59+05:30  Cprogrammer
  * added EAI - RFC 6530-32 - unicode address support
  *
@@ -6250,7 +6253,7 @@ addrrelay()
 void
 getversion_smtpd_c()
 {
-	static char    *x = "$Id: smtpd.c,v 1.232 2020-12-03 17:29:59+05:30 Cprogrammer Exp mbhangui $";
+	static char    *x = "$Id: smtpd.c,v 1.233 2020-12-07 12:06:27+05:30 Cprogrammer Exp mbhangui $";
 
 	if (x)
 		x++;

--- a/indimail-mta-x/smtpd.c
+++ b/indimail-mta-x/smtpd.c
@@ -2841,7 +2841,7 @@ smtp_ehlo(char *arg)
 	}
 #endif
 #ifdef SMTPUTF8
-	if (env_get("SMTPUTF8")) {
+	if (env_get("UTF8")) {
 		smtputf8_enable = 1;
 		out("250-SMTPUTF8\r\n");
 	}

--- a/indimail-mta-x/svctool.9
+++ b/indimail-mta-x/svctool.9
@@ -64,6 +64,7 @@ Known values for OPTION are:
   [--dksign=dk|dkim|both|none --private_key=private_key]
   [--password-cache] [--query-cache]
   [--smtp-plugin]
+  [--utf8]
   --default-domain=domain
 
  Installs a new queue with a SMTP Listener
@@ -158,6 +159,7 @@ Known values for OPTION are:
   shared-objects - Enabled tcpserver plugins, 0 - disabled, 1 - enabled
   use-dlmopen    - Use dlmopen() instead of dlopen() to load shared objects
   smtp-plugin    - Enable SMTP Plugin support
+  utf8           - Enable Email Address Internationalization Support (SMTPUTF8)
 
 --delivery=ident --qbase=queue_path --qcount=N --qstart=I
   --servicedir=service_path
@@ -179,6 +181,7 @@ Known values for OPTION are:
   [--dksign=dk|dkim|both|none --private_key=private_key]
   [--remote-authsmtp=b]
   [--ssl]
+  [--utf8]
   --default-domain=domain
 
  Installs a new queue without a SMTP listener
@@ -228,6 +231,7 @@ Known values for OPTION are:
                    delivery times.
   b              - Authenticated SMTP method to use by qmail-remote (plain, login, cram-md5)
   ssl            - Use SSL encrypted communication in qmail-remote
+  utf8           - Enable Email Address Internationalization Support (SMTPUTF8)
 
 --queueParam=dir --qbase=queue_path --qcount=N --qstart=I
   [--cntrldir=cntrl_path]

--- a/indimail-mta-x/svctool.in
+++ b/indimail-mta-x/svctool.in
@@ -1,7 +1,7 @@
 #!/bin/sh
 # WARNING: This file was auto-generated. Do not edit!
 #
-# $Id: svctool.in,v 2.529 2020-11-18 15:01:22+05:30 Cprogrammer Exp mbhangui $
+# $Id: svctool.in,v 2.530 2020-12-03 17:30:09+05:30 Cprogrammer Exp mbhangui $
 #
 
 #
@@ -28,7 +28,7 @@ host=@HOST@
 shared_objects=0
 use_dlmopen=0
 skip_sendmail_check=0
-RCSID="# \$Id: svctool.in,v 2.529 2020-11-18 15:01:22+05:30 Cprogrammer Exp mbhangui $"
+RCSID="# \$Id: svctool.in,v 2.530 2020-12-03 17:30:09+05:30 Cprogrammer Exp mbhangui $"
 
 if [ -d /run/mysqld ] ; then
 	mysqlSocket=/run/mysqld/mysqld.sock
@@ -97,6 +97,7 @@ Known values for OPTION are:
   [--dksign=dk|dkim|both|none --private_key=private_key]
   [--password-cache] [--query-cache]
   [--smtp-plugin]
+  [--utf8]
   --default-domain=domain
 
  Installs a new queue with a SMTP Listener
@@ -191,6 +192,7 @@ Known values for OPTION are:
   shared-objects - Enabled tcpserver plugins, 0 - disabled, 1 - enabled
   use-dlmopen    - Use dlmopen() instead of dlopen() to load shared objects
   smtp-plugin    - Enable SMTP Plugin support
+  utf8           - Enable Email Address Internationalization Support (SMTPUTF8)
 
 --delivery=ident --qbase=queue_path --qcount=N --qstart=I
   --servicedir=service_path
@@ -212,9 +214,10 @@ Known values for OPTION are:
   [--dksign=dk|dkim|both|none --private_key=private_key]
   [--remote-authsmtp=b]
   [--ssl]
+  [--utf8]
   --default-domain=domain
 
- Installs a new queue without a SMTP listener
+ Installs a new queue with a delivery daemon
   N              - No of Queues
   I              - Numeral Prefix of first queue (i.e 1 for @qmaildir@/queue/queue1)
   M              - Minimum Disk Space to maintain in queue after which
@@ -261,6 +264,7 @@ Known values for OPTION are:
                    delivery times.
   b              - Authenticated SMTP method to use by qmail-remote (plain, login, cram-md5)
   ssl            - Use SSL encrypted communication in qmail-remote
+  utf8           - Enable Email Address Internationalization Support (SMTPUTF8)
 
 --queueParam=dir --qbase=queue_path --qcount=N --qstart=I
   [--cntrldir=cntrl_path]
@@ -277,7 +281,7 @@ Known values for OPTION are:
   [--dkverify=dk|dkim|both|none]
   [--dksign=dk|dkim|both|none --private_key=private_key]
 
- Installs a new queue with a SMTP Listener
+ Installs a new queue without a SMTP Listener
   dir            - dir where to install queuedef environment variable directory
   queue_path     - Path where the queues are installed. If this is different from
                    @qmaildir@ appropriate links will be created in
@@ -1991,8 +1995,8 @@ echo "$prog_args" > $conf_dir/.options
 
 create_smtp()
 {
-if [ $# -ne 10 ] ; then
-	echo "USAGE: create_smtp qbase queue_count first_queue_no supervise_dir smtp_port check_user=0|1 check_relay=0|1 use_ssl=0|1 force_tls=0|1 infifo=fifo_path" 1>&2
+if [ $# -ne 11 ] ; then
+	echo "USAGE: create_smtp qbase queue_count first_queue_no supervise_dir smtp_port check_user=0|1 check_relay=0|1 use_ssl=0|1 force_tls=0|1 infifo=fifo_path utf8=0|1" 1>&2
 	return 1
 fi
 QUEUE_BASE=$1
@@ -2005,6 +2009,7 @@ chkrelay=$7
 smtp_ssl=$8
 force_tls=$9
 infifo=${10}
+utf8=${11}
 
 # qmail-smtpd script
 if [ " $servicetag" = " " ] ; then
@@ -2249,6 +2254,11 @@ if [ " $odmr" = " " ] ; then
 				> $conf_dir/CHECKRELAY
 			fi
 		fi
+	fi
+	if [ $utf -eq 1 ] ; then
+		echo > $conf_dir/UTF8
+	else
+		> $conf_dir/UTF8
 	fi
 fi # odmr
 if [ $shared_objects -eq 1 ] ; then
@@ -5795,10 +5805,10 @@ if [ $run_file_only -eq 1 ] ; then
 fi
 }
 
-create_queue()
+create_delivery()
 {
-if [ $# -ne 7 ] ; then
-	echo "USAGE: create_queue qbase queue_count first_queue_no supervise_dir ident routes=smtp|qmtp|static use_ssl" 1>&2
+if [ $# -ne 8 ] ; then
+	echo "USAGE: create_delivery qbase queue_count first_queue_no supervise_dir ident routes=smtp|qmtp|static use_ssl utf8" 1>&2
 	return 1
 fi
 QUEUE_BASE=$1
@@ -5808,6 +5818,7 @@ SERVICEDIR=$4
 QUEUE_IDENT=$5
 routes=$6
 qmr_ssl=$7
+utf8=$8
 if [ " $servicetag" = " " ] ; then
 	tag=$QUEUE_IDENT
 else
@@ -5892,6 +5903,11 @@ else
 fi
 if [ $qmr_ssl -eq 1 ] ; then
 echo $sysconfdir/certs > $conf_dir/CERTDIR #for qmail-remote
+fi
+if [ $utf8 -eq 1 ] ; then
+	echo $utf8 > $conf_dir/UTF8
+else
+	> $conf_dir/UTF8
 fi
 if [ ! " $routes" = " " ] ; then
 	echo $routes > $conf_dir/ROUTES
@@ -8717,6 +8733,7 @@ use_starttls=0
 forcetls=0
 nooverwrite=0
 run_file_only=0
+utf8=0
 databytes=$DATABYTES
 if [ " $CONTROLDIR" = " " ] ; then
 	cntrldir=$sysconfdir/control
@@ -8965,6 +8982,9 @@ while test $# -gt 0; do
 	;;
 	--routes=*)
 	routes=$optarg
+	;;
+	--utf8)
+	utf8=1
 	;;
 	--cname-lookup)
 	enable_cname_lookup="yes"
@@ -9498,9 +9518,9 @@ case $option in
 		if [ " $skipsend" = " " ] ; then
 			echo "Creating $qcount queues"
 			if [ $use_starttls -ne 0 -o $use_ssl -ne 0 ] ; then
-				create_queue "$qbase" "$qcount" "$qstart" "$servicedir" "$smtp_port" "$routes" "1"
+				create_delivery "$qbase" "$qcount" "$qstart" "$servicedir" "$smtp_port" "$routes" "1" "$utf8"
 			else
-				create_queue "$qbase" "$qcount" "$qstart" "$servicedir" "$smtp_port" "$routes" "0"
+				create_delivery "$qbase" "$qcount" "$qstart" "$servicedir" "$smtp_port" "$routes" "0" "$utf8"
 			fi
 		fi
 	fi
@@ -9509,7 +9529,7 @@ case $option in
 	else
 	echo "Creating SMTP Listener Port $smtp_port, Service $servicedir"
 	fi
-	create_smtp "$qbase" "$qcount" "$qstart" "$servicedir" "$smtp_port" "$chkrecipient" "$chkrelay" "$use_ssl" "$forcetls" "$infifo"
+	create_smtp "$qbase" "$qcount" "$qstart" "$servicedir" "$smtp_port" "$chkrecipient" "$chkrelay" "$use_ssl" "$forcetls" "$infifo" "$utf8"
 	;;
 
 	2) # IMAP Service
@@ -9701,7 +9721,7 @@ case $option in
 	create_fetchmail "$qbase" "$qcount" "$qstart" "$servicedir"
 	;;
 
-	10)
+	10) # --config
 	# config creation for MySQL, MySQL Database creation, imap, 
 	# 1  MySQL Config creation
 	# 2  MySQL Database creation
@@ -10172,7 +10192,7 @@ case $option in
 	esac
 	;;
 
-	11)
+	11) # check install
 	# Check that we're a privileged user
 	[ `id -u` = 0 ] || exit 4
 	if [ " $qbase" = " " ] ; then
@@ -10191,7 +10211,7 @@ case $option in
 	check_installation "$qbase" "$qcount" "$qstart" "$servicedir" "$verbose"
 	;;
 
-	12)
+	12) # create_svscan
 	# Check that we're a privileged user
 	[ `id -u` = 0 ] || exit 4
 	if [ " $servicedir" = " " ] ; then
@@ -10221,7 +10241,7 @@ case $option in
 	fi
 	;;
 
-	13)
+	13) # mysqldump
 	# Check that we're a privileged user
 	[ `id -u` = 0 ] || exit 4
 	if [ " $servicedir" = " " ] ; then
@@ -10251,7 +10271,7 @@ case $option in
 	fi
 	;;
 
-	14)
+	14) # repair tables
 	if [ " $mysqlPrefix" = " " ] ; then
 		echo "MySQL Installation Prefix directory not specified" 1>&2
 		usage 1
@@ -10259,13 +10279,13 @@ case $option in
 	repair_tables
 	;;
 
-	15)
+	15) # reports
 	# Check that we're a privileged user
 	[ `id -u` = 0 ] || exit 4
 	report $report_option
 	;;
 
-	16)
+	16) # create_qscanq
 	# Check that we're a privileged user
 	[ `id -u` = 0 ] || exit 4
 	if [ " $servicedir" = " " ] ; then
@@ -10293,7 +10313,7 @@ case $option in
 	create_clamd $clamdPrefix $servicedir $mysysconfdir
 	;;
 
-	18)
+	18) # create_poppass
 	# Check that we're a privileged user
 	[ `id -u` = 0 ] || exit 4
 	if [ " $poppass_port" = " " ] ; then
@@ -10316,7 +10336,7 @@ case $option in
 	create_poppass "$servicedir" "$poppass_port" "$password_cmd" "$use_ssl"
 	;;
 
-	19)
+	19) # create_svscan
 	# Check that we're a privileged user
 	[ `id -u` = 0 ] || exit 4
 	if [ " $servicedir" = " " ] ; then
@@ -10327,7 +10347,7 @@ case $option in
 	create_svscan $servicedir $svscan_init_cmd
 	;;
 
-	20)
+	20) # create_pwdlookup service
 	# Check that we're a privileged user
 	[ `id -u` = 0 ] || exit 4
 	if [ " $servicedir" = " " ] ; then
@@ -10360,7 +10380,7 @@ case $option in
 	"$mysql_pass" "$mysql_port" "$mysql_socket"
 	;;
 
-	21)
+	21) # dump config
 	if [ " $servicedir" = " " ] ; then
 		echo "Supervise Directory not specified" 1>&2
 		usage 1
@@ -10370,7 +10390,7 @@ case $option in
 	dump_config "$servicedir" "$cntrldir"
 	;;
 
-	22)
+	22) # create_greylist
 	# Check that we're a privileged user
 	[ `id -u` = 0 ] || exit 4
 	if [ " $servicedir" = " " ] ; then
@@ -10380,7 +10400,7 @@ case $option in
 	create_greylist "$servicedir" "$grey_port" "$min_resend_min" " $resend_win_hr" "$timeout_days" "$context_file" "$save_interval" "$hash_size" "$whitelist" "$use_greydaemon"
 	;;
 
-	23)
+	23) # create_qmtp
 	# Check that we're a privileged user
 	[ `id -u` = 0 ] || exit 4
 	if [ " $servicedir" = " " ] ; then
@@ -10413,7 +10433,7 @@ case $option in
 	create_qmtp_or_qmqp "qmtpd" "$qbase" "$qcount" "$qstart" "$servicedir" "$qmtp_port"
 	;;
 
-	24)
+	24) # create_qmqp
 	# Check that we're a privileged user
 	[ `id -u` = 0 ] || exit 4
 	if [ " $servicedir" = " " ] ; then
@@ -10446,7 +10466,7 @@ case $option in
 	create_qmtp_or_qmqp "qmqpd" "$qbase" "$qcount" "$qstart" "$servicedir" "$qmqp_port"
 	;;
 
-	25)
+	25) # create_queuedef
 	# Check that we're a privileged user
 	[ `id -u` = 0 ] || exit 4
 	if [ " $queuedef" = " " ] ; then
@@ -10496,7 +10516,7 @@ case $option in
 	create_queuedef "$qbase" "$qcount" "$qstart" "$queuedef"
 	;;
 
-	26)
+	26) # crete_delivery
 	# Check that we're a privileged user
 	[ `id -u` = 0 ] || exit 4
 	if [ " $servicedir" = " " ] ; then
@@ -10548,13 +10568,13 @@ case $option in
 	esac
 	echo "Creating delivery only $qcount queues"
 	if [ $use_starttls -ne 0 -o $use_ssl -ne 0 ] ; then
-		create_queue "$qbase" "$qcount" "$qstart" "$servicedir" "$queue_ident" "$routes" 1
+		create_delivery "$qbase" "$qcount" "$qstart" "$servicedir" "$queue_ident" "$routes" 1 $utf8
 	else
-		create_queue "$qbase" "$qcount" "$qstart" "$servicedir" "$queue_ident" "$routes" 0
+		create_delivery "$qbase" "$qcount" "$qstart" "$servicedir" "$queue_ident" "$routes" 0 $utf8
 	fi
 	;;
 
-	27)
+	27) # create_udplogger
 	[ `id -u` = 0 ] || exit 4
 	if [ " $servicedir" = " " ] ; then
 		echo "Supervise Directory not specified" 1>&2
@@ -10566,7 +10586,7 @@ case $option in
 	create_udplogger "$udp_port" "$servicedir"
 	;;
 
-	28)
+	28) # create_fifologger
 	[ `id -u` = 0 ] || exit 4
 	if [ " $servicedir" = " " ] ; then
 		echo "Supervise Directory not specified" 1>&2
@@ -10579,7 +10599,7 @@ case $option in
 	create_fifologger $logfilter $servicedir
 	;;
 
-	29)
+	29) # create mrtg
 	[ `id -u` = 0 ] || exit 4
 	if [ " $servicedir" = " " ] ; then
 		echo "Supervise Directory not specified" 1>&2
@@ -10592,7 +10612,7 @@ case $option in
 	create_mrtg $htmldir $servicedir
 	;;
 
-	30)
+	30) # tls certificate check
 	[ `id -u` = 0 ] || exit 4
 	if [ -z "$cert_file" ] ; then
 		tls_cert_check
@@ -10601,17 +10621,17 @@ case $option in
 	fi
 	;;
 
-	31)
+	31) # enable service
 	shift
 	enable_service $*
 	;;
 
-	32)
+	32) # disable service
 	shift
 	disable_service $*
 	;;
 
-	33)
+	33) # create dane
 	# Check that we're a privileged user
 	[ `id -u` = 0 ] || exit 4
 	if [ " $servicedir" = " " ] ; then
@@ -10621,7 +10641,7 @@ case $option in
 	create_dane "$servicedir" "$dane_port" "$timeout_days" "$context_file" "$save_interval" "$hash_size" "$whitelist"
 	;;
 
-	34)
+	34) # refresh services
 	[ `id -u` = 0 ] || exit 4
 	if [ " $servicedir" = " " ] ; then
 		echo "Supervise Directory not specified" 1>&2
@@ -10630,7 +10650,7 @@ case $option in
 	refreshsvc $service
 	;;
 
-	35)
+	35) # set norefresh service flag
 	[ `id -u` = 0 ] || exit 4
 	if [ " $servicedir" = " " ] ; then
 		echo "Supervise Directory not specified" 1>&2

--- a/indimail-mta-x/tryidn2.c
+++ b/indimail-mta-x/tryidn2.c
@@ -1,0 +1,13 @@
+#ifdef SMTPUTF8
+#include <idn2.h>
+#endif
+int
+main(int argc, char **argv)
+{
+#ifdef SMTPUTF8
+	char           *ascii;
+	idn2_lookup_u8((const uint8_t *) argv[1], (uint8_t **) &ascii, IDN2_NFC_INPUT);
+#else
+	:
+#endif
+}


### PR DESCRIPTION
1. Adapted from Arnt Gulbrandsen unicode address support [patch](http://arnt.gulbrandsen.priv.no/qmail/qmail-smtputf8.patch) for qmail.
2. To enable it, have -DSMTPUTF8 in conf-smtputf8
3. Requires libidn2-devel / libidn2-dev. If missing, build will compile without SMTPUTF8
4. Adds SMTPUTF8 capability to qmail-smtpd
5. qmail-remote will check if a message is utf8 and use the SMTPUTF8 extenstion in MAIL FROM parameter
6. If the message is utf8 and remote server doesn't support, the email will be bounced back with the message "Connected to xxxx, but server does not support unicode in email addresses"