### PR TITLE
noreturn attribute - use __attribute__((noreturn)) by inluding noreturn.h

### DIFF
--- a/indimail-mta-x/822addr.c
+++ b/indimail-mta-x/822addr.c
@@ -1,5 +1,8 @@
 /*
  * $Log: 822addr.c,v $
+ * Revision 1.4  2021-08-29 23:27:08+05:30  Cprogrammer
+ * define funtions as noreturn
+ *
  * Revision 1.3  2020-11-24 13:41:57+05:30  Cprogrammer
  * removed exit.h
  *
@@ -11,35 +14,35 @@
  *
  */
 #include <unistd.h>
-#include "substdio.h"
-#include "alloc.h"
-#include "strerr.h"
-#include "getln.h"
-#include "mess822.h"
-#include "case.h"
-#include "stralloc.h"
+#include <substdio.h>
+#include <alloc.h>
+#include <strerr.h>
+#include <getln.h>
+#include <mess822.h>
+#include <case.h>
+#include <stralloc.h>
+#include <noreturn.h>
 
 #define FATAL "822addr: fatal: "
 
 static char     ssinbuf[1024];
-static substdio ssin = SUBSTDIO_FDBUF(read, 0, ssinbuf, sizeof ssinbuf);
 static char     ssoutbuf[512];
+static substdio ssin = SUBSTDIO_FDBUF(read, 0, ssinbuf, sizeof ssinbuf);
 static substdio ssout = SUBSTDIO_FDBUF(write, 1, ssoutbuf, sizeof ssoutbuf);
-int             flag;
-stralloc        addr = { 0 };
+static int      flag;
+static int      match;
+static stralloc addr = { 0 };
+static stralloc line = { 0 };
 
-mess822_header  h = MESS822_HEADER;
-mess822_action *a;
-mess822_action  a0[] = {
-	{"to", &flag, 0, 0, &addr, 0}
-	, {"cc", &flag, 0, 0, &addr, 0}
-	, {0, 0, 0, 0, 0, 0}
+static mess822_header  h = MESS822_HEADER;
+static mess822_action *a;
+static mess822_action  a0[] = {
+	{"to", &flag, 0, 0, &addr, 0},
+	{"cc", &flag, 0, 0, &addr, 0},
+	{0, 0, 0, 0, 0, 0}
 };
 
-stralloc        line = { 0 };
-int             match;
-
-void
+no_return void
 nomem()
 {
 	strerr_die2x(111, FATAL, "out of memory");
@@ -55,12 +58,9 @@ init(int n, char **s)
 	if (!n)
 		return a0;
 
-	a1 = (mess822_action *) alloc((n + 1) * sizeof(mess822_action));
-	if (!a1)
+	if (!(a1 = (mess822_action *) alloc((n + 1) * sizeof(mess822_action))))
 		nomem();
-
-	for (i = 0; i < n; i++)
-	{
+	for (i = 0; i < n; i++) {
 		a1[i].name = *s;
 		a1[i].flag = &flag;
 		a1[i].copy = 0;
@@ -75,7 +75,6 @@ init(int n, char **s)
 	a1[n].value = 0;
 	a1[n].addr = 0;
 	a1[n].when = 0;
-
 	return a1;
 }
 
@@ -85,11 +84,9 @@ main(int argc, char **argv)
 	a = init(argc - 1, ++argv);
 	if (!mess822_begin(&h, a))
 		nomem();
-	for (;;)
-	{
+	for (;;) {
 		if (getln(&ssin, &line, &match, '\n') == -1)
 			strerr_die2sys(111, FATAL, "unable to read input: ");
-
 		if (!mess822_ok(&line))
 			break;
 		if (!mess822_line(&h, &line))
@@ -109,7 +106,7 @@ main(int argc, char **argv)
 void
 getversion_822addr_c()
 {
-	static char    *x = "$Id: 822addr.c,v 1.3 2020-11-24 13:41:57+05:30 Cprogrammer Exp mbhangui $";
+	static char    *x = "$Id: 822addr.c,v 1.4 2021-08-29 23:27:08+05:30 Cprogrammer Exp mbhangui $";
 
 	x++;
 }

--- a/indimail-mta-x/822date.c
+++ b/indimail-mta-x/822date.c
@@ -1,5 +1,8 @@
 /*
  * $Log: 822date.c,v $
+ * Revision 1.10  2021-08-29 23:27:08+05:30  Cprogrammer
+ * define funtions as noreturn
+ *
  * Revision 1.9  2021-06-13 17:27:04+05:30  Cprogrammer
  * removed chdir(auto_sysconfdir)
  *
@@ -39,11 +42,12 @@
 #include "leapsecs.h"
 #include "caltime.h"
 #include "tai.h"
+#include "noreturn.h"
 #include "auto_sysconfdir.h"
 
 #define FATAL "822date: fatal: "
 
-void
+no_return void
 nomem()
 {
 	strerr_die2x(111, FATAL, "out of memory");
@@ -123,7 +127,7 @@ main(argc, argv)
 void
 getversion_822date_c()
 {
-	static char    *x = "$Id: 822date.c,v 1.9 2021-06-13 17:27:04+05:30 Cprogrammer Exp mbhangui $";
+	static char    *x = "$Id: 822date.c,v 1.10 2021-08-29 23:27:08+05:30 Cprogrammer Exp mbhangui $";
 
 	x++;
 }

--- a/indimail-mta-x/822field.c
+++ b/indimail-mta-x/822field.c
@@ -1,5 +1,8 @@
 /*
  * $Log: 822field.c,v $
+ * Revision 1.6  2021-08-29 23:27:08+05:30  Cprogrammer
+ * define funtions as noreturn
+ *
  * Revision 1.5  2020-11-28 12:43:07+05:30  Cprogrammer
  * +HeaderName feature by Erwin Hoffman: display all headers which have HeaderName as the initial text
  *
@@ -17,47 +20,39 @@
  *
  */
 #include <unistd.h>
-#include "substdio.h"
-#include "strerr.h"
-#include "subfd.h"
-#include "getln.h"
-#include "mess822.h"
+#include <substdio.h>
+#include <strerr.h>
+#include <subfd.h>
+#include <getln.h>
+#include <mess822.h>
+#include <noreturn.h>
 
 #define FATAL "822field: fatal: "
 
-void
+no_return void
 nomem()
 {
 	strerr_die2x(111, FATAL, "out of memory");
 }
 
-int             flag;
-stralloc        value = { 0 };
-
-mess822_header  h = MESS822_HEADER;
-mess822_action  a[] = {
-	{"subject", &flag, 0, &value, 0, 0}
-	, {0, 0, 0, 0, 0, 0}
-};
-
-stralloc        line = { 0 };
-int             match;
-
 int
-main(argc, argv)
-	int             argc;
-	char          **argv;
+main(int argc, char **argv)
 {
-	int             t = 0;
+	int             t = 0, flag, match;
+	stralloc        value = { 0 }, line = { 0 };
+	mess822_header  h = MESS822_HEADER;
+	mess822_action  a[] = {
+		{"subject", &flag, 0, &value, 0, 0},
+		{0, 0, 0, 0, 0, 0}
+	};
 
 	if (argv[1]) {
 		if (*argv[1] == '+') {
 			t = 1;
 			if (!*(argv[1] + 1))
 				a[0].name = "subject";
-			else {
+			else
 				a[0].name = argv[1] + 1;
-			}
 		} else
 			a[0].name = argv[1];
 	}
@@ -85,7 +80,7 @@ main(argc, argv)
 void
 getversion_822field_c()
 {
-	static char    *x = "$Id: 822field.c,v 1.5 2020-11-28 12:43:07+05:30 Cprogrammer Exp mbhangui $";
+	static char    *x = "$Id: 822field.c,v 1.6 2021-08-29 23:27:08+05:30 Cprogrammer Exp mbhangui $";
 
 	x++;
 }

--- a/indimail-mta-x/822received.c
+++ b/indimail-mta-x/822received.c
@@ -1,5 +1,8 @@
 /*
  * $Log: 822received.c,v $
+ * Revision 1.10  2021-08-29 23:27:08+05:30  Cprogrammer
+ * define funtions as noreturn
+ *
  * Revision 1.9  2021-06-14 00:33:36+05:30  Cprogrammer
  * removed chdir(auto_sysconfdir)
  *
@@ -31,20 +34,21 @@
 #include <sys/types.h>
 #include <time.h>
 #include <unistd.h>
-#include "substdio.h"
-#include "case.h"
-#include "strerr.h"
-#include "subfd.h"
-#include "getln.h"
-#include "mess822.h"
-#include "leapsecs.h"
-#include "caltime.h"
-#include "tai.h"
+#include <substdio.h>
+#include <case.h>
+#include <strerr.h>
+#include <subfd.h>
+#include <getln.h>
+#include <mess822.h>
+#include <leapsecs.h>
+#include <caltime.h>
+#include <tai.h>
+#include <noreturn.h>
 #include "auto_sysconfdir.h"
 
 #define FATAL "822received: fatal: "
 
-void
+no_return void
 nomem()
 {
 	strerr_die2x(111, FATAL, "out of memory");
@@ -214,7 +218,7 @@ main(int argc, char **argv)
 void
 getversion_822received_c()
 {
-	static char    *x = "$Id: 822received.c,v 1.9 2021-06-14 00:33:36+05:30 Cprogrammer Exp mbhangui $";
+	static char    *x = "$Id: 822received.c,v 1.10 2021-08-29 23:27:08+05:30 Cprogrammer Exp mbhangui $";
 
 	x++;
 }

--- a/indimail-mta-x/addrlist.c
+++ b/indimail-mta-x/addrlist.c
@@ -1,5 +1,8 @@
 /*
  * $Log: addrlist.c,v $
+ * Revision 1.3  2021-08-29 23:27:08+05:30  Cprogrammer
+ * define funtions as noreturn
+ *
  * Revision 1.2  2004-10-22 20:16:53+05:30  Cprogrammer
  * added RCS id
  *
@@ -8,15 +11,16 @@
  *
  */
 #include <unistd.h>
-#include "substdio.h"
-#include "strerr.h"
-#include "subfd.h"
-#include "getln.h"
-#include "mess822.h"
+#include <substdio.h>
+#include <strerr.h>
+#include <subfd.h>
+#include <getln.h>
+#include <mess822.h>
+#include <noreturn.h>
 
 #define FATAL "addrlist: fatal: "
 
-void
+no_return void
 nomem()
 {
 	strerr_die2x(111, FATAL, "out of memory");
@@ -107,7 +111,7 @@ main()
 void
 getversion_addrlist_c()
 {
-	static char    *x = "$Id: addrlist.c,v 1.2 2004-10-22 20:16:53+05:30 Cprogrammer Stab mbhangui $";
+	static char    *x = "$Id: addrlist.c,v 1.3 2021-08-29 23:27:08+05:30 Cprogrammer Exp mbhangui $";
 
 	x++;
 }

--- a/indimail-mta-x/autoresponder.c
+++ b/indimail-mta-x/autoresponder.c
@@ -1,5 +1,8 @@
 /*
  * $Log: autoresponder.c,v $
+ * Revision 1.35  2021-08-29 23:27:08+05:30  Cprogrammer
+ * define funtions as noreturn
+ *
  * Revision 1.34  2021-07-19 07:57:58+05:30  Cprogrammer
  * fixed compiler warning on _XOPEN_SOURCE redefinition
  *
@@ -101,29 +104,30 @@
 #define _XOPEN_SOURCE
 #endif
 #include <time.h>
-#include "now.h"
-#include "sgetopt.h"
-#include "subfd.h"
-#include "mess822.h"
-#include "date822fmt.h"
-#include "getln.h"
-#include "stralloc.h"
-#include "env.h"
-#include "case.h"
-#include "auto_qmail.h"
-#include "str.h"
-#include "strerr.h"
-#include "control.h"
-#include "error.h"
-#include "alloc.h"
-#include "fmt.h"
-#include "quote.h"
-#include "byte.h"
+#include <now.h>
+#include <sgetopt.h>
+#include <subfd.h>
+#include <mess822.h>
+#include <date822fmt.h>
+#include <getln.h>
+#include <stralloc.h>
+#include <env.h>
+#include <case.h>
+#include <str.h>
+#include <strerr.h>
+#include <error.h>
+#include <alloc.h>
+#include <fmt.h>
+#include <byte.h>
+#include <tai.h>
+#include <constmap.h>
+#include <noreturn.h>
+#include "qregex.h"
 #include "ip.h"
 #include "ipme.h"
-#include "tai.h"
-#include "constmap.h"
-#include "qregex.h"
+#include "quote.h"
+#include "control.h"
+#include "auto_qmail.h"
 
 #define strcasecmp(x,y)    case_diffs((x), (y))
 #define strncasecmp(x,y,z) case_diffb((x), (z), (y))
@@ -204,7 +208,7 @@ char           *usage_str =
 	" This program must be run by qmail";
 
 /*- Ignore message and do not respond */
-void
+no_return void
 ignore(char *msg)
 {
 	if (opt_quiet)
@@ -356,7 +360,7 @@ match_addr(stralloc *addrlist, char *email_addr)
 	return(0);
 }
 
-void
+no_return void
 usage(char *msg)
 {
 	if (msg) {
@@ -1290,7 +1294,7 @@ main(int argc, char *argv[])
 void
 getversion_qmail_autoresponder_c()
 {
-	static char    *x = "$Id: autoresponder.c,v 1.34 2021-07-19 07:57:58+05:30 Cprogrammer Exp mbhangui $";
+	static char    *x = "$Id: autoresponder.c,v 1.35 2021-08-29 23:27:08+05:30 Cprogrammer Exp mbhangui $";
 
 	x++;
 }

--- a/indimail-mta-x/batv.c
+++ b/indimail-mta-x/batv.c
@@ -1,5 +1,8 @@
 /*
  * $Log: batv.c,v $
+ * Revision 1.6  2021-08-29 23:27:08+05:30  Cprogrammer
+ * define funtions as noreturn
+ *
  * Revision 1.5  2015-08-20 18:34:28+05:30  Cprogrammer
  * added usage for invalid option
  *
@@ -21,16 +24,17 @@
 #include <unistd.h>
 #include <ctype.h>
 #include <openssl/md5.h>
-#include "sgetopt.h"
-#include "stralloc.h"
-#include "now.h"
-#include "env.h"
-#include "str.h"
-#include "scan.h"
-#include "constmap.h"
-#include "strerr.h"
-#include "subfd.h"
-#include "byte.h"
+#include <sgetopt.h>
+#include <stralloc.h>
+#include <now.h>
+#include <env.h>
+#include <str.h>
+#include <scan.h>
+#include <constmap.h>
+#include <strerr.h>
+#include <subfd.h>
+#include <byte.h>
+#include <noreturn.h>
 
 #define FATAL "batv: fatal: "
 #define BATVLEN 3 /*- number of bytes */
@@ -60,7 +64,7 @@ flush()
 	return;
 }
 
-void
+no_return void
 die_nomem()
 {
 	substdio_flush(subfdout);
@@ -272,7 +276,7 @@ main(argc, argv)
 void
 getversion_batv_c()
 {
-	static char    *x = "$Id: batv.c,v 1.5 2015-08-20 18:34:28+05:30 Cprogrammer Stab mbhangui $";
+	static char    *x = "$Id: batv.c,v 1.6 2021-08-29 23:27:08+05:30 Cprogrammer Exp mbhangui $";
 
 	x++;
 }

--- a/indimail-mta-x/cdbdump.c
+++ b/indimail-mta-x/cdbdump.c
@@ -1,5 +1,8 @@
 /*
  * $Log: cdbdump.c,v $
+ * Revision 1.3  2021-08-29 23:27:08+05:30  Cprogrammer
+ * define funtions as noreturn
+ *
  * Revision 1.2  2020-11-24 13:44:11+05:30  Cprogrammer
  * removed exit.h
  *
@@ -8,14 +11,15 @@
  *
  */
 #include <unistd.h>
-#include "uint32.h"
-#include "fmt.h"
-#include "subfd.h"
-#include "strerr.h"
+#include <uint32.h>
+#include <fmt.h>
+#include <subfd.h>
+#include <strerr.h>
+#include <noreturn.h>
 
 #define FATAL "cdbdump: fatal: "
 
-void
+no_return void
 die_write(void)
 {
 	strerr_die2sys(111, FATAL, "unable to write output: ");
@@ -112,7 +116,7 @@ main()
 void
 getversion_cdbdump_c()
 {
-	static char    *x = "$Id: cdbdump.c,v 1.2 2020-11-24 13:44:11+05:30 Cprogrammer Exp mbhangui $";
+	static char    *x = "$Id: cdbdump.c,v 1.3 2021-08-29 23:27:08+05:30 Cprogrammer Exp mbhangui $";
 
 	x++;
 }

--- a/indimail-mta-x/cdbget.c
+++ b/indimail-mta-x/cdbget.c
@@ -1,5 +1,8 @@
 /*
  * $Log: cdbget.c,v $
+ * Revision 1.5  2021-08-29 23:27:08+05:30  Cprogrammer
+ * define funtions as noreturn
+ *
  * Revision 1.4  2020-11-24 13:44:14+05:30  Cprogrammer
  * removed exit.h
  *
@@ -14,27 +17,28 @@
  *
  */
 #include <unistd.h>
-#include "scan.h"
-#include "str.h"
-#include "subfd.h"
-#include "strerr.h"
-#include "cdb.h"
+#include <scan.h>
+#include <str.h>
+#include <subfd.h>
+#include <strerr.h>
+#include <cdb.h>
+#include <noreturn.h>
 
 #define FATAL "cdbget: fatal: "
 
-void
+no_return void
 die_read(void)
 {
 	strerr_die2sys(111, FATAL, "unable to read input: ");
 }
 
-void
+no_return void
 die_write(void)
 {
 	strerr_die2sys(111, FATAL, "unable to write output: ");
 }
 
-void
+no_return void
 die_usage(void)
 {
 	strerr_die1x(111, "cdbget: usage: cdbget key [skip]");
@@ -99,7 +103,7 @@ main(int argc, char **argv)
 void
 getversion_cdbget_c()
 {
-	static char    *x = "$Id: cdbget.c,v 1.4 2020-11-24 13:44:14+05:30 Cprogrammer Exp mbhangui $";
+	static char    *x = "$Id: cdbget.c,v 1.5 2021-08-29 23:27:08+05:30 Cprogrammer Exp mbhangui $";
 	if (x)
 		x++;
 }

--- a/indimail-mta-x/cdbstats.c
+++ b/indimail-mta-x/cdbstats.c
@@ -1,5 +1,8 @@
 /*
  * $Log: cdbstats.c,v $
+ * Revision 1.4  2021-08-29 23:27:08+05:30  Cprogrammer
+ * define funtions as noreturn
+ *
  * Revision 1.3  2020-11-24 13:44:16+05:30  Cprogrammer
  * removed exit.h
  *
@@ -11,29 +14,30 @@
  *
  */
 #include <unistd.h>
-#include "uint32.h"
-#include "fmt.h"
-#include "str.h"
-#include "subfd.h"
-#include "strerr.h"
-#include "seek.h"
-#include "cdb.h"
+#include <uint32.h>
+#include <fmt.h>
+#include <str.h>
+#include <subfd.h>
+#include <strerr.h>
+#include <seek.h>
+#include <cdb.h>
+#include <noreturn.h>
 
 #define FATAL "cdbstats: fatal: "
 
-void
+no_return void
 die_read(void)
 {
 	strerr_die2sys(111, FATAL, "unable to read input: ");
 }
 
-void
+no_return void
 die_readformat(void)
 {
 	strerr_die2x(111, FATAL, "unable to read input: truncated file");
 }
 
-void
+no_return void
 die_write(void)
 {
 	strerr_die2sys(111, FATAL, "unable to write output: ");
@@ -165,7 +169,7 @@ main()
 void
 getversion_cdbstats_c()
 {
-	static char    *x = "$Id: cdbstats.c,v 1.3 2020-11-24 13:44:16+05:30 Cprogrammer Exp mbhangui $";
+	static char    *x = "$Id: cdbstats.c,v 1.4 2021-08-29 23:27:08+05:30 Cprogrammer Exp mbhangui $";
 
 	x++;
 }

--- a/indimail-mta-x/cdbtest.c
+++ b/indimail-mta-x/cdbtest.c
@@ -1,5 +1,8 @@
 /*
  * $Log: cdbtest.c,v $
+ * Revision 1.4  2021-08-29 23:27:08+05:30  Cprogrammer
+ * define funtions as noreturn
+ *
  * Revision 1.3  2020-11-24 13:44:19+05:30  Cprogrammer
  * removed exit.h
  *
@@ -11,23 +14,24 @@
  *
  */
 #include <unistd.h>
-#include "uint32.h"
-#include "str.h"
-#include "fmt.h"
-#include "subfd.h"
-#include "strerr.h"
-#include "seek.h"
-#include "cdb.h"
+#include <uint32.h>
+#include <str.h>
+#include <fmt.h>
+#include <subfd.h>
+#include <strerr.h>
+#include <seek.h>
+#include <cdb.h>
+#include <noreturn.h>
 
 #define FATAL "cdbtest: fatal: "
 
-void
+no_return void
 die_read(void)
 {
 	strerr_die2sys(111, FATAL, "unable to read input: ");
 }
 
-void
+no_return void
 die_write(void)
 {
 	strerr_die2sys(111, FATAL, "unable to write output: ");
@@ -154,7 +158,7 @@ main()
 void
 getversion_cdbtest_c()
 {
-	static char    *x = "$Id: cdbtest.c,v 1.3 2020-11-24 13:44:19+05:30 Cprogrammer Exp mbhangui $";
+	static char    *x = "$Id: cdbtest.c,v 1.4 2021-08-29 23:27:08+05:30 Cprogrammer Exp mbhangui $";
 
 	x++;
 }

--- a/indimail-mta-x/checkaddr.c
+++ b/indimail-mta-x/checkaddr.c
@@ -1,5 +1,8 @@
 /*
  * $Log: checkaddr.c,v $
+ * Revision 1.4  2021-08-29 23:27:08+05:30  Cprogrammer
+ * define funtions as noreturn
+ *
  * Revision 1.3  2020-11-24 13:44:22+05:30  Cprogrammer
  * removed exit.h
  *
@@ -11,53 +14,56 @@
  *
  */
 #include <unistd.h>
-#include "substdio.h"
-#include "strerr.h"
-#include "getln.h"
-#include "mess822.h"
-#include "case.h"
-#include "env.h"
+#include <substdio.h>
+#include <strerr.h>
+#include <getln.h>
+#include <mess822.h>
+#include <case.h>
+#include <env.h>
+#include <noreturn.h>
 
 #define FATAL "checkaddr: fatal: "
 
-void nomem()
+char           *recipient;
+char          **recips;
+
+no_return void
+nomem()
 {
-  strerr_die2x(111,FATAL,"out of memory");
+	strerr_die2x(111, FATAL, "out of memory");
 }
 
-stralloc addrlist = {0};
-int match;
-static char     ssinbuf[1024];
-static substdio ssin = SUBSTDIO_FDBUF(read, 0, ssinbuf, sizeof ssinbuf);
-
-char *recipient;
-char **recips;
-
-void check(addr)
-char *addr;
+void
+check(char *addr)
 {
-  int i;
+	int             i;
 
-  if (recipient)
-    if (case_equals(addr,recipient)) _exit(0);
-
-  if (!recipient)
-    for (i = 0;recips[i];++i)
-      if (case_equals(addr,recips[i])) _exit(0);
+	if (recipient)
+		if (case_equals(addr, recipient))
+			_exit(0);
+	if (!recipient)
+		for (i = 0; recips[i]; ++i)
+			if (case_equals(addr, recips[i]))
+				_exit(0);
 }
 
-int main(argc,argv)
-int argc;
-char **argv;
+int
+main(int argc, char **argv)
 {
-  recipient = env_get("RECIPIENT");
-  recips = argv + 1;
-  if (*recips) recipient = 0;
+	stralloc        addrlist = { 0 };
+	int             match;
+	char            ssinbuf[1024];
+	substdio        ssin = SUBSTDIO_FDBUF(read, 0, ssinbuf, sizeof ssinbuf);
 
+	recipient = env_get("RECIPIENT");
+	recips = argv + 1;
+	if (*recips)
+		recipient = 0;
 	for (;;) {
-		if (getln(&ssin,&addrlist,&match,'\0') == -1)
-			strerr_die2sys(111,FATAL,"unable to read input: ");
-		if (!match) break;
+		if (getln(&ssin, &addrlist, &match, '\0') == -1)
+			strerr_die2sys(111, FATAL, "unable to read input: ");
+		if (!match)
+			break;
 		if (addrlist.s[0] == '+')
 			check(addrlist.s + 1);
 	}
@@ -68,7 +74,7 @@ char **argv;
 void
 getversion_checkaddr_c()
 {
-	static char    *x = "$Id: checkaddr.c,v 1.3 2020-11-24 13:44:22+05:30 Cprogrammer Exp mbhangui $";
+	static char    *x = "$Id: checkaddr.c,v 1.4 2021-08-29 23:27:08+05:30 Cprogrammer Exp mbhangui $";
 
 	x++;
 }

--- a/indimail-mta-x/checkdomain.c
+++ b/indimail-mta-x/checkdomain.c
@@ -1,5 +1,8 @@
 /*
  * $Log: checkdomain.c,v $
+ * Revision 1.4  2021-08-29 23:27:08+05:30  Cprogrammer
+ * define funtions as noreturn
+ *
  * Revision 1.3  2020-11-24 13:44:25+05:30  Cprogrammer
  * removed exit.h
  *
@@ -11,41 +14,34 @@
  *
  */
 #include <unistd.h>
-#include "substdio.h"
-#include "str.h"
-#include "strerr.h"
-#include "getln.h"
-#include "mess822.h"
-#include "case.h"
-#include "env.h"
+#include <substdio.h>
+#include <str.h>
+#include <strerr.h>
+#include <getln.h>
+#include <mess822.h>
+#include <case.h>
+#include <env.h>
+#include <noreturn.h>
 
 #define FATAL "checkdomain: fatal: "
 
-void
+char           *recipient;
+char          **recips;
+
+no_return void
 nomem()
 {
 	strerr_die2x(111, FATAL, "out of memory");
 }
 
-stralloc        addrlist = { 0 };
-int             match;
-static char     ssinbuf[1024];
-static substdio ssin = SUBSTDIO_FDBUF(read, 0, ssinbuf, sizeof ssinbuf);
-
-char           *recipient;
-char          **recips;
-
 void
-check(addr)
-	char           *addr;
+check(char *addr)
 {
 	int             i;
-
 
 	if (recipient)
 		if (case_equals(addr, recipient))
 			_exit(0);
-
 	if (!recipient)
 		for (i = 0; recips[i]; ++i)
 			if (case_equals(addr, recips[i]))
@@ -53,44 +49,40 @@ check(addr)
 }
 
 int
-main(argc, argv)
-	int             argc;
-	char          **argv;
+main(int argc, char **argv)
 {
-	int             i;
+	int             i, match;
+	stralloc        addrlist = { 0 };
+	char            ssinbuf[1024];
+	substdio        ssin = SUBSTDIO_FDBUF(read, 0, ssinbuf, sizeof ssinbuf);
 
 	recipient = env_get("RECIPIENT");
 	recips = argv + 1;
 	if (*recips)
 		recipient = 0;
-	else
-	{
+	else {
 		recipient += str_rchr(recipient, '@');
 		if (recipient)
 			++recipient;
 	}
-
-	for (;;)
-	{
+	for (;;) {
 		if (getln(&ssin, &addrlist, &match, '\0') == -1)
 			strerr_die2sys(111, FATAL, "unable to read input: ");
 		if (!match)
 			break;
-		if (addrlist.s[0] == '+')
-		{
+		if (addrlist.s[0] == '+') {
 			i = str_rchr(addrlist.s, '@');
 			if (addrlist.s[i])
 				check(addrlist.s + i + 1);
 		}
 	}
-
 	_exit(100);
 }
 
 void
 getversion_checkdomain_c()
 {
-	static char    *x = "$Id: checkdomain.c,v 1.3 2020-11-24 13:44:25+05:30 Cprogrammer Exp mbhangui $";
+	static char    *x = "$Id: checkdomain.c,v 1.4 2021-08-29 23:27:08+05:30 Cprogrammer Exp mbhangui $";
 
 	x++;
 }

--- a/indimail-mta-x/cleanq.c
+++ b/indimail-mta-x/cleanq.c
@@ -1,5 +1,8 @@
 /*
  * $Log: cleanq.c,v $
+ * Revision 1.12  2021-08-29 23:27:08+05:30  Cprogrammer
+ * define funtions as noreturn
+ *
  * Revision 1.11  2021-06-27 10:35:07+05:30  Cprogrammer
  * uidnit new argument to disable/enable error on missing uids
  *
@@ -38,26 +41,27 @@
 #include <sys/stat.h>
 #include <unistd.h>
 #include <fcntl.h>
-#include "substdio.h"
-#include "subfd.h"
-#include "sgetopt.h"
-#include "error.h"
-#include "strerr.h"
-#include "direntry.h"
+#include <time.h>
+#include <substdio.h>
+#include <subfd.h>
+#include <sgetopt.h>
+#include <error.h>
+#include <strerr.h>
+#include <direntry.h>
+#include <wait.h>
+#include <str.h>
+#include <scan.h>
+#include <sig.h>
+#include <noreturn.h>
 #include "auto_ageout.h"
 #include "auto_uids.h"
-#include "wait.h"
-#include "str.h"
-#include "scan.h"
-#include <time.h>
-#include "sig.h"
 
 #define FATAL "cleanq: fatal: "
 #define WARNING "cleanq: warning: "
 
 static int      flaglog = 0, dir_flag = 0;
 
-void
+no_return void
 die_usage(void)
 {
 	strerr_die1x(100, "cleanq: usage: cleanq [-l] [-s interval] [directory]");
@@ -190,7 +194,7 @@ tryclean(const char *d)
 	remove_files(d);
 }
 
-void
+no_return void
 sigterm()
 {
 	if (flaglog)
@@ -270,7 +274,7 @@ main(int argc, char **argv)
 void
 getversion_cleanq_c()
 {
-	static char    *x = "$Id: cleanq.c,v 1.11 2021-06-27 10:35:07+05:30 Cprogrammer Exp mbhangui $";
+	static char    *x = "$Id: cleanq.c,v 1.12 2021-08-29 23:27:08+05:30 Cprogrammer Exp mbhangui $";
 
 	x++;
 }

--- a/indimail-mta-x/columnt.c
+++ b/indimail-mta-x/columnt.c
@@ -1,5 +1,8 @@
 /*
  * $Log: columnt.c,v $
+ * Revision 1.6  2021-08-29 23:27:08+05:30  Cprogrammer
+ * define funtions as noreturn
+ *
  * Revision 1.5  2020-11-24 13:44:34+05:30  Cprogrammer
  * removed exit.h
  *
@@ -17,30 +20,31 @@
  *
  */
 #include <unistd.h>
-#include "stralloc.h"
-#include "alloc.h"
+#include <stralloc.h>
+#include <alloc.h>
+#include <strerr.h>
+#include <substdio.h>
 #include "slurpclose.h"
-#include "strerr.h"
-#include "substdio.h"
+#include <noreturn.h>
 
 #define FATAL "columnt: fatal: "
 
 char            outbuf[4096];
 substdio        ssout = SUBSTDIO_FDBUF(write, 1, outbuf, sizeof outbuf);
 
-void
+no_return void
 nomem()
 {
 	strerr_die2x(111, FATAL, "out of memory");
 }
 
-void
+no_return void
 die_read()
 {
 	strerr_die2sys(111, FATAL, "unable to read input: ");
 }
 
-void
+no_return void
 die_write()
 {
 	strerr_die2sys(111, FATAL, "unable to write output: ");
@@ -171,7 +175,7 @@ main()
 void
 getversion_columnt_c()
 {
-	static char    *x = "$Id: columnt.c,v 1.5 2020-11-24 13:44:34+05:30 Cprogrammer Exp mbhangui $";
+	static char    *x = "$Id: columnt.c,v 1.6 2021-08-29 23:27:08+05:30 Cprogrammer Exp mbhangui $";
 
 	x++;
 }

--- a/indimail-mta-x/dktest.c
+++ b/indimail-mta-x/dktest.c
@@ -1,5 +1,8 @@
 /*
  * $Log: dktest.c,v $
+ * Revision 1.18  2021-08-29 23:27:08+05:30  Cprogrammer
+ * define funtions as noreturn
+ *
  * Revision 1.17  2019-06-07 11:25:58+05:30  Cprogrammer
  * replaced getopt() with subgetopt()
  *
@@ -59,13 +62,14 @@
 #include <string.h>
 #include <unistd.h>
 #include <stdlib.h>
+#include <sgetopt.h>
+#include <noreturn.h>
 #include "domainkeys.h"
-#include "sgetopt.h"
 
 #ifdef DOMAIN_KEYS
 int             optf = 0;
 
-void
+no_return void
 errorout(DK *dk, DK_STAT st)
 {
 	if (optf && dk)
@@ -431,7 +435,7 @@ main(int argc, char *argv[])
 void
 getversion_dktest_c()
 {
-	static char    *x = "$Id: dktest.c,v 1.17 2019-06-07 11:25:58+05:30 Cprogrammer Exp mbhangui $";
+	static char    *x = "$Id: dktest.c,v 1.18 2021-08-29 23:27:08+05:30 Cprogrammer Exp mbhangui $";
 
 	x++;
 }

--- a/indimail-mta-x/do_ripmime.c
+++ b/indimail-mta-x/do_ripmime.c
@@ -1,19 +1,21 @@
 /*
  * $Log: do_ripmime.c,v $
+ * Revision 1.2  2021-08-30 01:07:47+05:30  Cprogrammer
+ * renamed pid as cmd_pid
+ *
  * Revision 1.1  2008-08-03 18:27:30+05:30  Cprogrammer
  * Initial revision
  *
  */
 #include <sys/types.h>
 #include <unistd.h>
-#include "wait.h"
-#include "sig.h"
+#include <wait.h>
+#include <sig.h>
+#include <strerr.h>
 #include "exitcodes.h"
-#include "strerr.h"
 
 extern int      flaglog;
-extern int      alarm_flag;
-extern pid_t    pid;
+extern pid_t    cmd_pid;
 extern char    *auto_ripmime_cmd[];
 
 int
@@ -24,7 +26,7 @@ do_ripmime()
 	/*- Defer alarms */
 	sig_alarmblock();
 	/*- Launch ripmime */
-	switch (pid = vfork())
+	switch ((cmd_pid = vfork()))
 	{
 	case -1:
 		if (flaglog)
@@ -41,9 +43,9 @@ do_ripmime()
 	/*- Allow alarms */
 	sig_alarmunblock();
 	/*- Catch the exit status */
-	if (wait_pid(&rmstat, pid) == -1)
+	if (wait_pid(&rmstat, cmd_pid) == -1)
 		return 0;
-	pid = 0;
+	cmd_pid = 0;
 	if (wait_crashed(rmstat))
 		return 0;
 	if (wait_exitcode(rmstat) != 0)
@@ -54,7 +56,7 @@ do_ripmime()
 void
 getversion_do_ripmime_c()
 {
-	static char    *x = "$Id: do_ripmime.c,v 1.1 2008-08-03 18:27:30+05:30 Cprogrammer Stab mbhangui $";
+	static char    *x = "$Id: do_ripmime.c,v 1.2 2021-08-30 01:07:47+05:30 Cprogrammer Exp mbhangui $";
 
 	x++;
 }

--- a/indimail-mta-x/do_scan.c
+++ b/indimail-mta-x/do_scan.c
@@ -1,5 +1,8 @@
 /*
  * $Log: do_scan.c,v $
+ * Revision 1.19  2021-08-29 23:27:08+05:30  Cprogrammer
+ * define funtions as noreturn
+ *
  * Revision 1.18  2021-06-15 11:32:24+05:30  Cprogrammer
  * remove creation of link for /etc/indimail/control in scanq directory
  *
@@ -67,6 +70,7 @@
 #include <strerr.h>
 #include <str.h>
 #include <makeargs.h>
+#include <noreturn.h>
 #include "control.h"
 #include "qregex.h"
 #include "exitcodes.h"
@@ -74,31 +78,29 @@
 #include "variables.h"
 
 extern int      flaglog;
-extern pid_t    pid;
+extern pid_t    cmd_pid;
 extern int      alarm_flag;
 extern char    *auto_scancmd[];
 
-int             extok = 0;
 static stralloc ext = { 0 };
-struct constmap mapext;
-int             brpok = 0;
+static struct constmap mapext;
+static int      brpok = 0, extok = 0;
 static stralloc brp = { 0 };
 
-void
+no_return void
 die_nomem()
 {
 	_exit(51);
 }
 
-void
+no_return void
 die_control()
 {
 	_exit(55);
 }
 
-void
-die(e)
-	int             e;
+no_return void
+die(int e)
 {
 	_exit(e);
 }
@@ -187,7 +189,7 @@ do_scan()
 	case 5:
 	case 6:
 		/*- Launch antivir */
-		switch (pid = vfork())
+		switch ((cmd_pid = vfork()))
 		{
 		case -1: /*- Can't launch; temporary failure */
 			if (flaglog)
@@ -213,7 +215,7 @@ do_scan()
 		/*- Allow alarms */
 		sig_alarmunblock();
 		/*- Catch the exit status */
-		if (wait_pid(&avstat, pid) == -1) {
+		if (wait_pid(&avstat, cmd_pid) == -1) {
 			if (flaglog)
 				strerr_warn1("qscanq-stdin: waitpid failed: ", &strerr_sys);
 			return EX_TMPERR;
@@ -234,7 +236,7 @@ do_scan()
 void
 getversion_do_scan_c()
 {
-	static char    *x = "$Id: do_scan.c,v 1.18 2021-06-15 11:32:24+05:30 Cprogrammer Exp mbhangui $";
+	static char    *x = "$Id: do_scan.c,v 1.19 2021-08-29 23:27:08+05:30 Cprogrammer Exp mbhangui $";
 
 	x = sccsidmakeargsh;
 	x++;

--- a/indimail-mta-x/dot-forward.c
+++ b/indimail-mta-x/dot-forward.c
@@ -1,5 +1,8 @@
 /*
  * $Log: dot-forward.c,v $
+ * Revision 1.16  2021-08-29 23:27:08+05:30  Cprogrammer
+ * define funtions as noreturn
+ *
  * Revision 1.15  2021-07-05 21:10:12+05:30  Cprogrammer
  * skip $HOME/.defaultqueue for root
  *
@@ -65,6 +68,7 @@
 #include <fmt.h>
 #include <token822.h>
 #include <sgetopt.h>
+#include <noreturn.h>
 #include "control.h"
 #include "qmail.h"
 #include "set_environment.h"
@@ -108,31 +112,31 @@ char            qqbuf[256];
 substdio        ssqq = SUBSTDIO_FDBUF(mywrite, -1, qqbuf, sizeof qqbuf);
 char            inbuf[256];
 
-void
+no_return void
 die_nomem()
 {
 	strerr_die2x(111, FATAL, "out of memory");
 }
 
-void
+no_return void
 die_control()
 {
 	strerr_die2sys(111, FATAL, "unable to read controls: ");
 }
 
-void
+no_return void
 die_qq()
 {
 	strerr_die2sys(111, FATAL, "unable to run qq: ");
 }
 
-void
+no_return void
 die_readmess()
 {
 	strerr_die2sys(111, FATAL, "unable to read message: ");
 }
 
-void
+no_return void
 die_parse()
 {
 	if (!stralloc_0(&line))
@@ -517,7 +521,7 @@ main(argc, argv)
 void
 getversion_dot_forward_c()
 {
-	static char    *x = "$Id: dot-forward.c,v 1.15 2021-07-05 21:10:12+05:30 Cprogrammer Exp mbhangui $";
+	static char    *x = "$Id: dot-forward.c,v 1.16 2021-08-29 23:27:08+05:30 Cprogrammer Exp mbhangui $";
 
 	x++;
 }

--- a/indimail-mta-x/drate.c
+++ b/indimail-mta-x/drate.c
@@ -1,5 +1,8 @@
 /*
  * $Log: drate.c,v $
+ * Revision 1.21  2021-08-29 23:27:08+05:30  Cprogrammer
+ * define funtions as noreturn
+ *
  * Revision 1.20  2021-08-28 23:02:52+05:30  Cprogrammer
  * moved delivery variable to getDomainToken.c
  *
@@ -84,6 +87,7 @@
 #include <check_domain.h>
 #include <date822fmt.h>
 #include <no_of_days.h>
+#include <noreturn.h>
 #include "variables.h"
 #include "auto_qmail.h"
 #include "auto_uids.h"
@@ -126,7 +130,7 @@ logerrf(char *s)
 		_exit(1);
 }
 
-void
+no_return void
 my_error(char *s1, int exit_val)
 {
 	logerr(s1);
@@ -134,7 +138,7 @@ my_error(char *s1, int exit_val)
 	_exit(exit_val);
 }
 
-void
+no_return void
 cleanup(char *file, char *str, int e)
 {
 	if (e == error_noent)
@@ -624,7 +628,7 @@ main(int argc, char **argv)
 void
 getversion_drate_c()
 {
-	static char    *x = "$Id: drate.c,v 1.20 2021-08-28 23:02:52+05:30 Cprogrammer Exp mbhangui $";
+	static char    *x = "$Id: drate.c,v 1.21 2021-08-29 23:27:08+05:30 Cprogrammer Exp mbhangui $";
 
 	x = sccsidgetdomainth;
 	x = sccsidevalh;

--- a/indimail-mta-x/fastforward.c
+++ b/indimail-mta-x/fastforward.c
@@ -1,5 +1,8 @@
 /*
  * $Log: fastforward.c,v $
+ * Revision 1.13  2021-08-29 23:27:08+05:30  Cprogrammer
+ * define funtions as noreturn
+ *
  * Revision 1.12  2021-07-05 21:10:17+05:30  Cprogrammer
  * skip $HOME/.defaultqueue for root
  *
@@ -40,59 +43,57 @@
 #include <unistd.h>
 #include <sys/types.h>
 #include <sys/stat.h>
-#include "envdir.h"
-#include "pathexec.h"
-#include "stralloc.h"
-#include "substdio.h"
-#include "subfd.h"
-#include "open.h"
-#include "cdb.h"
-#include "str.h"
-#include "byte.h"
-#include "slurpclose.h"
-#include "strset.h"
-#include "strerr.h"
-#include "env.h"
-#include "sig.h"
+#include <envdir.h>
+#include <pathexec.h>
+#include <stralloc.h>
+#include <substdio.h>
+#include <subfd.h>
+#include <open.h>
+#include <cdb.h>
+#include <str.h>
+#include <byte.h>
+#include <strerr.h>
+#include <env.h>
+#include <sig.h>
+#include <fmt.h>
+#include <case.h>
+#include <alloc.h>
+#include <coe.h>
+#include <seek.h>
+#include <wait.h>
+#include <sgetopt.h>
+#include <noreturn.h>
 #include "qmail.h"
-#include "fmt.h"
-#include "case.h"
-#include "alloc.h"
-#include "coe.h"
-#include "seek.h"
-#include "wait.h"
-#include "sgetopt.h"
+#include "strset.h"
+#include "slurpclose.h"
 #include "set_environment.h"
 
 #define FATAL "fastforward: fatal: "
 #define WARN  "fastforward: warn: "
 
-void
+no_return void
 usage()
 {
 	strerr_die1x(100, "fastforward: usage: fastforward [ -nNpP ] data.cdb");
 }
 
-void
+no_return void
 nomem()
 {
 	strerr_die2x(111, FATAL, "out of memory");
 }
 
 void
-print(s)
-	char           *s;
+print(char *s)
 {
 	char            ch;
 
-	while ((ch = *s++)) {
+	while ((ch = *s++))
 		substdio_put(subfderr, &ch, 1);
-	}
 }
 
 void
-printsafe(s)
-	char           *s;
+printsafe(char *s)
 {
 	char            ch;
 
@@ -108,10 +109,7 @@ char            qp[FMT_ULONG];
 char            qqbuf[1];
 
 ssize_t
-qqwrite(fd, buf, len)
-	int             fd;
-	char           *buf;
-	int             len;
+qqwrite(int fd, char *buf, int len)
 {
 	qmail_put(&qq, buf, len);
 	return len;
@@ -131,8 +129,7 @@ stralloc        todo = { 0 };
 stralloc        mailinglist = { 0 };
 
 void
-dofile(fn)
-	char           *fn;
+dofile(char *fn)
 {
 	int             fd;
 	struct stat     st;
@@ -175,17 +172,14 @@ stralloc        key = { 0 };
 uint32          dlen;
 stralloc        data = { 0 };
 
-void
+no_return void
 cdbreaderror()
 {
 	strerr_die4sys(111, FATAL, "unable to read ", fncdb, ": ");
 }
 
 int
-findtarget(flagwild, prepend, addr)
-	int             flagwild;
-	char           *prepend;
-	char           *addr;
+findtarget(int flagwild, char *prepend, char *addr)
 {
 	int             r;
 	int             at;
@@ -226,10 +220,7 @@ findtarget(flagwild, prepend, addr)
 }
 
 int
-gettarget(flagwild, prepend, addr)
-	int             flagwild;
-	char           *prepend;
-	char           *addr;
+gettarget(int flagwild, char *prepend, char *addr)
 {
 	if (!findtarget(flagwild, prepend, addr))
 		return 0;
@@ -242,8 +233,7 @@ gettarget(flagwild, prepend, addr)
 }
 
 void
-doprogram(arg)
-	char           *arg;
+doprogram(char *arg)
 {
 	char           *args[5];
 	int             child;
@@ -330,8 +320,7 @@ dodata()
 }
 
 void
-dorecip(addr)
-	char           *addr;
+dorecip(char *addr)
 {
 
 	if (!findtarget(0, "?", addr) && gettarget(0, ":", addr)) {
@@ -345,8 +334,7 @@ dorecip(addr)
 }
 
 void
-doorigrecip(addr)
-	char           *addr;
+doorigrecip(char *addr)
 {
 	if (sender.len) {
 		if ((sender.len != 4) || byte_diff(sender.s, 4, "#@[]")) {
@@ -367,9 +355,7 @@ stralloc        recipient = { 0 };
 int             flagdefault = 0;
 
 int
-main(argc, argv)
-	int             argc;
-	char          **argv;
+main(int argc, char **argv)
 {
 	int             opt, i;
 	char           *x;
@@ -512,7 +498,7 @@ main(argc, argv)
 void
 getversion_fastforward_c()
 {
-	static char    *x = "$Id: fastforward.c,v 1.12 2021-07-05 21:10:17+05:30 Cprogrammer Exp mbhangui $";
+	static char    *x = "$Id: fastforward.c,v 1.13 2021-08-29 23:27:08+05:30 Cprogrammer Exp mbhangui $";
 
 	x++;
 }

--- a/indimail-mta-x/forward.c
+++ b/indimail-mta-x/forward.c
@@ -1,5 +1,8 @@
 /*
  * $Log: forward.c,v $
+ * Revision 1.15  2021-08-29 23:27:08+05:30  Cprogrammer
+ * define funtions as noreturn
+ *
  * Revision 1.14  2021-07-05 21:10:35+05:30  Cprogrammer
  * skip $HOME/.defaultqueue for root
  *
@@ -38,24 +41,25 @@
  *
  */
 #include <unistd.h>
-#include "envdir.h"
-#include "pathexec.h"
-#include "sig.h"
-#include "env.h"
-#include "qmail.h"
-#include "strerr.h"
-#include "substdio.h"
-#include "fmt.h"
+#include <envdir.h>
+#include <pathexec.h>
+#include <sig.h>
+#include <env.h>
+#include <strerr.h>
+#include <substdio.h>
+#include <fmt.h>
 #ifdef HAVESRS
-#include "stralloc.h"
-#include "srs.h"
+#include <stralloc.h>
+#include <srs.h>
 #endif
+#include <noreturn.h>
+#include "qmail.h"
 #include "set_environment.h"
 
 #define FATAL "forward: fatal: "
 #define WARN  "forward: warn: "
 
-void
+no_return void
 die_nomem()
 {
 	strerr_die2x(111, FATAL, "out of memory");
@@ -64,10 +68,7 @@ die_nomem()
 struct qmail    qqt;
 
 ssize_t
-mywrite(fd, buf, len)
-	int             fd;
-	char           *buf;
-	int             len;
+mywrite(int fd, char *buf, int len)
 {
 	qmail_put(&qqt, buf, len);
 	return len;
@@ -81,9 +82,7 @@ substdio        ssout = SUBSTDIO_FDBUF(mywrite, -1, outbuf, sizeof outbuf);
 char            num[FMT_ULONG];
 
 int
-main(argc, argv)
-	int             argc;
-	char          **argv;
+main(int argc, char **argv)
 {
 	char           *sender, *dtline, *qqeh, *qqx;
 
@@ -137,7 +136,7 @@ main(argc, argv)
 void
 getversion_forward_c()
 {
-	static char    *x = "$Id: forward.c,v 1.14 2021-07-05 21:10:35+05:30 Cprogrammer Exp mbhangui $";
+	static char    *x = "$Id: forward.c,v 1.15 2021-08-29 23:27:08+05:30 Cprogrammer Exp mbhangui $";
 
 	x++;
 }

--- a/indimail-mta-x/generic.c
+++ b/indimail-mta-x/generic.c
@@ -1,5 +1,8 @@
 /*
  * $Log: generic.c,v $
+ * Revision 1.6  2021-08-29 23:27:08+05:30  Cprogrammer
+ * define funtions as noreturn
+ *
  * Revision 1.5  2021-06-15 11:36:51+05:30  Cprogrammer
  * moved makeargs.h to libqmail
  *
@@ -21,10 +24,11 @@
 #include <env.h>
 #include <wait.h>
 #include <makeargs.h>
+#include <noreturn.h>
 
 extern char    *auto_scancmd[];
 
-int
+no_return int
 virusscan(char *messfn)
 {
 	int             wstat, child;
@@ -38,20 +42,17 @@ virusscan(char *messfn)
 	case -1:
 		_exit(121);
 	case 0:
-		if ((ptr = env_get("SCANCMD")))
-		{
+		if ((ptr = env_get("SCANCMD"))) {
 			if (!(argv = makeargs(ptr)))
 				_exit(51);
 		} else
 			argv = auto_scancmd;
-		if (!argv[1])
-		{
+		if (!argv[1]) {
 			scancmd[0] = argv[0];
 			scancmd[1] = messfn;
 			argv = scancmd;
 		} else
-		for (u = 1; argv[u]; u++)
-		{
+		for (u = 1; argv[u]; u++) {
 			if (!str_diffn(argv[u], "%s", 2))
 				argv[u] = messfn;
 		}
@@ -72,7 +73,7 @@ virusscan(char *messfn)
 void
 getversion_generic_c()
 {
-	static char    *x = "$Id: generic.c,v 1.5 2021-06-15 11:36:51+05:30 Cprogrammer Exp mbhangui $";
+	static char    *x = "$Id: generic.c,v 1.6 2021-08-29 23:27:08+05:30 Cprogrammer Exp mbhangui $";
 
 	x = sccsidmakeargsh;
 	x++;

--- a/indimail-mta-x/iftocc.c
+++ b/indimail-mta-x/iftocc.c
@@ -1,5 +1,8 @@
 /*
  * $Log: iftocc.c,v $
+ * Revision 1.4  2021-08-29 23:27:08+05:30  Cprogrammer
+ * define funtions as noreturn
+ *
  * Revision 1.3  2020-11-24 13:45:30+05:30  Cprogrammer
  * removed exit.h
  *
@@ -11,17 +14,18 @@
  *
  */
 #include <unistd.h>
-#include "substdio.h"
-#include "strerr.h"
-#include "subfd.h"
-#include "getln.h"
-#include "mess822.h"
-#include "case.h"
-#include "env.h"
+#include <substdio.h>
+#include <strerr.h>
+#include <subfd.h>
+#include <getln.h>
+#include <mess822.h>
+#include <case.h>
+#include <env.h>
+#include <noreturn.h>
 
 #define FATAL "iftocc: fatal: "
 
-void
+no_return void
 nomem()
 {
 	strerr_die2x(111, FATAL, "out of memory");
@@ -43,8 +47,7 @@ char           *recipient;
 char          **recips;
 
 void
-check(addr)
-	char           *addr;
+check(char *addr)
 {
 	int             i;
 
@@ -59,9 +62,7 @@ check(addr)
 }
 
 int
-main(argc, argv)
-	int             argc;
-	char          **argv;
+main(int argc, char **argv)
 {
 	int             i;
 	int             j;
@@ -104,7 +105,7 @@ main(argc, argv)
 void
 getversion_iftocc_c()
 {
-	static char    *x = "$Id: iftocc.c,v 1.3 2020-11-24 13:45:30+05:30 Cprogrammer Exp mbhangui $";
+	static char    *x = "$Id: iftocc.c,v 1.4 2021-08-29 23:27:08+05:30 Cprogrammer Exp mbhangui $";
 
 	x++;
 }

--- a/indimail-mta-x/iftoccfrom.c
+++ b/indimail-mta-x/iftoccfrom.c
@@ -1,5 +1,8 @@
 /*
  * $Log: iftoccfrom.c,v $
+ * Revision 1.4  2021-08-29 23:27:08+05:30  Cprogrammer
+ * define funtions as noreturn
+ *
  * Revision 1.3  2020-11-24 13:45:33+05:30  Cprogrammer
  * removed exit.h
  *
@@ -11,89 +14,93 @@
  *
  */
 #include <unistd.h>
-#include "substdio.h"
-#include "strerr.h"
-#include "getln.h"
-#include "mess822.h"
-#include "case.h"
-#include "env.h"
+#include <substdio.h>
+#include <strerr.h>
+#include <getln.h>
+#include <mess822.h>
+#include <case.h>
+#include <env.h>
+#include <noreturn.h>
 
 #define FATAL "iftoccfrom: fatal: "
 
-void nomem()
+no_return void
+nomem()
 {
-  strerr_die2x(111,FATAL,"out of memory");
+	strerr_die2x(111, FATAL, "out of memory");
 }
 
-stralloc addrlist = {0};
 
-mess822_header h = MESS822_HEADER;
-mess822_action a[] = {
-  { "to", 0, 0, 0, &addrlist, 0 }
-, { "cc", 0, 0, 0, &addrlist, 0 }
-, { "from", 0, 0, 0, &addrlist, 0 }
-, { 0, 0, 0, 0, 0, 0 }
-} ;
+char           *recipient;
+char          **recips;
 
-stralloc line = {0};
-int match;
-static char     ssinbuf[1024];
-static substdio ssin = SUBSTDIO_FDBUF(read, 0, ssinbuf, sizeof ssinbuf);
-
-char *recipient;
-char **recips;
-
-void check(addr)
-char *addr;
+void
+check(addr)
+	char           *addr;
 {
-  int i;
+	int             i;
 
-  if (recipient)
-    if (case_equals(addr,recipient)) _exit(0);
+	if (recipient)
+		if (case_equals(addr, recipient))
+			_exit(0);
 
-  if (!recipient)
-    for (i = 0;recips[i];++i)
-      if (case_equals(addr,recips[i])) _exit(0);
+	if (!recipient)
+		for (i = 0; recips[i]; ++i)
+			if (case_equals(addr, recips[i]))
+				_exit(0);
 }
 
-int main(argc,argv)
-int argc;
-char **argv;
+int
+main(argc, argv)
+	int             argc;
+	char          **argv;
 {
-  int i;
-  int j;
+	int             i, j, match;
+	stralloc        addrlist = { 0 }, line = { 0 };
+	char            ssinbuf[1024];
+	substdio        ssin = SUBSTDIO_FDBUF(read, 0, ssinbuf, sizeof ssinbuf);
+	mess822_header  h = MESS822_HEADER;
+	mess822_action  a[] = {
+		{ "to", 0, 0, 0, &addrlist, 0 },
+		{ "cc", 0, 0, 0, &addrlist, 0 },
+		{ "from", 0, 0, 0, &addrlist, 0 },
+		{ 0, 0, 0, 0, 0, 0 }
+	};
 
-  recipient = env_get("RECIPIENT");
-  recips = argv + 1;
-  if (*recips) recipient = 0;
+	recipient = env_get("RECIPIENT");
+	recips = argv + 1;
+	if (*recips)
+		recipient = 0;
 
-  if (!mess822_begin(&h,a)) nomem();
+	if (!mess822_begin(&h, a))
+		nomem();
 
-  for (;;) {
-    if (getln(&ssin,&line,&match,'\n') == -1)
-      strerr_die2sys(111,FATAL,"unable to read input: ");
-
-    if (!mess822_ok(&line)) break;
-    if (!mess822_line(&h,&line)) nomem();
-    if (!match) break;
-  }
-
-  if (!mess822_end(&h)) nomem();
-
-  for (j = i = 0;j < addrlist.len;++j)
-    if (!addrlist.s[j]) {
-      if (addrlist.s[i] == '+')
+	for (;;) {
+		if (getln(&ssin, &line, &match, '\n') == -1)
+			strerr_die2sys(111, FATAL, "unable to read input: ");
+		if (!mess822_ok(&line))
+			break;
+		if (!mess822_line(&h, &line))
+			nomem();
+		if (!match)
+			break;
+	}
+	if (!mess822_end(&h))
+		nomem();
+	for (j = i = 0; j < addrlist.len; ++j) {
+		if (!addrlist.s[j]) {
+			if (addrlist.s[i] == '+')
 				check(addrlist.s + i + 1);
-      i = j + 1;
-    }
-
-  _exit(100);
+			i = j + 1;
+		}
+	}
+	_exit(100);
 }
 
 void
 getversion_iftoccfrom_c()
 {
-	static char    *x = "$Id: iftoccfrom.c,v 1.3 2020-11-24 13:45:33+05:30 Cprogrammer Exp mbhangui $";
+	static char    *x = "$Id: iftoccfrom.c,v 1.4 2021-08-29 23:27:08+05:30 Cprogrammer Exp mbhangui $";
 
 	x++;
 }

--- a/indimail-mta-x/inewaliases.c
+++ b/indimail-mta-x/inewaliases.c
@@ -1,5 +1,8 @@
 /*
  * $Log: inewaliases.c,v $
+ * Revision 1.7  2021-08-29 23:27:08+05:30  Cprogrammer
+ * define funtions as noreturn
+ *
  * Revision 1.6  2021-06-15 11:38:13+05:30  Cprogrammer
  * moved token822 to libqmail
  *
@@ -30,6 +33,7 @@
 #include <byte.h>
 #include <case.h>
 #include <cdbmss.h>
+#include <noreturn.h>
 #include "control.h"
 #include "variables.h"
 
@@ -37,46 +41,61 @@
 
 int             rename(const char *, const char *);
 
-void
+static stralloc me = { 0 };
+static stralloc defaulthost = { 0 };
+static stralloc defaultdomain = { 0 };
+static stralloc plusdomain = { 0 };
+static stralloc target = { 0 };
+static stralloc fulltarget = { 0 };
+static stralloc instr = { 0 };
+static stralloc cbuf = { 0 };
+static stralloc address = { 0 };
+static stralloc line = { 0 };
+static stralloc newline = { 0 };
+static stralloc key = { 0 };
+static token822_alloc toks = { 0 };
+static token822_alloc tokaddr = { 0 };
+static int      match;
+static char     inbuf[1024];
+static substdio ssin;
+static struct cdbmss cdbmss;
+
+
+no_return void
 nomem()
 {
 	strerr_die2x(111, FATAL, "out of memory");
 }
 
-void
+no_return void
 nulbyte()
 {
 	strerr_die2x(100, FATAL, "NUL bytes are not permitted");
 }
 
-void
+no_return void
 longaddress()
 {
 	strerr_die2x(100, FATAL, "addresses over 800 bytes are not permitted");
 }
 
-void
+no_return void
 writeerr()
 {
 	strerr_die2sys(111, FATAL, "unable to write to /etc/aliases.tmp: ");
 }
 
-void
+no_return void
 readerr()
 {
 	strerr_die2sys(111, FATAL, "unable to read /etc/aliases: ");
 }
 
-void
+no_return void
 die_control()
 {
 	strerr_die2sys(111, FATAL, "unable to read controls: ");
 }
-
-stralloc        me = { 0 };
-stralloc        defaulthost = { 0 };
-stralloc        defaultdomain = { 0 };
-stralloc        plusdomain = { 0 };
 
 void
 readcontrols()
@@ -100,15 +119,6 @@ readcontrols()
 	if (!r && !stralloc_copy(&plusdomain, &me))
 		nomem();
 }
-
-stralloc        target = { 0 };
-stralloc        fulltarget = { 0 };
-stralloc        instr = { 0 };
-
-stralloc        cbuf = { 0 };
-token822_alloc  toks = { 0 };
-token822_alloc  tokaddr = { 0 };
-stralloc        address = { 0 };
 
 void
 gotincl()
@@ -199,11 +209,7 @@ gotaddr()
 		strerr_die2x(111, FATAL, "NUL not permitted in recipient addresses");
 }
 
-stralloc        line = { 0 };
-stralloc        newline = { 0 };
-int             match;
-
-void
+no_return void
 parseerr()
 {
 	if (!stralloc_0(&line))
@@ -293,11 +299,6 @@ parseline()
 		gotaddr();
 }
 
-char            inbuf[1024];
-substdio        ssin;
-struct cdbmss   cdbmss;
-stralloc        key = { 0 };
-
 void
 doit()
 {
@@ -379,7 +380,7 @@ main()
 void
 getversion_newaliases_c()
 {
-	static char    *x = "$Id: inewaliases.c,v 1.6 2021-06-15 11:38:13+05:30 Cprogrammer Exp mbhangui $";
+	static char    *x = "$Id: inewaliases.c,v 1.7 2021-08-29 23:27:08+05:30 Cprogrammer Exp mbhangui $";
 
 	x++;
 }

--- a/indimail-mta-x/installer.c
+++ b/indimail-mta-x/installer.c
@@ -1,5 +1,8 @@
 /*
  * $Log: installer.c,v $
+ * Revision 1.19  2021-08-29 23:27:08+05:30  Cprogrammer
+ * define funtions as noreturn
+ *
  * Revision 1.18  2021-08-05 20:52:44+05:30  Cprogrammer
  * fixed bug of skipping files in check mode
  *
@@ -76,6 +79,7 @@
 #include <byte.h>
 #include <scan.h>
 #include <fmt.h>
+#include <noreturn.h>
 
 static stralloc target = { 0 };
 static char    *user, *group, *to;
@@ -86,7 +90,7 @@ static substdio ssin, ssout;
 static uid_t    my_uid;
 static int      dofix, missing_ok, create_paths;
 
-void
+no_return void
 nomem()
 {
 	strerr_die2x(111, FATAL, "out of memory");
@@ -527,7 +531,7 @@ doit(stralloc *line, int uninstall, int check)
 
 }
 
-void
+no_return void
 die_usage()
 {
 	const char     *usage_str =
@@ -595,7 +599,7 @@ main(int argc, char **argv)
 void
 getversion_installer_c()
 {
-	static const char *x = "$Id: installer.c,v 1.18 2021-08-05 20:52:44+05:30 Cprogrammer Exp mbhangui $";
+	static const char *x = "$Id: installer.c,v 1.19 2021-08-29 23:27:08+05:30 Cprogrammer Exp mbhangui $";
 
 	if (x)
 		x++;

--- a/indimail-mta-x/ldap-checkpwd.c
+++ b/indimail-mta-x/ldap-checkpwd.c
@@ -1,5 +1,8 @@
 /*-
  * $Log: ldap-checkpwd.c,v $
+ * Revision 1.12  2021-08-29 23:27:08+05:30  Cprogrammer
+ * define funtions as noreturn
+ *
  * Revision 1.11  2021-05-29 23:44:46+05:30  Cprogrammer
  * replace str_chr with str_rchr to get domain correctly from email address
  *
@@ -45,16 +48,16 @@
 #include <string.h>
 #include <ldap.h>
 #include <sys/types.h>
-#include "error.h"
-#include "pathexec.h"
-#include "str.h"
-#include "env.h"
-#include "scan.h"
-/*----*/
-#include "subfd.h"
-#include "substdio.h"
-#include "strerr.h"
-#include "stralloc.h"
+#include <error.h>
+#include <pathexec.h>
+#include <str.h>
+#include <env.h>
+#include <scan.h>
+#include <subfd.h>
+#include <substdio.h>
+#include <strerr.h>
+#include <stralloc.h>
+#include <noreturn.h>
 
 /*-
  * Customise these or set these as environment variables
@@ -126,7 +129,7 @@ logerrf(char *s)
 
 static int      debug;
 
-void
+no_return void
 my_error(char *s1, char *s2, int exit_val)
 {
 	logerr(s1);
@@ -572,7 +575,7 @@ main(argc, argv)
 void
 getversion_ldap_checkpwd_c()
 {
-	static char    *x = "$Id: ldap-checkpwd.c,v 1.11 2021-05-29 23:44:46+05:30 Cprogrammer Exp mbhangui $";
+	static char    *x = "$Id: ldap-checkpwd.c,v 1.12 2021-08-29 23:27:08+05:30 Cprogrammer Exp mbhangui $";
 
 	x++;
 }

--- a/indimail-mta-x/maildir.h
+++ b/indimail-mta-x/maildir.h
@@ -1,5 +1,8 @@
 /*
  * $Log: maildir.h,v $
+ * Revision 1.4  2021-08-29 23:27:08+05:30  Cprogrammer
+ * define funtions as noreturn
+ *
  * Revision 1.3  2004-10-11 13:55:06+05:30  Cprogrammer
  * added function prototypes
  *
@@ -9,7 +12,7 @@
  */
 #ifndef MAILDIR_H
 #define MAILDIR_H
-#include "strerr.h"
+#include <strerr.h>
 #include "prioq.h"
 
 extern struct strerr maildir_chdir_err;

--- a/indimail-mta-x/maildir2mbox.c
+++ b/indimail-mta-x/maildir2mbox.c
@@ -1,5 +1,8 @@
 /*
  * $Log: maildir2mbox.c,v $
+ * Revision 1.9  2021-08-29 23:27:08+05:30  Cprogrammer
+ * define funtions as noreturn
+ *
  * Revision 1.8  2021-06-03 18:12:04+05:30  Cprogrammer
  * use new prioq functions
  *
@@ -19,37 +22,38 @@
 #include <sys/types.h>
 #include <unistd.h>
 #include <sys/stat.h>
-#include "prioq.h"
-#include "env.h"
-#include "stralloc.h"
-#include "subfd.h"
-#include "substdio.h"
-#include "getln.h"
-#include "error.h"
-#include "open.h"
-#include "lock.h"
-#include "gfrom.h"
-#include "str.h"
-#include "qtime.h"
+#include <env.h>
+#include <stralloc.h>
+#include <subfd.h>
+#include <substdio.h>
+#include <getln.h>
+#include <error.h>
+#include <open.h>
+#include <lock.h>
+#include <str.h>
+#include <qtime.h>
+#include <strerr.h>
+#include <noreturn.h>
 #include "maildir.h"
+#include "prioq.h"
+#include "gfrom.h"
+
+#define FATAL   "maildir2mbox: fatal: "
+#define WARNING "maildir2mbox: warning: "
 
 int             rename(const char *, const char *);
 
-char           *mbox;
-char           *mboxtmp;
+static char    *mbox;
+static char    *mboxtmp;
+static char     inbuf[SUBSTDIO_INSIZE];
+static char     outbuf[SUBSTDIO_OUTSIZE];
+static stralloc filenames = { 0 };
+static stralloc line = { 0 };
+static stralloc ufline = { 0 };
+static prioq    pq = { 0 };
+static prioq    pq2 = { 0 };
 
-stralloc        filenames = { 0 };
-prioq           pq = { 0 };
-prioq           pq2 = { 0 };
-stralloc        line = { 0 };
-stralloc        ufline = { 0 };
-char            inbuf[SUBSTDIO_INSIZE];
-char            outbuf[SUBSTDIO_OUTSIZE];
-
-#define FATAL "maildir2mbox: fatal: "
-#define WARNING "maildir2mbox: warning: "
-
-void
+no_return void
 die_nomem()
 {
 	strerr_die2x(111, FATAL, "out of memory");
@@ -170,7 +174,7 @@ main()
 void
 getversion_maildir2mbox_c()
 {
-	static char    *x = "$Id: maildir2mbox.c,v 1.8 2021-06-03 18:12:04+05:30 Cprogrammer Exp mbhangui $";
+	static char    *x = "$Id: maildir2mbox.c,v 1.9 2021-08-29 23:27:08+05:30 Cprogrammer Exp mbhangui $";
 
 	x = sccsidmyctimeh;
 	x++;

--- a/indimail-mta-x/matchup.c
+++ b/indimail-mta-x/matchup.c
@@ -1,5 +1,8 @@
 /*
  * $Log: matchup.c,v $
+ * Revision 1.11  2021-08-29 23:27:08+05:30  Cprogrammer
+ * define funtions as noreturn
+ *
  * Revision 1.10  2020-11-24 13:46:11+05:30  Cprogrammer
  * removed exit.h
  *
@@ -32,40 +35,41 @@
  *
  */
 #include <unistd.h>
-#include "stralloc.h"
-#include "gen_alloc.h"
-#include "gen_allocdefs.h"
-#include "alloc.h"
-#include "strerr.h"
-#include "getln.h"
-#include "substdio.h"
-#include "subfd.h"
-#include "str.h"
-#include "fmt.h"
-#include "scan.h"
-#include "case.h"
+#include <stralloc.h>
+#include <gen_alloc.h>
+#include <gen_allocdefs.h>
+#include <alloc.h>
+#include <strerr.h>
+#include <getln.h>
+#include <substdio.h>
+#include <subfd.h>
+#include <str.h>
+#include <fmt.h>
+#include <scan.h>
+#include <case.h>
+#include <noreturn.h>
 
 #define FATAL "matchup: fatal: "
 
-void
+no_return void
 nomem()
 {
 	strerr_die2x(111, FATAL, "out of memory");
 }
 
-void
+no_return void
 die_read()
 {
 	strerr_die2sys(111, FATAL, "unable to read input: ");
 }
 
-void
+no_return void
 die_write()
 {
 	strerr_die2sys(111, FATAL, "unable to write output: ");
 }
 
-void
+no_return void
 die_write5()
 {
 	strerr_die2sys(111, FATAL, "unable to write fd 5: ");
@@ -759,7 +763,7 @@ main()
 void
 getversion_matchup_c()
 {
-	static char    *x = "$Id: matchup.c,v 1.10 2020-11-24 13:46:11+05:30 Cprogrammer Exp mbhangui $";
+	static char    *x = "$Id: matchup.c,v 1.11 2021-08-29 23:27:08+05:30 Cprogrammer Exp mbhangui $";
 
 	x++;
 }

--- a/indimail-mta-x/mlmatchup.c
+++ b/indimail-mta-x/mlmatchup.c
@@ -1,5 +1,8 @@
 /*
  * $Log: mlmatchup.c,v $
+ * Revision 1.5  2021-08-29 23:27:08+05:30  Cprogrammer
+ * define funtions as noreturn
+ *
  * Revision 1.4  2020-11-24 13:46:14+05:30  Cprogrammer
  * removed exit.h
  *
@@ -13,41 +16,42 @@
  * Initial revision
  *
  */
-#include "stralloc.h"
-#include "gen_alloc.h"
-#include "gen_allocdefs.h"
-#include "alloc.h"
-#include "strerr.h"
-#include "getln.h"
-#include "substdio.h"
-#include "subfd.h"
-#include "str.h"
-#include "fmt.h"
-#include "scan.h"
-#include "case.h"
 #include <unistd.h>
+#include <stralloc.h>
+#include <gen_alloc.h>
+#include <gen_allocdefs.h>
+#include <alloc.h>
+#include <strerr.h>
+#include <getln.h>
+#include <substdio.h>
+#include <subfd.h>
+#include <str.h>
+#include <fmt.h>
+#include <scan.h>
+#include <case.h>
+#include <noreturn.h>
 
 #define FATAL "matchup: fatal: "
 
-void
+no_return void
 nomem()
 {
 	strerr_die2x(111, FATAL, "out of memory");
 }
 
-void
+no_return void
 die_read()
 {
 	strerr_die2sys(111, FATAL, "unable to read input: ");
 }
 
-void
+no_return void
 die_write()
 {
 	strerr_die2sys(111, FATAL, "unable to write output: ");
 }
 
-void
+no_return void
 die_write5()
 {
 	strerr_die2sys(111, FATAL, "unable to write fd 5: ");
@@ -728,7 +732,7 @@ main()
 void
 getversion_mlmatchup_c()
 {
-	static char    *x = "$Id: mlmatchup.c,v 1.4 2020-11-24 13:46:14+05:30 Cprogrammer Exp mbhangui $";
+	static char    *x = "$Id: mlmatchup.c,v 1.5 2021-08-29 23:27:08+05:30 Cprogrammer Exp mbhangui $";
 
 	x++;
 }

--- a/indimail-mta-x/newinclude.c
+++ b/indimail-mta-x/newinclude.c
@@ -1,5 +1,8 @@
 /*
  * $Log: newinclude.c,v $
+ * Revision 1.6  2021-08-29 23:27:08+05:30  Cprogrammer
+ * define funtions as noreturn
+ *
  * Revision 1.5  2021-06-15 11:42:10+05:30  Cprogrammer
  * moved token822.h to libqmail
  *
@@ -26,6 +29,7 @@
 #include <byte.h>
 #include <token822.h>
 #include <env.h>
+#include <noreturn.h>
 #include "control.h"
 #include "variables.h"
 
@@ -33,45 +37,45 @@
 
 int             rename(const char *, const char *);
 
-char           *fnlist;
-substdio        sslist;
-char            listbuf[1024];
-stralloc        bin = { 0 };
-stralloc        tmp = { 0 };
 #define fnbin bin.s
 #define fntmp tmp.s
-substdio        sstmp;
-char            tmpbuf[1024];
-stralloc        cbuf = { 0 };
-token822_alloc  toks = { 0 };
-token822_alloc  tokaddr = { 0 };
-stralloc        address = { 0 };
-stralloc        me = { 0 };
-stralloc        defaulthost = { 0 };
-stralloc        defaultdomain = { 0 };
-stralloc        plusdomain = { 0 };
-stralloc        line = { 0 };
-int             match;
+static char    *fnlist;
+static char     listbuf[1024];
+static char     tmpbuf[1024];
+static int      match;
+static stralloc bin = { 0 };
+static stralloc tmp = { 0 };
+static stralloc cbuf = { 0 };
+static stralloc address = { 0 };
+static stralloc me = { 0 };
+static stralloc defaulthost = { 0 };
+static stralloc defaultdomain = { 0 };
+static stralloc plusdomain = { 0 };
+static stralloc line = { 0 };
+static substdio sslist;
+static substdio sstmp;
+static token822_alloc  toks = { 0 };
+static token822_alloc  tokaddr = { 0 };
 
-void
+no_return void
 nomem()
 {
 	strerr_die2x(111, FATAL, "out of memory");
 }
 
-void
+no_return void
 usage()
 {
 	strerr_die1x(100, "newinclude: usage: newinclude list");
 }
 
-void
+no_return void
 readerr()
 {
 	strerr_die4sys(111, FATAL, "unable to read ", fnlist, ": ");
 }
 
-void
+no_return void
 writeerr()
 {
 	strerr_die4sys(111, FATAL, "unable to write to ", fntmp, ": ");
@@ -87,9 +91,7 @@ out(s, len)
 }
 
 void
-doincl(buf, len)
-	char           *buf;
-	int             len;
+doincl(char *buf, int len)
 {
 	if (!len)
 		strerr_die2x(111, FATAL, "empty :include: filenames not permitted");
@@ -104,9 +106,7 @@ doincl(buf, len)
 }
 
 void
-dorecip(buf, len)
-	char           *buf;
-	int             len;
+dorecip(char *buf, int len)
 {
 	if (!len)
 		strerr_die2x(111, FATAL, "empty recipient addresses not permitted");
@@ -123,7 +123,7 @@ dorecip(buf, len)
 	out("", 1);
 }
 
-void
+no_return void
 die_control()
 {
 	strerr_die2sys(111, FATAL, "unable to read controls: ");
@@ -226,7 +226,7 @@ gotaddr()
 	dorecip(address.s, address.len);
 }
 
-void
+no_return void
 parseerr()
 {
 	if (!stralloc_0(&line))
@@ -317,9 +317,7 @@ parseline()
 }
 
 int
-main(argc, argv)
-	int             argc;
-	char          **argv;
+main(int argc, char **argv)
 {
 	int             fd;
 
@@ -364,7 +362,7 @@ main(argc, argv)
 void
 getversion_newinclude_c()
 {
-	static char    *x = "$Id: newinclude.c,v 1.5 2021-06-15 11:42:10+05:30 Cprogrammer Exp mbhangui $";
+	static char    *x = "$Id: newinclude.c,v 1.6 2021-08-29 23:27:08+05:30 Cprogrammer Exp mbhangui $";
 
 	x++;
 }

--- a/indimail-mta-x/ofmipname.c
+++ b/indimail-mta-x/ofmipname.c
@@ -1,5 +1,8 @@
 /*
  * $Log: ofmipname.c,v $
+ * Revision 1.6  2021-08-29 23:27:08+05:30  Cprogrammer
+ * define funtions as noreturn
+ *
  * Revision 1.5  2021-06-15 11:42:52+05:30  Cprogrammer
  * moved cdbmss.h to libqmail
  *
@@ -27,49 +30,45 @@
 #include <subfd.h>
 #include <stralloc.h>
 #include <getln.h>
+#include <noreturn.h>
 
 #define FATAL "ofmipname: fatal: "
 
-char           *fncdb;
-char           *fntmp;
 int             rename(char *, char *);
 
-void
+static char    *fncdb;
+static char    *fntmp;
+static stralloc line = { 0 };
+static stralloc key = { 0 };
+static stralloc data = { 0 };
+static struct cdbmss   cdbmss;
+
+no_return void
 nomem()
 {
 	strerr_die2x(111, FATAL, "out of memory");
 }
 
-void
+no_return void
 die_read()
 {
 	strerr_die2sys(111, FATAL, "unable to read input: ");
 }
 
-void
+no_return void
 die_write()
 {
 	strerr_die4sys(111, FATAL, "unable to create ", fntmp, ": ");
 }
 
-void
+no_return void
 usage()
 {
 	strerr_die1x(100, "ofmipname: usage: ofmipname cdb tmp");
 }
 
-struct cdbmss   cdbmss;
-
-stralloc        line = { 0 };
-int             match;
-
-stralloc        key = { 0 };
-stralloc        data = { 0 };
-
 void
-doit(x, len)
-	char           *x;
-	unsigned int    len;
+doit(char *x, unsigned int len)
 {
 	unsigned int    colon;
 
@@ -112,29 +111,21 @@ doit(x, len)
 }
 
 int
-main(argc, argv)
-	int             argc;
-	char          **argv;
+main(int argc, char **argv)
 {
-	int             fd;
+	int             fd, match;
 
 	umask(033);
 
-	fncdb = argv[1];
-	if (!fncdb)
+	if (!(fncdb = argv[1]))
 		usage();
-	fntmp = argv[2];
-	if (!fntmp)
+	if (!(fntmp = argv[2]))
 		usage();
-
-	fd = open_trunc(fntmp);
-	if (fd == -1)
+	if ((fd = open_trunc(fntmp)) == -1)
 		die_write();
 	if (cdbmss_start(&cdbmss, fd) == -1)
 		die_write();
-
-	for (;;)
-	{
+	for (;;) {
 		if (getln(subfdin, &line, &match, '\n') == -1)
 			die_read();
 		doit(line.s, line.len);
@@ -147,10 +138,8 @@ main(argc, argv)
 	if (fsync(fd) == -1)
 		die_write();
 	if (close(fd) == -1)
-		die_write();			/*
-								 * NFS stupidity 
-								 */
-	if (rename(fntmp, fncdb) == -1)
+		die_write();		
+	if (rename(fntmp, fncdb) == -1) /*- NFS stupidity */
 		strerr_die5sys(111, FATAL, "unable to move ", fntmp, " to ", fncdb);
 	_exit(0);
 }
@@ -158,7 +147,7 @@ main(argc, argv)
 void
 getversion_ofmipname_c()
 {
-	static char    *x = "$Id: ofmipname.c,v 1.5 2021-06-15 11:42:52+05:30 Cprogrammer Exp mbhangui $";
+	static char    *x = "$Id: ofmipname.c,v 1.6 2021-08-29 23:27:08+05:30 Cprogrammer Exp mbhangui $";
 
 	x++;
 }

--- a/indimail-mta-x/parsedate.c
+++ b/indimail-mta-x/parsedate.c
@@ -1,5 +1,8 @@
 /*
  * $Log: parsedate.c,v $
+ * Revision 1.6  2021-08-29 23:27:08+05:30  Cprogrammer
+ * define funtions as noreturn
+ *
  * Revision 1.5  2021-06-13 17:28:51+05:30  Cprogrammer
  * removed chdir(auto_sysconfdir)
  *
@@ -17,40 +20,38 @@
  *
  */
 #include <unistd.h>
-#include "substdio.h"
-#include "strerr.h"
-#include "subfd.h"
-#include "getln.h"
-#include "mess822.h"
-#include "leapsecs.h"
-#include "caltime.h"
-#include "tai.h"
+#include <substdio.h>
+#include <strerr.h>
+#include <subfd.h>
+#include <getln.h>
+#include <mess822.h>
+#include <leapsecs.h>
+#include <caltime.h>
+#include <tai.h>
+#include <noreturn.h>
 #include "auto_sysconfdir.h"
 
 #define FATAL "parsedate: fatal: "
 
-void
+no_return void
 nomem()
 {
 	strerr_die2x(111, FATAL, "out of memory");
 }
 
-stralloc        line = { 0 };
-int             match;
-
-mess822_time    t;
-struct tai      sec;
 
 int
 main()
 {
-	int             i;
+	int             i, match;
+	struct tai      sec;
+	stralloc        line = { 0 };
+	mess822_time    t;
 
 	if (leapsecs_init() == -1)
 		strerr_die2sys(111, FATAL, "unable to init leapsecs: ");
 
-	for (;;)
-	{
+	for (;;) {
 		if (getln(subfdinsmall, &line, &match, '\n') == -1)
 			strerr_die2sys(111, FATAL, "unable to read input: ");
 		if (!line.len)
@@ -68,8 +69,7 @@ main()
 		if (!mess822_when(&t, line.s))
 			nomem();
 
-		if (t.known)
-		{
+		if (t.known) {
 			if (!stralloc_ready(&line, caltime_fmt((char *) 0, &t.ct)))
 				nomem();
 			substdio_put(subfdoutsmall, line.s, caltime_fmt(line.s, &t.ct));
@@ -97,7 +97,7 @@ main()
 void
 getversion_parsedate_c()
 {
-	static char    *x = "$Id: parsedate.c,v 1.5 2021-06-13 17:28:51+05:30 Cprogrammer Exp mbhangui $";
+	static char    *x = "$Id: parsedate.c,v 1.6 2021-08-29 23:27:08+05:30 Cprogrammer Exp mbhangui $";
 
 	x++;
 }

--- a/indimail-mta-x/plugtest.c
+++ b/indimail-mta-x/plugtest.c
@@ -1,5 +1,8 @@
 /*
  * $Log: plugtest.c,v $
+ * Revision 1.7  2021-08-29 23:27:08+05:30  Cprogrammer
+ * define funtions as noreturn
+ *
  * Revision 1.6  2021-05-26 10:43:34+05:30  Cprogrammer
  * handle access() error other than ENOENT
  *
@@ -21,25 +24,26 @@
  */
 #include <unistd.h>
 #include <dlfcn.h>
-#include "sgetopt.h"
-#include "alloc.h"
-#include "str.h"
-#include "error.h"
-#include "strerr.h"
-#include "env.h"
-#include "stralloc.h"
-#include "fmt.h"
+#include <sgetopt.h>
+#include <alloc.h>
+#include <str.h>
+#include <error.h>
+#include <strerr.h>
+#include <env.h>
+#include <stralloc.h>
+#include <fmt.h>
+#include <subfd.h>
+#include <noreturn.h>
 #include "auto_qmail.h"
 #include "auto_prefix.h"
-#include "subfd.h"
 #include "smtp_plugin.h"
 
 #define FATAL "plugtest: fatal: "
 
-int              authenticated;
-char            *relayclient;
-PLUGIN         **plug = (PLUGIN **) 0;
-void           **handle;
+static int       authenticated;
+static char     *relayclient;
+static PLUGIN  **plug = (PLUGIN **) 0;
+static void    **handle;
 
 void
 out(char *str)
@@ -59,7 +63,7 @@ flush()
 	return;
 }
 
-void
+no_return void
 die_nomem()
 {
 	substdio_flush(subfdout);
@@ -68,7 +72,7 @@ die_nomem()
 	_exit(1);
 }
 
-void
+no_return void
 die_plugin(char *arg1, char *arg2, char *arg3, char *arg4)
 {
 	substdio_flush(subfdout);
@@ -381,7 +385,7 @@ main(int argc, char **argv)
 void
 getversion_plugtest_c()
 {
-	static char    *x = "$Id: plugtest.c,v 1.6 2021-05-26 10:43:34+05:30 Cprogrammer Exp mbhangui $";
+	static char    *x = "$Id: plugtest.c,v 1.7 2021-08-29 23:27:08+05:30 Cprogrammer Exp mbhangui $";
 
 	x++;
 }

--- a/indimail-mta-x/preline.c
+++ b/indimail-mta-x/preline.c
@@ -1,5 +1,8 @@
 /*
  * $Log: preline.c,v $
+ * Revision 1.10  2021-08-29 23:27:08+05:30  Cprogrammer
+ * define funtions as noreturn
+ *
  * Revision 1.9  2020-11-24 13:46:31+05:30  Cprogrammer
  * removed exit.h
  *
@@ -18,40 +21,37 @@
  *
  */
 #include <unistd.h>
-#include "fd.h"
-#include "sgetopt.h"
-#include "strerr.h"
-#include "substdio.h"
-#include "wait.h"
-#include "env.h"
-#include "sig.h"
-#include "error.h"
+#include <fd.h>
+#include <sgetopt.h>
+#include <strerr.h>
+#include <substdio.h>
+#include <wait.h>
+#include <env.h>
+#include <sig.h>
+#include <error.h>
+#include <noreturn.h>
 
 #define FATAL "preline: fatal: "
 
-void
+no_return void
 die_usage()
 {
 	strerr_die1x(100, "preline: usage: preline cmd [ arg ... ]");
 }
 
-int             flagufline = 1, flagrpline = 1, flagdtline = 1, flagqqeh = 1;
-char           *ufline, *rpline, *dtline, *qqeh;
-
-char            outbuf[SUBSTDIO_OUTSIZE];
-char            inbuf[SUBSTDIO_INSIZE];
-substdio        ssout = SUBSTDIO_FDBUF(write, 1, outbuf, sizeof outbuf);
-substdio        ssin = SUBSTDIO_FDBUF(read, 0, inbuf, sizeof inbuf);
 
 int
 main(argc, argv)
 	int             argc;
 	char          **argv;
 {
-	int             opt;
 	int             pi[2];
-	int             pid;
-	int             wstat;
+	int             flagufline = 1, flagrpline = 1, flagdtline = 1,
+					flagqqeh = 1, opt, pid, wstat;
+	char           *ufline, *rpline, *dtline, *qqeh;
+	char            outbuf[SUBSTDIO_OUTSIZE], inbuf[SUBSTDIO_INSIZE];
+	substdio        ssout = SUBSTDIO_FDBUF(write, 1, outbuf, sizeof outbuf);
+	substdio        ssin = SUBSTDIO_FDBUF(read, 0, inbuf, sizeof inbuf);
 
 	sig_pipeignore();
 
@@ -61,8 +61,7 @@ main(argc, argv)
 		die_usage();
 	if (!(dtline = env_get("DTLINE")))
 		die_usage();
-	while ((opt = getopt(argc, argv, "frde")) != opteof)
-	{
+	while ((opt = getopt(argc, argv, "frde")) != opteof) {
 		switch (opt)
 		{
 		case 'f':
@@ -90,8 +89,7 @@ main(argc, argv)
 	pid = fork();
 	if (pid == -1)
 		strerr_die2sys(111, FATAL, "unable to fork: ");
-	if (pid == 0)
-	{
+	if (pid == 0) {
 		close(pi[1]);
 		if (fd_move(0, pi[0]) == -1)
 			strerr_die2sys(111, FATAL, "unable to set up fds: ");
@@ -128,7 +126,7 @@ main(argc, argv)
 void
 getversion_preline_c()
 {
-	static char    *x = "$Id: preline.c,v 1.9 2020-11-24 13:46:31+05:30 Cprogrammer Exp mbhangui $";
+	static char    *x = "$Id: preline.c,v 1.10 2021-08-29 23:27:08+05:30 Cprogrammer Exp mbhangui $";
 
 	x++;
 }

--- a/indimail-mta-x/printforward.c
+++ b/indimail-mta-x/printforward.c
@@ -1,5 +1,8 @@
 /*
  * $Log: printforward.c,v $
+ * Revision 1.4  2021-08-29 23:27:08+05:30  Cprogrammer
+ * define funtions as noreturn
+ *
  * Revision 1.3  2005-08-23 17:33:32+05:30  Cprogrammer
  * gcc 4 compliance
  *
@@ -11,29 +14,29 @@
  *
  */
 #include <unistd.h>
-#include "substdio.h"
-#include "subfd.h"
-#include "strerr.h"
-#include "stralloc.h"
-#include "cdb.h"
+#include <substdio.h>
+#include <subfd.h>
+#include <strerr.h>
+#include <stralloc.h>
+#include <cdb.h>
+#include <noreturn.h>
 
 #define FATAL "printmaillist: fatal: "
 
-void
+no_return void
 badformat()
 {
 	strerr_die2x(100, FATAL, "bad database format");
 }
 
-void
+no_return void
 nomem()
 {
 	strerr_die2x(111, FATAL, "out of memory");
 }
 
 void
-getch(ch)
-	char           *ch;
+getch(char *ch)
 {
 	int             r;
 
@@ -44,30 +47,25 @@ getch(ch)
 }
 
 void
-putch(ch)
-	char           *ch;
+putch(char *ch)
 {
 	if (substdio_put(subfdoutsmall, ch, 1) == -1)
 		strerr_die2x(111, FATAL, "unable to write output: ");
 }
 
 void
-print(buf)
-	char           *buf;
+print(char *buf)
 {
 	while (*buf)
 		putch(buf++);
 }
 
 void
-printsafe(buf, len)
-	char           *buf;
-	int             len;
+printsafe(char *buf, int len)
 {
 	char            ch;
 
-	while (len)
-	{
+	while (len) {
 		ch = *buf;
 		if ((ch <= 32) || (ch == ',') || (ch == ':') || (ch == ';') || (ch == '\\') || (ch == '#'))
 			putch("\\");
@@ -76,9 +74,6 @@ printsafe(buf, len)
 		--len;
 	}
 }
-
-stralloc        key = { 0 };
-stralloc        data = { 0 };
 
 int
 main()
@@ -91,6 +86,8 @@ main()
 	char            ch;
 	int             i;
 	int             j;
+	stralloc        key = { 0 };
+	stralloc        data = { 0 };
 
 	for (i = 0; i < 4; ++i)
 		getch(buf + i);
@@ -98,8 +95,7 @@ main()
 	for (i = 4; i < 2048; ++i)
 		getch(&ch);
 	pos = 2048;
-	while (pos < eod)
-	{
+	while (pos < eod) {
 		if (eod - pos < 8)
 			badformat();
 		pos += 8;
@@ -112,8 +108,7 @@ main()
 		if (eod - pos < klen)
 			badformat();
 		pos += klen;
-		while (klen)
-		{
+		while (klen) {
 			--klen;
 			getch(&ch);
 			if (!stralloc_append(&key, &ch))
@@ -124,8 +119,7 @@ main()
 		pos += dlen;
 		if (!stralloc_copys(&data, ""))
 			nomem();
-		while (dlen)
-		{
+		while (dlen) {
 			--dlen;
 			getch(&ch);
 			if (!stralloc_append(&data, &ch))
@@ -133,37 +127,30 @@ main()
 		}
 		if (!key.len)
 			badformat();
-		if (key.s[0] == '?')
-		{
+		if (key.s[0] == '?') {
 			printsafe(key.s + 1, key.len - 1);
 			print(": ?");
 			printsafe(data.s, data.len);
 			print(";\n");
 		} else
-		if (key.s[0] == ':')
-		{
+		if (key.s[0] == ':') {
 			printsafe(key.s + 1, key.len - 1);
 			print(":\n");
 
 			i = 0;
-			for (j = 0; j < data.len; ++j)
-			{
-				if (!data.s[j])
-				{
-					if ((data.s[i] == '.') || (data.s[i] == '/'))
-					{
+			for (j = 0; j < data.len; ++j) {
+				if (!data.s[j]) {
+					if ((data.s[i] == '.') || (data.s[i] == '/')) {
 						print(", ");
 						printsafe(data.s + i, j - i);
 						print("\n");
 					} else
-					if ((data.s[i] == '|') || (data.s[i] == '!'))
-					{
+					if ((data.s[i] == '|') || (data.s[i] == '!')) {
 						print(", ");
 						printsafe(data.s + i, j - i);
 						print("\n");
 					} else
-					if ((data.s[i] == '&') && (j - i < 900))
-					{
+					if ((data.s[i] == '&') && (j - i < 900)) {
 						print(", ");
 						printsafe(data.s + i, j - i);
 						print("\n");
@@ -188,7 +175,7 @@ main()
 void
 getversion_printforward_c()
 {
-	static char    *x = "$Id: printforward.c,v 1.3 2005-08-23 17:33:32+05:30 Cprogrammer Stab mbhangui $";
+	static char    *x = "$Id: printforward.c,v 1.4 2021-08-29 23:27:08+05:30 Cprogrammer Exp mbhangui $";
 
 	x++;
 }

--- a/indimail-mta-x/printmaillist.c
+++ b/indimail-mta-x/printmaillist.c
@@ -1,5 +1,8 @@
 /*
  * $Log: printmaillist.c,v $
+ * Revision 1.3  2021-08-29 23:27:08+05:30  Cprogrammer
+ * define funtions as noreturn
+ *
  * Revision 1.2  2004-10-22 20:28:01+05:30  Cprogrammer
  * added RCS id
  *
@@ -8,33 +11,31 @@
  *
  */
 #include <unistd.h>
-#include "substdio.h"
-#include "subfd.h"
-#include "str.h"
-#include "strerr.h"
-#include "stralloc.h"
-#include "getln.h"
+#include <substdio.h>
+#include <subfd.h>
+#include <str.h>
+#include <strerr.h>
+#include <stralloc.h>
+#include <getln.h>
+#include <noreturn.h>
 
 #define FATAL "printmaillist: fatal: "
 
-void
+no_return void
 badformat()
 {
 	strerr_die2x(100, FATAL, "bad mailing list format");
 }
 
-stralloc        line = { 0 };
-int             match;
-
 int
 main()
 {
-	for (;;)
-	{
+	stralloc        line = { 0 };
+	int             match;
+	for (;;) {
 		if (getln(subfdinsmall, &line, &match, '\0') == -1)
 			strerr_die2sys(111, FATAL, "unable to read input: ");
-		if (!match)
-		{
+		if (!match) {
 			if (line.len)
 				badformat();
 			if (substdio_flush(subfdoutsmall) == -1)
@@ -47,16 +48,14 @@ main()
 			badformat();
 		if (line.s[line.len - 1] == '\t')
 			badformat();
-		if ((line.s[0] == '.') || (line.s[0] == '/'))
-		{
+		if ((line.s[0] == '.') || (line.s[0] == '/')) {
 			if (substdio_puts(subfdoutsmall, line.s) == -1)
 				strerr_die2sys(111, FATAL, "unable to write output: ");
 			if (substdio_puts(subfdoutsmall, "\n") == -1)
 				strerr_die2sys(111, FATAL, "unable to write output: ");
 			continue;
 		}
-		if (line.s[0] == '&')
-		{
+		if (line.s[0] == '&') {
 			if (line.len > 900)
 				badformat();
 			if (substdio_puts(subfdoutsmall, line.s) == -1)
@@ -73,7 +72,7 @@ main()
 void
 getversion_printmaillist_c()
 {
-	static char    *x = "$Id: printmaillist.c,v 1.2 2004-10-22 20:28:01+05:30 Cprogrammer Stab mbhangui $";
+	static char    *x = "$Id: printmaillist.c,v 1.3 2021-08-29 23:27:08+05:30 Cprogrammer Exp mbhangui $";
 
 	x++;
 }

--- a/indimail-mta-x/qaes.c
+++ b/indimail-mta-x/qaes.c
@@ -7,6 +7,9 @@
  * Saju Pillai (saju.pillai@gmail.com)
  *
  * $Log: qaes.c,v $
+ * Revision 1.6  2021-08-29 23:27:08+05:30  Cprogrammer
+ * define funtions as noreturn
+ *
  * Revision 1.5  2017-08-08 23:56:21+05:30  Cprogrammer
  * openssl 1.1.0 port
  *
@@ -27,15 +30,17 @@
 #include <unistd.h>
 #include <stdlib.h>
 #include <openssl/evp.h>
-#include "substdio.h"
-#include "fmt.h"
-#include "str.h"
-#include "stralloc.h"
-#include "base64.h"
-#include "getln.h"
-#include "scan.h"
-#include "sgetopt.h"
-#include "error.h"
+#include <substdio.h>
+#include <fmt.h>
+#include <str.h>
+#include <stralloc.h>
+#include <base64.h>
+#include <getln.h>
+#include <scan.h>
+#include <sgetopt.h>
+#include <error.h>
+#include <strerr.h>
+#include <noreturn.h>
 
 #define READ_ERR  1
 #define WRITE_ERR 2
@@ -44,13 +49,13 @@
 #define AES_BLOCK_SIZE 512
 
 static char     ssinbuf[1024];
-static substdio ssin = SUBSTDIO_FDBUF(read, 0, ssinbuf, sizeof ssinbuf);
 static char     ssoutbuf[512];
-static substdio ssout = SUBSTDIO_FDBUF(write, 1, ssoutbuf, sizeof ssoutbuf);
 static char     sserrbuf[512];
+static char    *usage = "usage: qaes -k key [ -i -d -e -s salt ]\n";
+static char     strnum[FMT_ULONG];
+static substdio ssin = SUBSTDIO_FDBUF(read, 0, ssinbuf, sizeof ssinbuf);
+static substdio ssout = SUBSTDIO_FDBUF(write, 1, ssoutbuf, sizeof ssoutbuf);
 static substdio sserr = SUBSTDIO_FDBUF(write, 2, sserrbuf, sizeof(sserrbuf));
-char           *usage = "usage: qaes -k key [ -i -d -e -s salt ]\n";
-char            strnum[FMT_ULONG];
 
 void
 logerr(char *s)
@@ -68,7 +73,7 @@ logerrf(char *s)
 		_exit(1);
 }
 
-void
+no_return void
 my_error(char *s1, char *s2, int exit_val)
 {
 	logerr(s1);
@@ -203,7 +208,8 @@ main(int argc, char **argv)
 #endif
 
 	while ((opt = getopt(argc, argv, "k:s:ide")) != opteof) {
-		switch (opt) {
+		switch (opt)
+		{
 		case 'k':
 			/*
 			 * 8 bytes to salt the key_data during key generation. This is an example of
@@ -229,11 +235,13 @@ main(int argc, char **argv)
 		case 'i':
 			ignore_newline = 1;
 			break;
+		default:
+			strerr_die1x(100, usage);
 		}
 	}
 	if (!key_data) {
 		logerrf("encryption key not specified\n");
-		_exit(111);
+		strerr_die1x(100, usage);
 	}
 	/*
 	 * gen key and iv. init the cipher ctx object 
@@ -335,7 +343,7 @@ main(int argc, char **argv)
 void
 getversion_qaes_c()
 {
-	static char    *x = "$Id: qaes.c,v 1.5 2017-08-08 23:56:21+05:30 Cprogrammer Exp mbhangui $";
+	static char    *x = "$Id: qaes.c,v 1.6 2021-08-29 23:27:08+05:30 Cprogrammer Exp mbhangui $";
 
 	x++;
 }

--- a/indimail-mta-x/qarf.c
+++ b/indimail-mta-x/qarf.c
@@ -1,5 +1,8 @@
 /*
  * $Log: qarf.c,v $
+ * Revision 1.13  2021-08-29 23:27:08+05:30  Cprogrammer
+ * define funtions as noreturn
+ *
  * Revision 1.12  2021-05-29 23:47:37+05:30  Cprogrammer
  * replace str_chr with str_rchr to get domain correctly from email address
  *
@@ -40,18 +43,19 @@
 #include <unistd.h>
 #include <fcntl.h>
 #include <sys/types.h>
-#include "stralloc.h"
-#include "str.h"
-#include "getln.h"
-#include "substdio.h"
-#include "datetime.h"
-#include "date822fmt.h"
-#include "mess822.h"
-#include "now.h"
-#include "env.h"
-#include "fmt.h"
-#include "error.h"
-#include "sgetopt.h"
+#include <stralloc.h>
+#include <str.h>
+#include <getln.h>
+#include <substdio.h>
+#include <datetime.h>
+#include <date822fmt.h>
+#include <mess822.h>
+#include <now.h>
+#include <env.h>
+#include <fmt.h>
+#include <error.h>
+#include <sgetopt.h>
+#include <noreturn.h>
 
 #define READ_ERR  1
 #define WRITE_ERR 2
@@ -61,12 +65,12 @@
 #define LSEEK_ERR 6
 #define USAGE_ERR 7
 
-char            strnum[FMT_ULONG];
 static char     ssoutbuf[512];
-static substdio ssout = SUBSTDIO_FDBUF(write, 1, ssoutbuf, sizeof ssoutbuf);
 static char     sserrbuf[512];
+static char     strnum[FMT_ULONG];
+static char    *usage = "usage: qarf [-i] -t recipient -s subject -f sender [-m filename]\n";
+static substdio ssout = SUBSTDIO_FDBUF(write, 1, ssoutbuf, sizeof ssoutbuf);
 static substdio sserr = SUBSTDIO_FDBUF(write, 2, sserrbuf, sizeof(sserrbuf));
-char           *usage = "usage: qarf [-i] -t recipient -s subject -f sender [-m filename]\n";
 
 void
 logerr(char *s)
@@ -84,7 +88,7 @@ logerrf(char *s)
 		_exit(1);
 }
 
-void
+no_return void
 my_error(char *s1, char *s2, int exit_val)
 {
 	logerr(s1);
@@ -412,7 +416,7 @@ main(int argc, char **argv)
 	my_putb("\"; ", 3);
 	my_puts(
 			"report-type=\"feedback-report\"\n"
-			"X-Mailer: qarf $Revision: 1.12 $\n");
+			"X-Mailer: qarf $Revision: 1.13 $\n");
 
 	/*- Body */
 	my_puts("\nThis is a multi-part message in MIME format\n\n");
@@ -456,7 +460,7 @@ main(int argc, char **argv)
 
 	my_puts(
 			"Feedback-Type: abuse\n"
-			"User-Agent: $Id: qarf.c,v 1.12 2021-05-29 23:47:37+05:30 Cprogrammer Exp mbhangui $\n"
+			"User-Agent: $Id: qarf.c,v 1.13 2021-08-29 23:27:08+05:30 Cprogrammer Exp mbhangui $\n"
 			"Version: 0.1\n");
 	if (email_from.len) {
 		my_putb("Original-Mail-From: ", 20);
@@ -516,7 +520,7 @@ main(int argc, char **argv)
 void
 getversion_qarf_c()
 {
-	static char    *x = "$Id: qarf.c,v 1.12 2021-05-29 23:47:37+05:30 Cprogrammer Exp mbhangui $";
+	static char    *x = "$Id: qarf.c,v 1.13 2021-08-29 23:27:08+05:30 Cprogrammer Exp mbhangui $";
 
 	x++;
 }

--- a/indimail-mta-x/qbase64.c
+++ b/indimail-mta-x/qbase64.c
@@ -1,5 +1,8 @@
 /*
  * $Log: qbase64.c,v $
+ * Revision 1.8  2021-08-29 23:27:08+05:30  Cprogrammer
+ * define funtions as noreturn
+ *
  * Revision 1.7  2010-03-03 11:00:41+05:30  Cprogrammer
  * remove newline
  *
@@ -14,17 +17,18 @@
  *
  */
 #include <unistd.h>
-#include "stralloc.h"
-#include "base64.h"
-#include "getln.h"
-#include "sgetopt.h"
-#include "error.h"
+#include <stralloc.h>
+#include <base64.h>
+#include <getln.h>
+#include <sgetopt.h>
+#include <error.h>
+#include <noreturn.h>
 
 static char     ssinbuf[1024];
-static substdio ssin = SUBSTDIO_FDBUF(read, 0, ssinbuf, sizeof ssinbuf);
 static char     ssoutbuf[512];
-static substdio ssout = SUBSTDIO_FDBUF(write, 1, ssoutbuf, sizeof ssoutbuf);
 static char     sserrbuf[512];
+static substdio ssin = SUBSTDIO_FDBUF(read, 0, ssinbuf, sizeof ssinbuf);
+static substdio ssout = SUBSTDIO_FDBUF(write, 1, ssoutbuf, sizeof ssoutbuf);
 static substdio sserr = SUBSTDIO_FDBUF(write, 2, sserrbuf, sizeof(sserrbuf));
 
 void
@@ -43,13 +47,12 @@ logerrf(char *s)
 		_exit(1);
 }
 
-void
+no_return void
 my_error(char *s1, char *s2, int exit_val)
 {
 	logerr(s1);
 	logerr(": ");
-	if (s2)
-	{
+	if (s2) {
 		logerr(s2);
 		logerr(": ");
 	}
@@ -99,7 +102,7 @@ main(int argc, char **argv)
 void
 getversion_qbase64_c()
 {
-	static char    *x = "$Id: qbase64.c,v 1.7 2010-03-03 11:00:41+05:30 Cprogrammer Stab mbhangui $";
+	static char    *x = "$Id: qbase64.c,v 1.8 2021-08-29 23:27:08+05:30 Cprogrammer Exp mbhangui $";
 
 	x++;
 }

--- a/indimail-mta-x/qhpsi.c
+++ b/indimail-mta-x/qhpsi.c
@@ -1,5 +1,8 @@
 /*
  * $Log: qhpsi.c,v $
+ * Revision 1.10  2021-08-29 23:27:08+05:30  Cprogrammer
+ * define funtions as noreturn
+ *
  * Revision 1.9  2021-06-27 10:37:09+05:30  Cprogrammer
  * uidnit new argument to disable/enable error on missing uids
  *
@@ -30,16 +33,17 @@
  */
 #include <unistd.h>
 #include <dlfcn.h>
-#include "strerr.h"
-#include "env.h"
-#include "str.h"
-#include "stralloc.h"
+#include <strerr.h>
+#include <env.h>
+#include <str.h>
+#include <stralloc.h>
+#include <noreturn.h>
 #include "auto_qmail.h"
 #include "auto_uids.h"
 
 #define FATAL "qhpsi: fatal: "
 
-void
+no_return void
 nomem(int flaglog)
 {
 	if (flaglog)
@@ -136,6 +140,6 @@ main(int argc, char **argv)
 void
 getversion_qmail_qhpsi_c()
 {
-	static char    *x = "$Id: qhpsi.c,v 1.9 2021-06-27 10:37:09+05:30 Cprogrammer Exp mbhangui $";
+	static char    *x = "$Id: qhpsi.c,v 1.10 2021-08-29 23:27:08+05:30 Cprogrammer Exp mbhangui $";
 	x++;
 }

--- a/indimail-mta-x/qmail-cat.c
+++ b/indimail-mta-x/qmail-cat.c
@@ -1,5 +1,8 @@
 /*
  * $Log: qmail-cat.c,v $
+ * Revision 1.8  2021-08-29 23:27:08+05:30  Cprogrammer
+ * define funtions as noreturn
+ *
  * Revision 1.7  2009-10-03 15:02:59+05:30  Cprogrammer
  * process all arguments on command line
  * bug fix in my_error - 2nd arg never printed
@@ -27,16 +30,17 @@
 #include <fcntl.h>
 #include <sys/types.h>
 #include <sys/stat.h>
-#include "substdio.h"
-#include "stralloc.h"
-#include "getln.h"
-#include "error.h"
+#include <substdio.h>
+#include <stralloc.h>
+#include <getln.h>
+#include <error.h>
+#include <noreturn.h>
 
 static char     ssinbuf[1024];
-static substdio ssin = SUBSTDIO_FDBUF(read, 0, ssinbuf, sizeof ssinbuf);
 static char     ssoutbuf[512];
-static substdio ssout = SUBSTDIO_FDBUF(write, 1, ssoutbuf, sizeof ssoutbuf);
 static char     sserrbuf[512];
+static substdio ssin = SUBSTDIO_FDBUF(read, 0, ssinbuf, sizeof ssinbuf);
+static substdio ssout = SUBSTDIO_FDBUF(write, 1, ssoutbuf, sizeof ssoutbuf);
 static substdio sserr = SUBSTDIO_FDBUF(write, 2, sserrbuf, sizeof(sserrbuf));
 
 void
@@ -55,7 +59,7 @@ logerrf(char *s)
 		_exit(1);
 }
 
-void
+no_return void
 my_error(char *s1, char *s2, int exit_val)
 {
 	logerr(s1);
@@ -115,7 +119,7 @@ main(int argc, char **argv)
 void
 getversion_qmail_cat_c()
 {
-	static char    *x = "$Id: qmail-cat.c,v 1.7 2009-10-03 15:02:59+05:30 Cprogrammer Stab mbhangui $";
+	static char    *x = "$Id: qmail-cat.c,v 1.8 2021-08-29 23:27:08+05:30 Cprogrammer Exp mbhangui $";
 
 	x++;
 }

--- a/indimail-mta-x/qmail-daemon.c
+++ b/indimail-mta-x/qmail-daemon.c
@@ -1,5 +1,8 @@
 /*
  * $Log: qmail-daemon.c,v $
+ * Revision 1.24  2021-08-29 23:27:08+05:30  Cprogrammer
+ * define funtions as noreturn
+ *
  * Revision 1.23  2021-07-19 12:54:19+05:30  Cprogrammer
  * exit 0 if flagexitasap is set
  *
@@ -74,41 +77,41 @@
  *
  */
 #include <stdlib.h>
-#include <string.h>
-#include "substdio.h"
-#include "error.h"
-#include "control.h"
-#include "fmt.h"
-#include "env.h"
-#include "scan.h"
-#include "wait.h"
-#include "sig.h"
-#include "lock.h"
-#include "open.h"
-#include "stralloc.h"
-#include "alloc.h"
-#include "str.h"
-#include "auto_qmail.h"
 #include <signal.h>
 #include <unistd.h>
+#include <substdio.h>
+#include <error.h>
+#include <fmt.h>
+#include <env.h>
+#include <scan.h>
+#include <wait.h>
+#include <sig.h>
+#include <lock.h>
+#include <open.h>
+#include <stralloc.h>
+#include <alloc.h>
+#include <str.h>
+#include <noreturn.h>
+#include "control.h"
+#include "auto_qmail.h"
 
 #ifndef QUEUE_COUNT
 #define QUEUE_COUNT 10
 #endif
 
-char            ssoutbuf[512];
-substdio        ssout = SUBSTDIO_FDBUF(write, 1, ssoutbuf, sizeof(ssoutbuf));
-char            sserrbuf[512];
-substdio        sserr = SUBSTDIO_FDBUF(write, 2, sserrbuf, sizeof(sserrbuf));
-int             flagexitasap = 0;
-char            strnum[FMT_ULONG];
-char           *(qlargs[]) = { "sbin/qmail-start", "./Mailbox", 0};
+static char     ssoutbuf[512];
+static char     sserrbuf[512];
+static char     strnum[FMT_ULONG];
+static char    *(qlargs[]) = { "sbin/qmail-start", "./Mailbox", 0};
+static int      flagexitasap = 0;
+static substdio ssout = SUBSTDIO_FDBUF(write, 1, ssoutbuf, sizeof(ssoutbuf));
+static substdio sserr = SUBSTDIO_FDBUF(write, 2, sserrbuf, sizeof(sserrbuf));
 struct pidtab
 {
 	int pid;
 	char *queuedir;
 };
-struct pidtab  *pid_table;
+static struct pidtab  *pid_table;
 
 void
 sigterm()
@@ -180,7 +183,7 @@ sigint()
 	}
 }
 
-void
+no_return void
 die()
 {
 	sleep(5);
@@ -518,7 +521,7 @@ main(int argc, char **argv)
 void
 getversion_qmail_daemon_c()
 {
-	static char    *x = "$Id: qmail-daemon.c,v 1.23 2021-07-19 12:54:19+05:30 Cprogrammer Exp mbhangui $";
+	static char    *x = "$Id: qmail-daemon.c,v 1.24 2021-08-29 23:27:08+05:30 Cprogrammer Exp mbhangui $";
 
 	x++;
 }

--- a/indimail-mta-x/qmail-daned.c
+++ b/indimail-mta-x/qmail-daned.c
@@ -1,5 +1,8 @@
 /*
  * $Log: qmail-daned.c,v $
+ * Revision 1.28  2021-08-29 23:27:08+05:30  Cprogrammer
+ * define funtions as noreturn
+ *
  * Revision 1.27  2021-06-15 11:50:15+05:30  Cprogrammer
  * removed chdir(auto_qmail)
  *
@@ -113,6 +116,7 @@
 #include <sgetopt.h>
 #include <env.h>
 #include <makeargs.h>
+#include <noreturn.h>
 #include "control.h"
 #include "tlsacheck.h"
 #include "haveip6.h"
@@ -145,24 +149,23 @@ struct danerec
 	char            status; /*- dane verification status */
 	struct danerec *prev, *next; /*- prev, next of linked list of danerec structures */
 };
-struct danerec *head;
-struct danerec *tail;
-int             dane_count, hcount;
-int             hash_size, h_allocated = 0;
-int             verbose = 0;
-unsigned long   timeout;
+static struct danerec *head;
+static struct danerec *tail;
+static unsigned long   timeout;
+static struct constmap mapwhite;
+static struct constmap maptlsadomains;
+static int      dane_count, hcount;
+static int      hash_size, h_allocated = 0;
+static int      whitelistok = 0;
+static int      tlsadomainsok = 0;
+static char    *whitefn = 0, *tlsadomainsfn = 0;
+static stralloc context_file = { 0 };
+static stralloc line = { 0 };
+static stralloc whitelist = { 0 };
+static stralloc tlsadomains = { 0 };
 int             timeoutconnect = 60;
+int             verbose = 0;
 int             timeoutssl = 300;
-char           *whitefn = 0, *tlsadomainsfn = 0;
-stralloc        context_file = { 0 };
-stralloc        line = { 0 };
-
-int             whitelistok = 0;
-stralloc        whitelist = { 0 };
-struct constmap mapwhite;
-int             tlsadomainsok = 0;
-stralloc        tlsadomains = { 0 };
-struct constmap maptlsadomains;
 stralloc        helohost = { 0 };
 
 extern stralloc save;
@@ -609,7 +612,6 @@ save_context()
 	return;
 }
 
-stralloc        context = { 0 };
 /*-
  * load records on startup from a context file which
  * was saved on shutdown (SIGTERM)
@@ -765,7 +767,7 @@ sigusr2()
 	return;
 }
 
-void
+no_return void
 sigterm()
 {
 	sig_block(SIGTERM);
@@ -1360,7 +1362,7 @@ main()
 void
 getversion_qmail_dane_c()
 {
-	static char    *x = "$Id: qmail-daned.c,v 1.27 2021-06-15 11:50:15+05:30 Cprogrammer Exp mbhangui $";
+	static char    *x = "$Id: qmail-daned.c,v 1.28 2021-08-29 23:27:08+05:30 Cprogrammer Exp mbhangui $";
 
 	x = sccsidstarttlsh;
 	x = sccsidmakeargsh;

--- a/indimail-mta-x/qmail-direct.c
+++ b/indimail-mta-x/qmail-direct.c
@@ -1,5 +1,8 @@
 /*
  * $Log: qmail-direct.c,v $
+ * Revision 1.9  2021-08-29 23:27:08+05:30  Cprogrammer
+ * define funtions as noreturn
+ *
  * Revision 1.8  2021-07-05 21:23:10+05:30  Cprogrammer
  * use qgetpw interface from libqmail if USE_QPWGR is set
  *
@@ -46,6 +49,7 @@
 #include <now.h>
 #include <date822fmt.h>
 #include <qgetpwgr.h>
+#include <noreturn.h>
 #include "pidopen.h"
 
 #define DEATH 86400				/* 24 hours; _must_ be below q-s's OSSIFIED (36 hours) */
@@ -58,11 +62,13 @@ static struct substdio ssin, ssout;
 static datetime_sec starttime;
 static struct datetime dt;
 static unsigned long   mypid, myuid, messnum;
+static unsigned int    receivedlen;
 static struct stat pidst;
 static char    *messfn, *intdfn, *tmp_fn;
 static int      intdfd, mailfd, flagmademess = 0, flagmadeintd = 0;
+static char    *received;
 
-void
+no_return void
 die(int e)
 {
 	_exit(e);
@@ -78,39 +84,37 @@ cleanup()
 	}
 }
 
-void
+no_return void
 die_write()
 {
 	die(53);
 }
 
-void
+no_return void
 die_read()
 {
 	die(54);
 }
 
-void
+no_return void
 die_nomem()
 {
 	cleanup();
 	die(51);
 }
 
-void
+no_return void
 sigalrm()
 {								/* thou shalt not clean up here */
 	die(52);
 }
 
-void
+no_return void
 sigbug()
 {
 	die(81);
 }
 
-unsigned int    receivedlen;
-char           *received;
 /*
  * "Received: (qmail-queue invoked by alias); 26 Sep 1995 04:46:54 -0000\n" 
  */
@@ -479,7 +483,7 @@ main(int argc, char **argv)
 void
 getversion_qmail_direct_c()
 {
-	static char    *x = "$Id: qmail-direct.c,v 1.8 2021-07-05 21:23:10+05:30 Cprogrammer Exp mbhangui $";
+	static char    *x = "$Id: qmail-direct.c,v 1.9 2021-08-29 23:27:08+05:30 Cprogrammer Exp mbhangui $";
 
 	x = sccsidpidopenh;
 	if (x)

--- a/indimail-mta-x/qmail-dk.c
+++ b/indimail-mta-x/qmail-dk.c
@@ -1,5 +1,8 @@
 /*
  * $Log: qmail-dk.c,v $
+ * Revision 1.56  2021-08-29 23:27:08+05:30  Cprogrammer
+ * define funtions as noreturn
+ *
  * Revision 1.55  2021-08-28 23:13:58+05:30  Cprogrammer
  * control file dkimkeys for domain specific private key, selector
  *
@@ -191,6 +194,7 @@
 #include <scan.h>
 #include <mess822.h>
 #include <makeargs.h>
+#include <noreturn.h>
 #include "qmail.h"
 #include "control.h"
 #include "variables.h"
@@ -217,38 +221,36 @@ unsigned long   uid;
 int             readfd;
 char           *dksign = 0;
 char           *dkverify = 0;
-void            die(int) __attribute__((noreturn));
 
-void
-die(e)
-	int             e;
+no_return void
+die(int e)
 {
 	_exit(e);
 }
 
-void
+no_return void
 die_write()
 {
-	die(53);
+	_exit(53);
 }
 
-void
+no_return void
 die_read()
 {
-	die(54);
+	_exit(54);
 }
 
-void
+no_return void
 sigalrm()
 {
 	/*- thou shalt not clean up here */
-	die(52);
+	_exit(52);
 }
 
-void
+no_return void
 sigbug()
 {
-	die(81);
+	_exit(81);
 }
 
 void
@@ -820,7 +822,7 @@ main(argc, argv)
 void
 getversion_qmail_dk_c()
 {
-	static char    *x = "$Id: qmail-dk.c,v 1.55 2021-08-28 23:13:58+05:30 Cprogrammer Exp mbhangui $";
+	static char    *x = "$Id: qmail-dk.c,v 1.56 2021-08-29 23:27:08+05:30 Cprogrammer Exp mbhangui $";
 
 #ifdef DOMAIN_KEYS
 	x = sccsidmakeargsh;

--- a/indimail-mta-x/qmail-dkim.c
+++ b/indimail-mta-x/qmail-dkim.c
@@ -1,5 +1,8 @@
 /*
  * $Log: qmail-dkim.c,v $
+ * Revision 1.61  2021-08-29 23:27:08+05:30  Cprogrammer
+ * define funtions as noreturn
+ *
  * Revision 1.60  2021-08-28 23:16:06+05:30  Cprogrammer
  * control file dkimkeys for domain specific private key, selector
  *
@@ -208,6 +211,7 @@
 #include <error.h>
 #include <dkim.h>
 #include <makeargs.h>
+#include <noreturn.h>
 #include "control.h"
 #include "auto_control.h"
 #include "qmail.h"
@@ -234,9 +238,8 @@ struct datetime dt;
 unsigned long   uid;
 int             readfd;
 DKIMContext     ctxt;
-void            die(int, int) __attribute__((noreturn));
 
-void
+no_return void
 die(int e, int what)
 {
 	if (!what)
@@ -245,26 +248,26 @@ die(int e, int what)
 	_exit(e);
 }
 
-void
+no_return void
 die_write()
 {
 	die(53, 0);
 }
 
-void
+no_return void
 die_read()
 {
 	die(54, 0);
 }
 
-void
+no_return void
 sigalrm()
 {
 	/*- thou shalt not clean up here */
 	die(52, 0);
 }
 
-void
+no_return void
 sigbug()
 {
 	die(81, 0);
@@ -1391,7 +1394,7 @@ main(argc, argv)
 void
 getversion_qmail_dkim_c()
 {
-	static char    *x = "$Id: qmail-dkim.c,v 1.60 2021-08-28 23:16:06+05:30 Cprogrammer Exp mbhangui $";
+	static char    *x = "$Id: qmail-dkim.c,v 1.61 2021-08-29 23:27:08+05:30 Cprogrammer Exp mbhangui $";
 
 #ifdef HASDKIM
 	x = sccsidmakeargsh;

--- a/indimail-mta-x/qmail-greyd.c
+++ b/indimail-mta-x/qmail-greyd.c
@@ -1,5 +1,8 @@
 /*
  * $Log: qmail-greyd.c,v $
+ * Revision 1.32  2021-08-29 23:27:08+05:30  Cprogrammer
+ * define funtions as noreturn
+ *
  * Revision 1.31  2021-06-12 18:07:02+05:30  Cprogrammer
  * removed chdir(auto_qmail)
  *
@@ -110,27 +113,28 @@
 #include <netdb.h>
 #include <sys/select.h>
 #include "sgetopt.h"
+#include <sig.h>
+#include <getln.h>
+#include <fmt.h>
+#include <str.h>
+#include <subfd.h>
+#include <byte.h>
+#include <strerr.h>
+#include <scan.h>
+#include <env.h>
+#include <stralloc.h>
+#include <constmap.h>
+#include <error.h>
+#include <uint32.h>
+#include <open.h>
+#include <cdb.h>
+#include <noreturn.h>
+#include "ip.h"
 #ifdef NETQMAIL
 #include "auto_qmail.h"
 #endif
 #include "auto_control.h"
-#include "ip.h"
-#include "sig.h"
-#include "getln.h"
-#include "fmt.h"
-#include "str.h"
-#include "subfd.h"
-#include "byte.h"
-#include "strerr.h"
-#include "scan.h"
-#include "env.h"
-#include "stralloc.h"
-#include "constmap.h"
 #include "control.h"
-#include "error.h"
-#include "uint32.h"
-#include "open.h"
-#include "cdb.h"
 #include "tablematch.h"
 #ifndef NETQMAIL /*- netqmail does not have configurable control directory */
 #include "variables.h"
@@ -165,8 +169,6 @@ union sockunion
 #endif
 };
 
-int             verbose = 0;
-
 struct greylst
 {
 	union v46addr   ip;
@@ -180,13 +182,6 @@ struct greylst
 	struct greylst *prev, *next; /*- prev, next of linked list of greylst structures */
 	struct greylst *ip_prev, *ip_next; /*- group records for an ip address+rpath+rcpt together */
 };
-struct greylst *head;
-struct greylst *tail;
-int             grey_count, hcount;
-int             hash_size, h_allocated = 0;
-unsigned long   timeout;
-char           *whitefn = 0;
-stralloc        context_file = { 0 };
 
 struct netspec
 {
@@ -194,7 +189,16 @@ struct netspec
 	unsigned int    max;
 };
 
-void
+static struct greylst *head;
+static struct greylst *tail;
+static unsigned long   timeout;
+static int      verbose = 0;
+static int      grey_count, hcount;
+static int      hash_size, h_allocated = 0;
+static char    *whitefn = 0;
+static stralloc context_file = { 0 };
+
+no_return void
 die_nomem()
 {
 	substdio_flush(subfdout);
@@ -204,7 +208,7 @@ die_nomem()
 	_exit(1);
 }
 
-void
+no_return void
 die_control(char *arg)
 {
 	substdio_flush(subfdout);
@@ -1110,7 +1114,7 @@ sigusr2()
 	return;
 }
 
-void
+no_return void
 sigterm()
 {
 	sig_block(SIGTERM);
@@ -1559,7 +1563,7 @@ main(int argc, char **argv)
 void
 getversion_qmail_greyd_c()
 {
-	static char    *x = "$Id: qmail-greyd.c,v 1.31 2021-06-12 18:07:02+05:30 Cprogrammer Exp mbhangui $";
+	static char    *x = "$Id: qmail-greyd.c,v 1.32 2021-08-29 23:27:08+05:30 Cprogrammer Exp mbhangui $";
 
 	x++;
 }

--- a/indimail-mta-x/qmail-multi.c
+++ b/indimail-mta-x/qmail-multi.c
@@ -1,5 +1,8 @@
 /*
  * $Log: qmail-multi.c,v $
+ * Revision 1.2  2021-08-29 23:27:08+05:30  Cprogrammer
+ * define funtions as noreturn
+ *
  * Revision 1.1  2021-06-12 18:21:28+05:30  Cprogrammer
  * Initial revision
  *
@@ -7,19 +10,20 @@
 #include <unistd.h>
 #include <sig.h>
 #include <env.h>
+#include <noreturn.h>
 #include "qmulti.h"
 #include "mailfilter.h"
 
 #define DEATH 86400	/*- 24 hours; _must_ be below q-s's OSSIFIED (36 hours) */
 
-void
+no_return void
 sigalrm()
 {
 	/*- thou shalt not clean up here */
 	_exit(52);
 }
 
-void
+no_return void
 sigbug()
 {
 	_exit(81);
@@ -43,7 +47,7 @@ main(int argc, char **argv)
 void
 getversion_qmail_multi_c()
 {
-	static char    *x = "$Id: qmail-multi.c,v 1.1 2021-06-12 18:21:28+05:30 Cprogrammer Exp mbhangui $";
+	static char    *x = "$Id: qmail-multi.c,v 1.2 2021-08-29 23:27:08+05:30 Cprogrammer Exp mbhangui $";
 
 	x = sccsidqmultih;
 	x = sccsidmailfilterh;

--- a/indimail-mta-x/qmail-newu.c
+++ b/indimail-mta-x/qmail-newu.c
@@ -1,5 +1,8 @@
 /*
  * $Log: qmail-newu.c,v $
+ * Revision 1.12  2021-08-29 23:27:08+05:30  Cprogrammer
+ * define funtions as noreturn
+ *
  * Revision 1.11  2021-06-15 11:57:21+05:30  Cprogrammer
  * moved cdbmss.h to libqmail
  *
@@ -38,17 +41,18 @@
 #include <open.h>
 #include <error.h>
 #include <case.h>
+#include <noreturn.h>
 #include "auto_assign.h"
 
 int             rename(const char *, const char *);
 
-void
+no_return void
 die_temp()
 {
 	_exit(111);
 }
 
-void
+no_return void
 die_chdir(char *home)
 {
 	substdio_puts(subfderr, "qmail-newu: fatal: unable to chdir to ");
@@ -57,76 +61,64 @@ die_chdir(char *home)
 	die_temp();
 }
 
-void
+no_return void
 die_nomem()
 {
 	substdio_putsflush(subfderr, "qmail-newu: fatal: out of memory\n");
 	die_temp();
 }
 
-void
+no_return void
 die_opena()
 {
 	substdio_putsflush(subfderr, "qmail-newu: fatal: unable to open users/assign\n");
 	die_temp();
 }
 
-void
+no_return void
 die_reada()
 {
 	substdio_putsflush(subfderr, "qmail-newu: fatal: unable to read users/assign\n");
 	die_temp();
 }
 
-void
+no_return void
 die_format()
 {
 	substdio_putsflush(subfderr, "qmail-newu: fatal: bad format in users/assign\n");
 	die_temp();
 }
 
-void
+no_return void
 die_opent()
 {
 	substdio_putsflush(subfderr, "qmail-newu: fatal: unable to open users/cdb.tmp\n");
 	die_temp();
 }
 
-void
+no_return void
 die_writet()
 {
 	substdio_putsflush(subfderr, "qmail-newu: fatal: unable to write users/cdb.tmp\n");
 	die_temp();
 }
 
-void
+no_return void
 die_rename()
 {
 	substdio_putsflush(subfderr, "qmail-newu: fatal: unable to move users/cdb.tmp to users/cdb\n");
 	die_temp();
 }
 
-struct cdbmss   cdbmss;
-stralloc        key = { 0 };
-stralloc        data = { 0 };
-
-char            inbuf[1024];
-substdio        ssin;
-
-int             fd;
-int             fdtemp;
-
-stralloc        line = { 0 };
-int             match;
-
-stralloc        wildchars = { 0 };
-
 int
 main(int argc, char **argv)
 {
-	int             i;
-	int             numcolons;
+	int             i, numcolons, fd, fdtemp, match;
 	char           *assigndir;
+	struct cdbmss   cdbmss;
+	stralloc        key = { 0 }, data = { 0 }, line = { 0 }, wildchars = { 0 };
+	char            inbuf[1024];
+	substdio        ssin;
 
 	assigndir = (assigndir = env_get("ASSIGNDIR")) ? assigndir : auto_assign;
 	if (chdir(argc == 1 ? assigndir : argv[1]) == -1)
@@ -214,7 +206,7 @@ main(int argc, char **argv)
 void
 getversion_qmail_newu_c()
 {
-	static char    *x = "$Id: qmail-newu.c,v 1.11 2021-06-15 11:57:21+05:30 Cprogrammer Exp mbhangui $";
+	static char    *x = "$Id: qmail-newu.c,v 1.12 2021-08-29 23:27:08+05:30 Cprogrammer Exp mbhangui $";
 
 	x++;
 }

--- a/indimail-mta-x/qmail-nullqueue.c
+++ b/indimail-mta-x/qmail-nullqueue.c
@@ -1,5 +1,8 @@
 /*
  * $Log: qmail-nullqueue.c,v $
+ * Revision 1.5  2021-08-29 23:27:08+05:30  Cprogrammer
+ * define funtions as noreturn
+ *
  * Revision 1.4  2011-05-17 21:21:11+05:30  Cprogrammer
  * added timeout
  *
@@ -16,20 +19,21 @@
  * Send Mails to Trash
  */
 #include <unistd.h>
-#include "sig.h"
-#include "scan.h"
-#include "env.h"
+#include <sig.h>
+#include <scan.h>
+#include <env.h>
+#include <noreturn.h>
 
 #define DEATH 300	/*- 24 hours; _must_ be below q-s's OSSIFIED (36 hours) */
 
-void
+no_return void
 sigalrm()
 {
 	/*- thou shalt not clean up here */
 	_exit(52);
 }
 
-void
+no_return void
 sigbug()
 {
 	_exit(81);
@@ -71,7 +75,7 @@ main()
 void
 getversion_qmail_nullqueue_c()
 {
-	static char    *x = "$Id: qmail-nullqueue.c,v 1.4 2011-05-17 21:21:11+05:30 Cprogrammer Stab mbhangui $";
+	static char    *x = "$Id: qmail-nullqueue.c,v 1.5 2021-08-29 23:27:08+05:30 Cprogrammer Exp mbhangui $";
 
 	x++;
 }

--- a/indimail-mta-x/qmail-popbull.c
+++ b/indimail-mta-x/qmail-popbull.c
@@ -1,5 +1,8 @@
 /*
  * $Log: qmail-popbull.c,v $
+ * Revision 1.11  2021-08-29 23:27:08+05:30  Cprogrammer
+ * define funtions as noreturn
+ *
  * Revision 1.10  2021-05-26 10:44:34+05:30  Cprogrammer
  * replaced strerror() with error_str()
  *
@@ -25,67 +28,66 @@
 #include <sys/stat.h>
 #include <unistd.h>
 #include <string.h>
-#include "direntry.h"
-#include "substdio.h"
-#include "stralloc.h"
-#include "subfd.h"
-#include "open.h"
-#include "fmt.h"
-#include "error.h"
-#include "datetime.h"
-#include "now.h"
-#include "str.h"
+#include <direntry.h>
+#include <substdio.h>
+#include <stralloc.h>
+#include <subfd.h>
+#include <open.h>
+#include <fmt.h>
+#include <error.h>
+#include <datetime.h>
+#include <now.h>
+#include <str.h>
+#include <noreturn.h>
 
-void
+static char     fntmptph[80 + FMT_ULONG * 2];
+
+no_return void
 die()
 {
 	_exit(100);
 }
 
-void
+no_return void
 die_temp()
 {
 	_exit(111);
 }
 
-void
+no_return void
 die_usage()
 {
 	substdio_putsflush(subfderr, "qmail-popbull: usage: qmail-popbull bulldir pop3d maildir\n");
 	die_temp();
 }
 
-void
+no_return void
 die_nobulldir()
 {
 	substdio_putsflush(subfderr, "qmail-popbull: fatal: unable to read bulldir\n");
 	die_temp();
 }
 
-void
+no_return void
 die_nomaildir()
 {
 	substdio_putsflush(subfderr, "qmail-popbull: fatal: unable to write to maildir\n");
 	die_temp();
 }
 
-void
+no_return void
 die_nocdmaildir()
 {
 	substdio_putsflush(subfderr, "qmail-popbull: fatal: unable to change to maildir\n");
 	die_temp();
 }
 
-void
+no_return void
 die_nomem()
 {
 	substdio_putsflush(subfderr, "qmail-popbull: fatal: out of memory\n");
 	die_temp();
 }
-
-stralloc        fn = { 0 };
-stralloc        fn2 = { 0 };
-char            fntmptph[80 + FMT_ULONG * 2];
 
 void
 fnmake_maildir()
@@ -122,22 +124,17 @@ fnmake_maildir()
 	}
 }
 
-
 int
-main(argc, argv)
-	int             argc;
-	char          **argv;
+main(int argc, char **argv)
 {
 	int             fd;
 	struct stat     st;
 	datetime_sec    ts_date;
-	char           *bulldirname;
-	char           *programname;
-	char           *maildirname;
+	char           *bulldirname, *programname, *maildirname;
+	char          **childargs;
 	DIR            *bulldir;
 	direntry       *d;
-	char          **childargs;
-	stralloc        errorstr = { 0 };
+	stralloc        errorstr = { 0 }, fn = { 0 };
 
 	if (!(bulldirname = argv[1]))
 		die_usage();
@@ -199,7 +196,7 @@ main(argc, argv)
 void
 getversion_qmail_popbull_c()
 {
-	static char    *x = "$Id: qmail-popbull.c,v 1.10 2021-05-26 10:44:34+05:30 Cprogrammer Exp mbhangui $";
+	static char    *x = "$Id: qmail-popbull.c,v 1.11 2021-08-29 23:27:08+05:30 Cprogrammer Exp mbhangui $";
 
 	x++;
 }

--- a/indimail-mta-x/qmail-poppass.c
+++ b/indimail-mta-x/qmail-poppass.c
@@ -1,5 +1,8 @@
 /*
  * $Log: qmail-poppass.c,v $
+ * Revision 1.5  2021-08-29 23:27:08+05:30  Cprogrammer
+ * define funtions as noreturn
+ *
  * Revision 1.4  2021-06-15 12:14:05+05:30  Cprogrammer
  * use makeargs from libqmail
  *
@@ -46,32 +49,31 @@
 #include <getln.h>
 #include <error.h>
 #include <makeargs.h>
+#include <noreturn.h>
 #include "auto_uids.h"
 
 static char     ssinbuf[1024];
-static substdio ssin = SUBSTDIO_FDBUF(read, 0, ssinbuf, sizeof ssinbuf);
 static char     ssoutbuf[512];
-static substdio ssout = SUBSTDIO_FDBUF(write, 1, ssoutbuf, sizeof ssoutbuf);
 static char     sserrbuf[512];
-static substdio sserr = SUBSTDIO_FDBUF(write, 2, sserrbuf, sizeof(sserrbuf));
-stralloc        user = { 0 };
-stralloc        old_pass = { 0 };
-stralloc        new_pass = { 0 };
-char          **authargs, **passargs;
 static char     upbuf[128];
+static char   **authargs, **passargs;
+static substdio ssin = SUBSTDIO_FDBUF(read, 0, ssinbuf, sizeof ssinbuf);
+static substdio ssout = SUBSTDIO_FDBUF(write, 1, ssoutbuf, sizeof ssoutbuf);
+static substdio sserr = SUBSTDIO_FDBUF(write, 2, sserrbuf, sizeof(sserrbuf));
+static stralloc user = { 0 };
+static stralloc old_pass = { 0 };
+static stralloc new_pass = { 0 };
 static substdio ssup;
 
 void
-errlog(s)
-	char           *s;
+errlog(char *s)
 {
 	if (substdio_puts(&sserr, s) == -1)
 		_exit(111);
 }
 
 void
-errlogf(s)
-	char           *s;
+errlogf(char *s)
 {
 	if (substdio_puts(&sserr, s) == -1)
 		_exit(111);
@@ -80,8 +82,7 @@ errlogf(s)
 }
 
 void
-out(s)
-	char           *s;
+out(char *s)
 {
 	if (substdio_puts(&ssout, s) == -1)
 		_exit(111);
@@ -94,7 +95,7 @@ flush()
 		_exit(111);
 }
 
-void
+no_return void
 my_error(char *s1, int exit_val)
 {
 	if (substdio_puts(&sserr, s1))
@@ -355,7 +356,7 @@ main(int argc, char **argv)
 void
 getversion_qmail_poppass_c()
 {
-	static char    *x = "$Id: qmail-poppass.c,v 1.4 2021-06-15 12:14:05+05:30 Cprogrammer Exp mbhangui $";
+	static char    *x = "$Id: qmail-poppass.c,v 1.5 2021-08-29 23:27:08+05:30 Cprogrammer Exp mbhangui $";
 
 	x = sccsidmakeargsh;
 	x++;

--- a/indimail-mta-x/qmail-pw2u.c
+++ b/indimail-mta-x/qmail-pw2u.c
@@ -1,5 +1,8 @@
 /*
  * $Log: qmail-pw2u.c,v $
+ * Revision 1.10  2021-08-29 23:27:08+05:30  Cprogrammer
+ * define funtions as noreturn
+ *
  * Revision 1.9  2020-05-11 11:09:34+05:30  Cprogrammer
  * fixed shadowing of global variables by local variables
  *
@@ -28,59 +31,86 @@
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <unistd.h>
-#include "substdio.h"
-#include "byte.h"
-#include "subfd.h"
-#include "sgetopt.h"
+#include <substdio.h>
+#include <byte.h>
+#include <subfd.h>
+#include <sgetopt.h>
+#include <constmap.h>
+#include <stralloc.h>
+#include <fmt.h>
+#include <str.h>
+#include <scan.h>
+#include <open.h>
+#include <error.h>
+#include <getln.h>
+#include <noreturn.h>
 #include "control.h"
-#include "constmap.h"
-#include "stralloc.h"
-#include "fmt.h"
-#include "str.h"
-#include "scan.h"
-#include "open.h"
-#include "error.h"
-#include "getln.h"
 #include "auto_break.h"
 #include "auto_assign.h"
 #include "auto_usera.h"
 
-void
+static char    *dashcolon = "-:";
+static int      flagalias = 0;
+static int      flagnoupper = 1;
+static int      okincl;
+static int      okexcl;
+static int      okmana;
+/*- 2: skip if home does not exist; skip if home is not owned by user */
+/*- 1: stop if home does not exist; skip if home is not owned by user */
+/*- 0: don't worry about home */
+static int      homestrategy = 2;
+static stralloc incl = { 0 };
+static stralloc excl = { 0 };
+static stralloc mana = { 0 };
+static stralloc allusers = { 0 };
+static stralloc uugh = { 0 };
+static stralloc user = { 0 };
+static stralloc uidstr = { 0 };
+static stralloc gidstr = { 0 };
+static stralloc home = { 0 };
+static stralloc line = { 0 };
+static struct constmap mapincl;
+static struct constmap mapexcl;
+static struct constmap mapmana;
+static struct constmap mapuser;
+static unsigned long   uid;
+
+no_return void
 die_chdir()
 {
 	substdio_putsflush(subfderr, "qmail-pw2u: fatal: unable to chdir\n");
 	_exit(111);
 }
 
-void
+no_return void
 die_nomem()
 {
 	substdio_putsflush(subfderr, "qmail-pw2u: fatal: out of memory\n");
 	_exit(111);
 }
 
-void
+no_return void
 die_read()
 {
 	substdio_putsflush(subfderr, "qmail-pw2u: fatal: unable to read input\n");
 	_exit(111);
 }
 
-void
+no_return void
 die_write()
 {
 	substdio_putsflush(subfderr, "qmail-pw2u: fatal: unable to write output\n");
 	_exit(111);
 }
 
-void
+no_return void
 die_control()
 {
 	substdio_putsflush(subfderr, "qmail-pw2u: fatal: unable to read controls\n");
 	_exit(111);
 }
 
-void
+no_return void
 die_alias()
 {
 	substdio_puts(subfderr, "qmail-pw2u: fatal: unable to find ");
@@ -90,9 +120,8 @@ die_alias()
 	_exit(111);
 }
 
-void
-die_home(fn)
-	char           *fn;
+no_return void
+die_home(char *fn)
 {
 	substdio_puts(subfderr, "qmail-pw2u: fatal: unable to stat ");
 	substdio_puts(subfderr, fn);
@@ -101,10 +130,8 @@ die_home(fn)
 	_exit(111);
 }
 
-void
-die_user(s, len)
-	char           *s;
-	unsigned int    len;
+no_return void
+die_user(char *s, unsigned int len)
 {
 	substdio_puts(subfderr, "qmail-pw2u: fatal: unable to find ");
 	substdio_put(subfderr, s, len);
@@ -112,36 +139,6 @@ die_user(s, len)
 	substdio_flush(subfderr);
 	_exit(111);
 }
-
-char           *dashcolon = "-:";
-int             flagalias = 0;
-int             flagnoupper = 1;
-int             homestrategy = 2;
-/*- 2: skip if home does not exist; skip if home is not owned by user */
-/*- 1: stop if home does not exist; skip if home is not owned by user */
-/*- 0: don't worry about home */
-
-int             okincl;
-stralloc        incl = { 0 };
-struct constmap mapincl;
-int             okexcl;
-stralloc        excl = { 0 };
-struct constmap mapexcl;
-int             okmana;
-stralloc        mana = { 0 };
-struct constmap mapmana;
-
-stralloc        allusers = { 0 };
-struct constmap mapuser;
-
-stralloc        uugh = { 0 };
-stralloc        user = { 0 };
-stralloc        uidstr = { 0 };
-stralloc        gidstr = { 0 };
-stralloc        home = { 0 };
-unsigned long   uid;
-
-stralloc        line = { 0 };
 
 void
 doaccount()
@@ -514,7 +511,7 @@ main(argc, argv)
 void
 getversion_qmail_pw2u_c()
 {
-	static char    *x = "$Id: qmail-pw2u.c,v 1.9 2020-05-11 11:09:34+05:30 Cprogrammer Exp mbhangui $";
+	static char    *x = "$Id: qmail-pw2u.c,v 1.10 2021-08-29 23:27:08+05:30 Cprogrammer Exp mbhangui $";
 
 	x++;
 }

--- a/indimail-mta-x/qmail-qmqpd.c
+++ b/indimail-mta-x/qmail-qmqpd.c
@@ -1,5 +1,8 @@
 /*
  * $Log: qmail-qmqpd.c,v $
+ * Revision 1.10  2021-08-29 23:27:08+05:30  Cprogrammer
+ * define funtions as noreturn
+ *
  * Revision 1.9  2021-06-12 18:26:58+05:30  Cprogrammer
  * removed chdir(auto_qmail)
  *
@@ -20,54 +23,50 @@
  *
  */
 #include <unistd.h>
+#include <sig.h>
+#include <byte.h>
+#include <str.h>
+#include <substdio.h>
+#include <now.h>
+#include <fmt.h>
+#include <env.h>
+#include <noreturn.h>
 #include "qmail.h"
 #include "received.h"
-#include "sig.h"
-#include "byte.h"
-#include "str.h"
-#include "substdio.h"
-#include "now.h"
-#include "fmt.h"
-#include "env.h"
 
-void
+ssize_t         saferead(int fd, char *_buf, size_t len);
+ssize_t         safewrite(int fd, char *_buf, size_t len);
+
+static char     ssinbuf[512];
+static char     ssoutbuf[256];
+static substdio ssin = SUBSTDIO_FDBUF(saferead, 0, ssinbuf, sizeof ssinbuf);
+static substdio ssout = SUBSTDIO_FDBUF(safewrite, 1, ssoutbuf, sizeof ssoutbuf);
+static unsigned long   bytesleft = 100;
+
+no_return void
 resources()
 {
 	_exit(111);
 }
 
 ssize_t
-safewrite(fd, buf, len)
-	int             fd;
-	char           *buf;
-	int             len;
+safewrite(int fd, char *buf, size_t len)
 {
 	int             r;
-	r = write(fd, buf, len);
-	if (r <= 0)
+
+	if((r = write(fd, buf, len)) <= 0)
 		_exit(0);
 	return r;
 }
 
 ssize_t
-saferead(fd, buf, len)
-	int             fd;
-	char           *buf;
-	int             len;
+saferead(int fd, char *buf, size_t len)
 {
 	int             r;
-	r = read(fd, buf, len);
-	if (r <= 0)
+	if ((r = read(fd, buf, len)) <=0)
 		_exit(0);
 	return r;
 }
-
-char            ssinbuf[512];
-substdio        ssin = SUBSTDIO_FDBUF(saferead, 0, ssinbuf, sizeof ssinbuf);
-char            ssoutbuf[256];
-substdio        ssout = SUBSTDIO_FDBUF(safewrite, 1, ssoutbuf, sizeof ssoutbuf);
-
-unsigned long   bytesleft = 100;
 
 void
 getbyte(ch)
@@ -228,7 +227,7 @@ main()
 void
 getversion_qmail_qmqpd_c()
 {
-	static char    *x = "$Id: qmail-qmqpd.c,v 1.9 2021-06-12 18:26:58+05:30 Cprogrammer Exp mbhangui $";
+	static char    *x = "$Id: qmail-qmqpd.c,v 1.10 2021-08-29 23:27:08+05:30 Cprogrammer Exp mbhangui $";
 
 	x++;
 }

--- a/indimail-mta-x/qmail-rm.c
+++ b/indimail-mta-x/qmail-rm.c
@@ -1,5 +1,8 @@
 /*
  * $Log: qmail-rm.c,v $
+ * Revision 1.24  2021-08-29 23:27:08+05:30  Cprogrammer
+ * define funtions as noreturn
+ *
  * Revision 1.23  2021-05-29 23:50:55+05:30  Cprogrammer
  * fixed qbase path
  *
@@ -182,19 +185,22 @@
 #include <time.h>
 #include <unistd.h>
 #include <fts.h>
-#include "stralloc.h"
-#include "substdio.h"
-#include "lock.h"
-#include "error.h"
-#include "open.h"
-#include "fmt.h"
-#include "env.h"
-#include "scan.h"
+#include <stralloc.h>
+#include <substdio.h>
+#include <lock.h>
+#include <error.h>
+#include <open.h>
+#include <fmt.h>
+#include <env.h>
+#include <scan.h>
+#include <sgetopt.h>
+#include <noreturn.h>
 #include "control.h"
-#include "sgetopt.h"
 #include "auto_split.h"
 #include "getEnvConfig.h"
 #include "auto_qmail.h"
+
+const char      cvsrid[] = "$Id: qmail-rm.c,v 1.24 2021-08-29 23:27:08+05:30 Cprogrammer Exp mbhangui $";
 
 /*- many linux fcntl.h's seem to be broken */
 #ifndef O_NOFOLLOW
@@ -218,28 +224,28 @@ char           *mk_nohashpath(char *, int);
 char           *mk_hashpath(char *, int);
 char           *mk_newpath(char *, int);
 int             rename(const char *, const char *);
-
-const char      cvsrid[] = "$Id: qmail-rm.c,v 1.23 2021-05-29 23:50:55+05:30 Cprogrammer Exp mbhangui $";
+char           *strptime(const char *s, const char *format, struct tm *tm);
 
 /*- globals */
 extern const char *__progname;
-const char     *default_pattern = ".*";
-int             regex_flags = 0, verbosity = 0, conf_split, remove_files = 0, delete_files = 0;
-char           *yank_dir = "trash";
-unsigned long   read_bytes = 0;
+static const char     *default_pattern = ".*";
+static unsigned long   read_bytes = 0;
+static int      regex_flags = 0, verbosity = 0, conf_split, remove_files = 0, delete_files = 0;
+static char    *yank_dir = "trash";
 
-char           *strptime(const char *s, const char *format, struct tm *tm);
 /*- if the eXpire option is specified on the command line, this will reflect that */
-int             expire_files = 0;
+static int      expire_files = 0;
 /*- one week in seconds -- this can be changed in the future by a parameter passed to us */
-time_t          expire_offset = 60 * 60 * 24 * 7;
+static time_t   expire_offset = 60 * 60 * 24 * 7;
 /*- if specified, this is the timestamp the file will be stamped with */
-time_t          expire_date = 0;
-char            sserrbuf[512];
-char            ssoutbuf[512];
-substdio        ssout = SUBSTDIO_FDBUF(write, 1, ssoutbuf, sizeof(ssoutbuf));
-substdio        sserr = SUBSTDIO_FDBUF(write, 2, sserrbuf, sizeof(sserrbuf));
-char            strnum[FMT_ULONG];
+static time_t   expire_date = 0;
+static char     sserrbuf[512];
+static char     ssoutbuf[512];
+static char     strnum[FMT_ULONG];
+static substdio ssout = SUBSTDIO_FDBUF(write, 1, ssoutbuf, sizeof(ssoutbuf));
+static substdio sserr = SUBSTDIO_FDBUF(write, 2, sserrbuf, sizeof(sserrbuf));
+static stralloc QueueBase = { 0 };
+static stralloc Queuedir = { 0 };
 
 /*
  * queues i
@@ -247,7 +253,7 @@ char            strnum[FMT_ULONG];
  * NOTE: the first queue must be mess as it is used as a key
  *
  */
-const char     *queues[] = { "mess", "local", "remote", "info", "intd", "todo", "bounce", NULL };
+static const char     *queues[] = { "mess", "local", "remote", "info", "intd", "todo", "bounce", NULL };
 
 void
 flush()
@@ -256,23 +262,20 @@ flush()
 }
 
 void
-out(s)
-	char           *s;
+out(char *s)
 {
 	substdio_puts(&ssout, s);
 }
 
 void
-logerr(s)
-	char           *s;
+logerr(char *s)
 {
 	if (substdio_puts(&sserr, s) == -1)
 		_exit(1);
 }
 
 void
-logerrf(s)
-	char           *s;
+logerrf(char *s)
 {
 	if (substdio_puts(&sserr, s) == -1)
 		_exit(1);
@@ -280,14 +283,14 @@ logerrf(s)
 		_exit(1);
 }
 
-void
+no_return void
 die_nomem()
 {
 	substdio_puts(&sserr, "fatal: out of memory\n");
 	_exit(111);
 }
 
-void
+no_return void
 die_chdir(char *dir)
 {
 	logerr("chdir: ");
@@ -351,9 +354,6 @@ check_send(char *queuedir)
 	}
 	return(fd);
 }
-
-stralloc        QueueBase = { 0 };
-stralloc        Queuedir = { 0 };
 
 int
 main(int argc, char **argv)
@@ -570,7 +570,7 @@ main(int argc, char **argv)
 }
 
 
-void
+no_return void
 usage(void)
 {
 	logerr((char *) __progname);
@@ -1208,7 +1208,7 @@ digits(unsigned long num)
 void
 getversion_qmail_rm_c()
 {
-	static char    *x = "$Id: qmail-rm.c,v 1.23 2021-05-29 23:50:55+05:30 Cprogrammer Exp mbhangui $";
+	static char    *x = "$Id: qmail-rm.c,v 1.24 2021-08-29 23:27:08+05:30 Cprogrammer Exp mbhangui $";
 
 	x++;
 }

--- a/indimail-mta-x/qmail-showctl.c
+++ b/indimail-mta-x/qmail-showctl.c
@@ -1,5 +1,8 @@
 /*
  * $Log: qmail-showctl.c,v $
+ * Revision 1.3  2021-08-29 23:27:08+05:30  Cprogrammer
+ * define funtions as noreturn
+ *
  * Revision 1.2  2021-07-05 21:28:04+05:30  Cprogrammer
  * allow processing $HOME/.defaultqueue for root
  *
@@ -28,6 +31,7 @@
 #include <error.h>
 #include <strerr.h>
 #include <qprintf.h>
+#include <noreturn.h>
 #include "control.h"
 #include "auto_uids.h"
 #include "auto_qmail.h"
@@ -49,13 +53,13 @@
 #define FATAL "qmail-showctl: fatal: "
 #define WARN  "qmail-showctl: warn: "
 
-stralloc        me = { 0 };
-stralloc        line = { 0 };
-stralloc        libfn = { 0 };
-int             meok, conf_split;
-char            num[FMT_ULONG];
+static stralloc me = { 0 };
+static stralloc line = { 0 };
+static stralloc libfn = { 0 };
+static int      meok, conf_split;
+static char     num[FMT_ULONG];
 
-void
+no_return void
 die_nomem()
 {
 	substdio_puts(subfderr, "Out of memory\n");
@@ -178,7 +182,7 @@ print_concurrency()
 	}
 }
 
-void
+no_return void
 die_chdir(char *dir)
 {
 	substdio_puts(subfdout, "Oops! Unable to chdir to ");
@@ -826,7 +830,7 @@ main(int argc, char **argv)
 void
 getversion_qmail_showctl_c()
 {
-	static char    *x = "$Id: qmail-showctl.c,v 1.2 2021-07-05 21:28:04+05:30 Cprogrammer Exp mbhangui $";
+	static char    *x = "$Id: qmail-showctl.c,v 1.3 2021-08-29 23:27:08+05:30 Cprogrammer Exp mbhangui $";
 
 	if (x)
 		x++;

--- a/indimail-mta-x/qmail-spamfilter.c
+++ b/indimail-mta-x/qmail-spamfilter.c
@@ -1,5 +1,8 @@
 /*
  * $Log: qmail-spamfilter.c,v $
+ * Revision 1.2  2021-08-29 23:27:08+05:30  Cprogrammer
+ * define funtions as noreturn
+ *
  * Revision 1.1  2021-06-15 12:16:52+05:30  Cprogrammer
  * Initial revision
  *
@@ -17,18 +20,19 @@
 #include "auto_qmail.h"
 #include <makeargs.h>
 #include <mktempfile.h>
+#include <noreturn.h>
 #include "qmulti.h"
 
 #define DEATH 86400	/*- 24 hours; _must_ be below q-s's OSSIFIED (36 hours) */
 
-void
+no_return void
 sigalrm()
 {
 	/*- thou shalt not clean up here */
 	_exit(52);
 }
 
-void
+no_return void
 sigbug()
 {
 	_exit(81);
@@ -219,7 +223,7 @@ finish:
 void
 getversion_qmail_spamfilter_c()
 {
-	static char    *x = "$Id: qmail-spamfilter.c,v 1.1 2021-06-15 12:16:52+05:30 Cprogrammer Exp mbhangui $";
+	static char    *x = "$Id: qmail-spamfilter.c,v 1.2 2021-08-29 23:27:08+05:30 Cprogrammer Exp mbhangui $";
 
 	x = sccsidqmultih;
 	x = sccsidmakeargsh;

--- a/indimail-mta-x/qmail-start.c
+++ b/indimail-mta-x/qmail-start.c
@@ -1,5 +1,8 @@
 /*
  * $Log: qmail-start.c,v $
+ * Revision 1.23  2021-08-29 23:27:08+05:30  Cprogrammer
+ * define funtions as noreturn
+ *
  * Revision 1.22  2021-06-27 10:40:10+05:30  Cprogrammer
  * uidnit new argument to disable/enable error on missing uids
  *
@@ -52,22 +55,23 @@
 #include <fcntl.h>
 #include <grp.h>
 #include <str.h>
-#include "fd.h"
-#include "env.h"
-#include "alloc.h"
-#include "prot.h"
+#include <fd.h>
+#include <env.h>
+#include <alloc.h>
+#include <prot.h>
+#include <noreturn.h>
 #include "auto_uids.h"
 #include "setuserid.h"
 
-char           *(qsargs[]) = { "qmail-send", 0};
-char           *(qcargs[]) = { "qmail-clean", 0};
-char           *(qlargs[]) = { "qmail-lspawn", "./Mailbox", 0};
-char           *(qrargs[]) = { "qmail-rspawn", 0};
+static char    *(qsargs[]) = { "qmail-send", 0};
+static char    *(qcargs[]) = { "qmail-clean", 0};
+static char    *(qlargs[]) = { "qmail-lspawn", "./Mailbox", 0};
+static char    *(qrargs[]) = { "qmail-rspawn", 0};
 #ifdef EXTERNAL_TODO
-char           *(qtargs[]) = { "qmail-todo", 0};
+static char    *(qtargs[]) = { "qmail-todo", 0};
 #endif
 
-void
+no_return void
 die()
 {
 	_exit(111);
@@ -404,7 +408,7 @@ main(argc, argv)
 void
 getversion_qmail_start_c()
 {
-	static char    *x = "$Id: qmail-start.c,v 1.22 2021-06-27 10:40:10+05:30 Cprogrammer Exp mbhangui $";
+	static char    *x = "$Id: qmail-start.c,v 1.23 2021-08-29 23:27:08+05:30 Cprogrammer Exp mbhangui $";
 
 	x++;
 }

--- a/indimail-mta-x/qmaildirwatch.c
+++ b/indimail-mta-x/qmaildirwatch.c
@@ -1,5 +1,8 @@
 /*
  * $Log: qmaildirwatch.c,v $
+ * Revision 1.9  2021-08-29 23:27:08+05:30  Cprogrammer
+ * define funtions as noreturn
+ *
  * Revision 1.8  2021-06-03 18:15:46+05:30  Cprogrammer
  * use new prioq functions
  *
@@ -17,29 +20,31 @@
  *
  */
 #include <unistd.h>
-#include "getln.h"
-#include "substdio.h"
-#include "subfd.h"
+#include <getln.h>
+#include <substdio.h>
+#include <subfd.h>
+#include <stralloc.h>
+#include <str.h>
+#include <open.h>
+#include <strerr.h>
+#include <noreturn.h>
 #include "prioq.h"
-#include "stralloc.h"
-#include "str.h"
 #include "hfield.h"
-#include "open.h"
 #include "headerbody.h"
 #include "maildir.h"
 
 #define FATAL "qmaildirwatch: fatal: "
 
-void
+static stralloc recipient = { 0 };
+static stralloc sender = { 0 };
+static stralloc fromline = { 0 };
+static stralloc text = { 0 };
+
+no_return void
 die_nomem()
 {
 	strerr_die2x(111, FATAL, "out of memory");
 }
-
-stralloc        recipient = { 0 };
-stralloc        sender = { 0 };
-stralloc        fromline = { 0 };
-stralloc        text = { 0 };
 
 void
 addtext(char *s, int n)
@@ -161,7 +166,7 @@ main()
 void
 getversion_qmaildirwatch_c()
 {
-	static char    *x = "$Id: qmaildirwatch.c,v 1.8 2021-06-03 18:15:46+05:30 Cprogrammer Exp mbhangui $";
+	static char    *x = "$Id: qmaildirwatch.c,v 1.9 2021-08-29 23:27:08+05:30 Cprogrammer Exp mbhangui $";
 
 	x++;
 }

--- a/indimail-mta-x/qmulti.c
+++ b/indimail-mta-x/qmulti.c
@@ -1,5 +1,8 @@
 /*
  * $Log: qmulti.c,v $
+ * Revision 1.56  2021-08-29 23:27:08+05:30  Cprogrammer
+ * define funtions as noreturn
+ *
  * Revision 1.55  2021-06-12 18:52:06+05:30  Cprogrammer
  * added chdir(auto_qmail) for qmail-queue
  *
@@ -167,6 +170,7 @@
 #include <fmt.h>
 #include <scan.h>
 #include <error.h>
+#include <noreturn.h>
 #ifdef sun
 #include <sys/types.h>
 #include <sys/statvfs.h>
@@ -210,7 +214,7 @@ getfreespace(char *filesystem)
 	return (0);
 }
 
-int
+no_return int
 qmulti(char *queue_env, int argc, char **argv)
 {
 	datetime_sec    queueNo;
@@ -276,8 +280,6 @@ qmulti(char *queue_env, int argc, char **argv)
 		qqargs[0] = "sbin/qmail-queue";
 	execv(*qqargs, argv);
 	_exit(120);
-	/*- Not reached */
-	return (0);
 }
 
 int
@@ -342,7 +344,7 @@ rewrite_envelope(int outfd)
 void
 getversion_qmulti_c()
 {
-	static char    *x = "$Id: qmulti.c,v 1.55 2021-06-12 18:52:06+05:30 Cprogrammer Exp mbhangui $";
+	static char    *x = "$Id: qmulti.c,v 1.56 2021-08-29 23:27:08+05:30 Cprogrammer Exp mbhangui $";
 
 	x = sccsidqmultih;
 	x++;

--- a/indimail-mta-x/qnotify.c
+++ b/indimail-mta-x/qnotify.c
@@ -1,5 +1,8 @@
 /*
  * $Log: qnotify.c,v $
+ * Revision 1.12  2021-08-29 23:27:08+05:30  Cprogrammer
+ * define funtions as noreturn
+ *
  * Revision 1.11  2021-07-05 21:11:27+05:30  Cprogrammer
  * skip $HOME/.defaultqueue for root
  *
@@ -38,21 +41,22 @@
 #include <fcntl.h>
 #include <sys/types.h>
 #include "stralloc.h"
+#include <case.h>
+#include <str.h>
+#include <getln.h>
+#include <substdio.h>
+#include <datetime.h>
+#include <date822fmt.h>
+#include <mess822.h>
+#include <now.h>
+#include <env.h>
+#include <fmt.h>
+#include <error.h>
+#include <envdir.h>
+#include <pathexec.h>
+#include <strerr.h>
+#include <noreturn.h>
 #include "qmail.h"
-#include "case.h"
-#include "str.h"
-#include "getln.h"
-#include "substdio.h"
-#include "datetime.h"
-#include "date822fmt.h"
-#include "mess822.h"
-#include "now.h"
-#include "env.h"
-#include "fmt.h"
-#include "error.h"
-#include "envdir.h"
-#include "pathexec.h"
-#include "strerr.h"
 #include "sgetopt.h"
 #include "set_environment.h"
 
@@ -97,30 +101,30 @@
  *
  */
 
-char            strnum[FMT_ULONG];
+static char     strnum[FMT_ULONG];
 static char     ssoutbuf[512];
-static substdio ssout = SUBSTDIO_FDBUF(write, 1, ssoutbuf, sizeof ssoutbuf);
 static char     sserrbuf[512];
+static char    *usage = "usage: qnotify [-n][-h]\n";
+static substdio ssout = SUBSTDIO_FDBUF(write, 1, ssoutbuf, sizeof ssoutbuf);
 static substdio sserr = SUBSTDIO_FDBUF(write, 2, sserrbuf, sizeof(sserrbuf));
-char           *usage = "usage: qnotify [-n][-h]\n";
-struct qmail    qqt;
-int             flagqueue = 1;
+static int      flagqueue = 1;
+static struct qmail    qqt;
 
-void
+no_return void
 die_fork()
 {
 	substdio_putsflush(&sserr, "qnotify: fatal: unable to fork\n");
 	_exit (WRITE_ERR);
 }
 
-void
+no_return void
 die_qqperm()
 {
 	substdio_putsflush(&sserr, "qnotify: fatal: permanent qmail-queue error\n");
 	_exit (100);
 }
 
-void
+no_return void
 die_qqtemp()
 {
 	substdio_putsflush(&sserr, "qnotify: fatal: temporary qmail-queue error\n");
@@ -143,7 +147,7 @@ logerrf(char *s)
 		_exit (WRITE_ERR);
 }
 
-void
+no_return void
 my_error(char *s1, char *s2, int exit_val)
 {
 	logerr(s1);
@@ -576,7 +580,7 @@ main(int argc, char **argv)
 void
 getversion_qnotify_c()
 {
-	static char    *x = "$Id: qnotify.c,v 1.11 2021-07-05 21:11:27+05:30 Cprogrammer Exp mbhangui $";
+	static char    *x = "$Id: qnotify.c,v 1.12 2021-08-29 23:27:08+05:30 Cprogrammer Exp mbhangui $";
 
 	x++;
 }

--- a/indimail-mta-x/qquote.c
+++ b/indimail-mta-x/qquote.c
@@ -1,5 +1,8 @@
 /*
  * $Log: qquote.c,v $
+ * Revision 1.3  2021-08-29 23:27:08+05:30  Cprogrammer
+ * define funtions as noreturn
+ *
  * Revision 1.2  2004-10-22 20:29:43+05:30  Cprogrammer
  * added RCS id
  *
@@ -8,64 +11,56 @@
  *
  */
 #include <unistd.h>
-#include "mess822.h"
-#include "subfd.h"
-#include "substdio.h"
-#include "strerr.h"
+#include <mess822.h>
+#include <subfd.h>
+#include <substdio.h>
+#include <strerr.h>
+#include <noreturn.h>
 
 #define FATAL "quote: fatal: "
 
-void
+no_return void
 nomem()
 {
 	strerr_die2x(111, FATAL, "out of memory");
 }
 
-stralloc        quoted = { 0 };
-stralloc        addr = { 0 };
-char           *comment = 0;
-
 int
-main(argc, argv)
-	int             argc;
-	char          **argv;
+main(int argc, char **argv)
 {
+	stralloc        quoted = { 0 };
+	stralloc        addr = { 0 };
+	char           *comment = 0;
+
 	if (!stralloc_copys(&addr, "@"))
 		nomem();
 
-	if (argv[1])
-	{
+	if (argv[1]) {
 		if (!stralloc_copys(&addr, argv[1]))
 			nomem();
 		if (!stralloc_cats(&addr, "@"))
 			nomem();
 
-		if (argv[2])
-		{
+		if (argv[2]) {
 			if (!stralloc_cats(&addr, argv[2]))
 				nomem();
-
 			comment = argv[3];
 		}
 	}
-
 	if (!stralloc_0(&addr))
 		nomem();
 	if (!mess822_quote(&quoted, addr.s, comment))
 		nomem();
-
 	if (!stralloc_append(&quoted, "\n"))
 		nomem();
-
 	substdio_putflush(subfdout, quoted.s, quoted.len);
-
 	_exit(0);
 }
 
 void
 getversion_qquote_c()
 {
-	static char    *x = "$Id: qquote.c,v 1.2 2004-10-22 20:29:43+05:30 Cprogrammer Stab mbhangui $";
+	static char    *x = "$Id: qquote.c,v 1.3 2021-08-29 23:27:08+05:30 Cprogrammer Exp mbhangui $";
 
 	x++;
 }

--- a/indimail-mta-x/qreceipt.c
+++ b/indimail-mta-x/qreceipt.c
@@ -1,5 +1,8 @@
 /*
  * $Log: qreceipt.c,v $
+ * Revision 1.15  2021-08-29 23:27:08+05:30  Cprogrammer
+ * define funtions as noreturn
+ *
  * Revision 1.14  2021-07-05 21:11:38+05:30  Cprogrammer
  * skip $HOME/.defaultqueue for root
  *
@@ -52,6 +55,7 @@
 #include <gen_alloc.h>
 #include <gen_allocdefs.h>
 #include <open.h>
+#include <noreturn.h>
 #include "hfield.h"
 #include "headerbody.h"
 #include "quote.h"
@@ -61,60 +65,68 @@
 #define FATAL "qreceipt: fatal: "
 #define WARN  "qreceipt: warn: "
 
-void
+static char    *target;
+static char    *returnpath;
+static int      flagreceipt = 0;
+static stralloc messageid = { 0 };
+static stralloc sanotice = { 0 };
+static stralloc quoted = { 0 };
+static stralloc hfbuf = { 0 };
+
+no_return void
 die_noreceipt()
 {
 	_exit(0);
 }
 
-void
+no_return void
 die()
 {
 	_exit(100);
 }
 
-void
+no_return void
 die_temp()
 {
 	_exit(111);
 }
 
-void
+no_return void
 die_nomem()
 {
 	substdio_putsflush(subfderr, "qreceipt: fatal: out of memory\n");
 	die_temp();
 }
 
-void
+no_return void
 die_fork()
 {
 	substdio_putsflush(subfderr, "qreceipt: fatal: unable to fork\n");
 	die_temp();
 }
 
-void
+no_return void
 die_qqperm()
 {
 	substdio_putsflush(subfderr, "qreceipt: fatal: permanent qmail-queue error\n");
 	die();
 }
 
-void
+no_return void
 die_qqtemp()
 {
 	substdio_putsflush(subfderr, "qreceipt: fatal: temporary qmail-queue error\n");
 	die_temp();
 }
 
-void
+no_return void
 die_usage()
 {
 	substdio_putsflush(subfderr, "qreceipt: usage: qreceipt deliveryaddress\n");
 	die();
 }
 
-void
+no_return void
 die_read()
 {
 	if (errno == error_nomem)
@@ -123,7 +135,7 @@ die_read()
 	die_temp();
 }
 
-void
+no_return void
 die_control()
 {
 	substdio_putsflush(subfderr, "fatal: unable to read controls\n");
@@ -131,9 +143,7 @@ die_control()
 }
 
 void
-doordie(sa, r)
-	stralloc       *sa;
-	int             r;
+doordie(stralloc *sa, int r)
 {
 	if (r == 1)
 		return;
@@ -144,15 +154,8 @@ doordie(sa, r)
 	die();
 }
 
-char           *target;
-int             flagreceipt = 0;
-char           *returnpath;
-stralloc        messageid = { 0 };
-stralloc        sanotice = { 0 };
-
 int
-rwnotice(addr)
-	token822_alloc *addr;
+rwnotice(token822_alloc *addr)
 {
 	token822_reverse(addr);
 	if (token822_unquote(&sanotice, addr) != 1)
@@ -163,13 +166,11 @@ rwnotice(addr)
 	return 1;
 }
 
-struct qmail    qqt;
-stralloc        quoted = { 0 };
-
 void
 finishheader()
 {
 	char           *qqx;
+	struct qmail    qqt;
 
 	if (!flagreceipt)
 		die_noreceipt();
@@ -208,15 +209,13 @@ following address: ");
 	}
 }
 
-stralloc        hfbuf = { 0 };
-token822_alloc  hfin = { 0 };
-token822_alloc  hfrewrite = { 0 };
-token822_alloc  hfaddr = { 0 };
-
 void
-doheaderfield(h)
-	stralloc       *h;
+doheaderfield(stralloc *h)
 {
+	token822_alloc  hfin = { 0 };
+	token822_alloc  hfrewrite = { 0 };
+	token822_alloc  hfaddr = { 0 };
+
 	switch (hfield_known(h->s, h->len))
 	{
 	case H_MESSAGEID:
@@ -231,17 +230,12 @@ doheaderfield(h)
 }
 
 void
-dobody(h)
-	stralloc       *h;
+dobody(stralloc *h)
 {;
 }
 
-stralloc        QueueBase = { 0 };
-
 int
-main(argc, argv)
-	int             argc;
-	char          **argv;
+main(int argc, char **argv)
 {
 
 	sig_pipeignore();
@@ -260,7 +254,7 @@ main(argc, argv)
 void
 getversion_qreceipt_c()
 {
-	static char    *x = "$Id: qreceipt.c,v 1.14 2021-07-05 21:11:38+05:30 Cprogrammer Exp mbhangui $";
+	static char    *x = "$Id: qreceipt.c,v 1.15 2021-08-29 23:27:08+05:30 Cprogrammer Exp mbhangui $";
 
 	x++;
 }

--- a/indimail-mta-x/qsmhook.c
+++ b/indimail-mta-x/qsmhook.c
@@ -1,5 +1,8 @@
 /*
  * $Log: qsmhook.c,v $
+ * Revision 1.10  2021-08-29 23:27:08+05:30  Cprogrammer
+ * define funtions as noreturn
+ *
  * Revision 1.9  2020-11-24 13:47:49+05:30  Cprogrammer
  * removed exit.h
  *
@@ -17,68 +20,63 @@
  *
  */
 #include <unistd.h>
-#include "fd.h"
-#include "stralloc.h"
-#include "sgetopt.h"
-#include "wait.h"
-#include "env.h"
-#include "byte.h"
-#include "str.h"
-#include "alloc.h"
-#include "case.h"
-#include "subfd.h"
-#include "error.h"
-#include "substdio.h"
-#include "sig.h"
+#include <fd.h>
+#include <stralloc.h>
+#include <sgetopt.h>
+#include <wait.h>
+#include <env.h>
+#include <byte.h>
+#include <str.h>
+#include <alloc.h>
+#include <case.h>
+#include <subfd.h>
+#include <error.h>
+#include <substdio.h>
+#include <sig.h>
+#include <noreturn.h>
 
-void
+no_return void
 die(int e, char *s)
 {
 	substdio_putsflush(subfderr, s);
 	_exit(e);
 }
 
-void
+no_return void
 die_usage()
 {
 	die(100, "qsmhook: fatal: incorrect usage\n");
 }
 
-void
+no_return void
 die_temp()
 {
 	die(111, "qsmhook: fatal: temporary problem\n");
 }
 
-void
+no_return void
 die_read()
 {
 	die(111, "qsmhook: fatal: unable to read message\n");
 }
 
-void
+no_return void
 die_badcmd()
 {
 	die(100, "qsmhook: fatal: command not found\n");
 }
 
-int             flagrpline = 0, flagufline = 1, flagdtline = 0;
-char           *rpline, *ufline, *dtline;
-char           *host, *sender, *recip;
-stralloc        newarg = { 0 };
-substdio        ssin, ssout;
-char            inbuf[SUBSTDIO_INSIZE], outbuf[SUBSTDIO_OUTSIZE];
-
 int
-main(argc, argv)
-	int             argc;
-	char          **argv;
+main(int argc, char **argv)
 {
 	unsigned int    i;
-	int             pid, wstat, opt, flagesc;
+	int             pid, wstat, opt, flagesc, flagrpline = 0, flagufline = 1, flagdtline = 0;
 	int             pi[2];
 	char          **arg;
-	char           *x;
+	char           *x, *rpline, *ufline, *dtline, *host, *sender, *recip;
+	char            inbuf[SUBSTDIO_INSIZE], outbuf[SUBSTDIO_OUTSIZE];
+	stralloc        newarg = { 0 };
+	substdio        ssin, ssout;
 
 	sig_pipeignore();
 
@@ -208,7 +206,7 @@ main(argc, argv)
 void
 getversion_qsmhook_c()
 {
-	static char    *x = "$Id: qsmhook.c,v 1.9 2020-11-24 13:47:49+05:30 Cprogrammer Exp mbhangui $";
+	static char    *x = "$Id: qsmhook.c,v 1.10 2021-08-29 23:27:08+05:30 Cprogrammer Exp mbhangui $";
 
 	x++;
 }

--- a/indimail-mta-x/queue-fix.c
+++ b/indimail-mta-x/queue-fix.c
@@ -1,5 +1,8 @@
 /*
  * $Log: queue-fix.c,v $
+ * Revision 1.26  2021-08-29 23:27:08+05:30  Cprogrammer
+ * define funtions as noreturn
+ *
  * Revision 1.25  2021-07-20 09:04:36+05:30  Cprogrammer
  * added missing options in usage string
  *
@@ -85,11 +88,12 @@
 #include <env.h>
 #include <sgetopt.h>
 #include <strmsg.h>
-#include "direntry.h"
+#include <direntry.h>
+#include <pathexec.h>
+#include <envdir.h>
+#include <getEnvConfig.h>
+#include <noreturn.h>
 #include "tcpto.h"
-#include "pathexec.h"
-#include "envdir.h"
-#include "getEnvConfig.h"
 #include "auto_split.h"
 #include "auto_uids.h"
 #include "set_environment.h"
@@ -99,15 +103,14 @@
 
 extern int rename (const char *, const char *);
 
-stralloc        queue_dir = { 0 };	/*- the root queue dir with trailing slash */
-stralloc        check_dir = { 0 };	/*- the current directory being checked */
-stralloc        temp_filename = { 0 };	/*- temporary used for checking individuals */
-stralloc        temp_dirname = { 0 };	/*- temporary used for checking individuals */
-stralloc        old_name = { 0 };	/*- used in rename */
-stralloc        new_name = { 0 };	/*- used in rename */
-stralloc        mess_dir = { 0 };	/*- used for renaming in mess dir */
-stralloc        query = { 0 };	/*- used in interactive query function */
-
+static stralloc queue_dir = { 0 };	/*- the root queue dir with trailing slash */
+static stralloc check_dir = { 0 };	/*- the current directory being checked */
+static stralloc temp_filename = { 0 };	/*- temporary used for checking individuals */
+static stralloc temp_dirname = { 0 };	/*- temporary used for checking individuals */
+static stralloc old_name = { 0 };	/*- used in rename */
+static stralloc new_name = { 0 };	/*- used in rename */
+static stralloc mess_dir = { 0 };	/*- used for renaming in mess dir */
+static stralloc query = { 0 };	/*- used in interactive query function */
 static char     name_num[FMT_ULONG];
 static int      flag_interactive = 0;
 static int      flag_doit = 1;
@@ -141,7 +144,7 @@ flush()
 	return;
 }
 
-void
+no_return void
 usage()
 {
 	char            strnum[FMT_ULONG];
@@ -159,7 +162,7 @@ usage()
 	_exit(100);
 }
 
-void
+no_return void
 die_check()
 {
 	strerr_warn2(WARN, "Failed while checking directory structure.\n"
@@ -168,7 +171,7 @@ die_check()
 	_exit(111);
 }
 
-void
+no_return void
 die_recon()
 {
 	strerr_warn2(WARN, "Failed to reconstruct queue.\n"
@@ -177,7 +180,7 @@ die_recon()
 	_exit(111);
 }
 
-void
+no_return void
 die_rerun()
 {
 	strerr_warn2(WARN, ".tmp files exist in the queue.\n"
@@ -1049,7 +1052,7 @@ main(int argc, char **argv)
 void
 getversion_queue_fix_c()
 {
-	static char    *x = "$Id: queue-fix.c,v 1.25 2021-07-20 09:04:36+05:30 Cprogrammer Exp mbhangui $";
+	static char    *x = "$Id: queue-fix.c,v 1.26 2021-08-29 23:27:08+05:30 Cprogrammer Exp mbhangui $";
 
 	x++;
 }

--- a/indimail-mta-x/replier-config.c
+++ b/indimail-mta-x/replier-config.c
@@ -1,5 +1,8 @@
 /*
  * $Log: replier-config.c,v $
+ * Revision 1.6  2021-08-29 23:27:08+05:30  Cprogrammer
+ * define funtions as noreturn
+ *
  * Revision 1.5  2021-06-14 01:08:57+05:30  Cprogrammer
  * removed dependency on auto_qmail.h
  *
@@ -20,41 +23,36 @@
 #include <sys/stat.h>
 #include <pwd.h>
 #include <unistd.h>
-#include "strerr.h"
-#include "substdio.h"
-#include "stralloc.h"
-#include "open.h"
+#include <strerr.h>
+#include <substdio.h>
+#include <stralloc.h>
+#include <open.h>
+#include <str.h>
+#include <noreturn.h>
 #include "auto_ezmlm.h"
-#include "str.h"
 
 #define FATAL "replier-config: fatal: "
 
-void
+static int      fd;
+static substdio ss;
+static stralloc dirplus = { 0 };
+static stralloc dotplus = { 0 };
+static char    *fn, *dir, *dot, *local, *host, *outlocal, *outhost;
+static char     buf[1024];
+
+no_return void
 usage(void)
 {
 	strerr_die1x(100, "replier-config: usage: replier-config dir dot local host [ outlocal [ outhost ]]");
 }
 
-void
+no_return void
 nomem()
 {
 	strerr_die2x(111, FATAL, "out of memory");
 }
 
-char           *dir;
-char           *dot;
-char           *local;
-char           *host;
-char           *outlocal;
-char           *outhost;
-char           *extnum;
-
-char           *fn;
-char            buf[1024];
-int             fd;
-substdio        ss;
-
-void
+no_return void
 fail(void)
 {
 	strerr_die6sys(111, FATAL, "unable to create ", dir, "/", fn, ": ");
@@ -72,8 +70,7 @@ void
 start(char *s)
 {
 	fn = s;
-	fd = open_trunc(fn);
-	if (fd == -1)
+	if ((fd = open_trunc(fn)) == -1)
 		fail();
 	substdio_fdbuf(&ss, write, fd, buf, sizeof buf);
 }
@@ -102,13 +99,8 @@ perm(int mode)
 		fail();
 }
 
-stralloc        dirplus = { 0 };
-stralloc        dotplus = { 0 };
-stralloc        outadmin = { 0 };
-
 void
-dirplusmake(slash)
-	char           *slash;
+dirplusmake(char *slash)
 {
 	if (!stralloc_copys(&dirplus, dir) ||
 			!stralloc_cats(&dirplus, slash) ||
@@ -117,9 +109,7 @@ dirplusmake(slash)
 }
 
 void
-linkdotdir(dash, slash)
-	char           *dash;
-	char           *slash;
+linkdotdir(char *dash, char *slash)
 {
 	if (!stralloc_copys(&dotplus, dot) ||
 			!stralloc_cats(&dotplus, dash) ||
@@ -135,27 +125,20 @@ main(int argc, char **argv)
 {
 	umask(077);
 
-	dir = argv[1];
-	if (!dir)
+	if (!(dir = argv[1]))
 		usage();
 	if (dir[0] != '/')
 		usage();
-	dot = argv[2];
-	if (!dot)
+	if (!(dot = argv[2]))
 		usage();
-	local = argv[3];
-	if (!local)
+	if (!(local = argv[3]))
 		usage();
-	host = argv[4];
-	if (!host)
+	if (!(host = argv[4]))
 		usage();
-	outlocal = argv[5];
-	if (!outlocal)
-	{
+	if (!(outlocal = argv[5])) {
 		outlocal = local;
 		outhost = host;
-	} else
-	{
+	} else {
 		outhost = argv[6];
 		if (!outhost)
 			outhost = host;
@@ -306,7 +289,7 @@ main(int argc, char **argv)
 void
 getversion_replier_config_c()
 {
-	static char    *x = "$Id: replier-config.c,v 1.5 2021-06-14 01:08:57+05:30 Cprogrammer Exp mbhangui $";
+	static char    *x = "$Id: replier-config.c,v 1.6 2021-08-29 23:27:08+05:30 Cprogrammer Exp mbhangui $";
 
 	x++;
 }

--- a/indimail-mta-x/replier.c
+++ b/indimail-mta-x/replier.c
@@ -1,5 +1,8 @@
 /*
  * $Log: replier.c,v $
+ * Revision 1.12  2021-08-29 23:27:08+05:30  Cprogrammer
+ * define funtions as noreturn
+ *
  * Revision 1.11  2021-07-05 21:11:41+05:30  Cprogrammer
  * skip $HOME/.defaultqueue for root
  *
@@ -38,27 +41,28 @@
 #include <signal.h>
 #include <sys/types.h>
 #include <sys/stat.h>
-#include "alloc.h"
-#include "envdir.h"
-#include "stralloc.h"
-#include "byte.h"
-#include "strerr.h"
-#include "error.h"
-#include "qmail.h"
-#include "env.h"
-#include "sig.h"
-#include "open.h"
-#include "getln.h"
-#include "case.h"
-#include "scan.h"
-#include "str.h"
-#include "fmt.h"
-#include "substdio.h"
+#include <alloc.h>
+#include <envdir.h>
+#include <stralloc.h>
+#include <byte.h>
+#include <strerr.h>
+#include <error.h>
+#include <env.h>
+#include <sig.h>
+#include <open.h>
+#include <getln.h>
+#include <case.h>
+#include <scan.h>
+#include <str.h>
+#include <fmt.h>
+#include <substdio.h>
+#include <constmap.h>
+#include <fd.h>
+#include <wait.h>
+#include <pathexec.h>
+#include <noreturn.h>
 #include "getconf.h"
-#include "constmap.h"
-#include "fd.h"
-#include "wait.h"
-#include "pathexec.h"
+#include "qmail.h"
 #include "set_environment.h"
 
 #define FATAL "replier: fatal: "
@@ -67,85 +71,64 @@
 void (*sig_defaulthandler)() = SIG_DFL;
 void (*sig_ignorehandler)() = SIG_IGN;
 
-
-void
+no_return void
 usage()
 {
 	strerr_die1x(100, "replier: usage: replier dir addr prog [ args ]");
 }
 
-void
+no_return void
 nomem()
 {
 	strerr_die2x(111, FATAL, "out of memory");
 }
 
-void
+no_return void
 badaddr()
 {
 	strerr_die2x(100, FATAL, "I do not accept messages at this address (#5.1.1)");
 }
 
-char            strnum[FMT_ULONG];
-
-stralloc        fnadir = { 0 };
-stralloc        fnaf = { 0 };
-stralloc        fnsub = { 0 };
-stralloc        line = { 0 };
-
-stralloc        mailinglist = { 0 };
-stralloc        inlocal = { 0 };
-stralloc        outlocal = { 0 };
-stralloc        outhost = { 0 };
-stralloc        headerremove = { 0 };
-struct constmap headerremovemap;
-stralloc        headeradd = { 0 };
-
-struct qmail    qq;
-static char     inbuf[1024];
-static char     outbuf[512];
-static substdio ssin, ssout;
+static struct qmail qq;
 
 ssize_t
-mywrite(fd, buf, len)
-	int             fd;
-	char           *buf;
-	unsigned int    len;
+mywrite(int fd, char *buf, unsigned int len)
 {
 	qmail_put(&qq, buf, len);
 	return len;
 }
 
 void
-put(buf, len)
-	char           *buf;
-	int             len;
+put(char *buf, int len)
 {
 	qmail_put(&qq, buf, len);
 }
 
 void
-myputs(buf)
-	char           *buf;
+myputs(char *buf)
 {
 	qmail_puts(&qq, buf);
 }
 
-void
+no_return void
 sigalrm()
 {
 	strerr_die1x(111, "Timeout on maildir delivery. (#4.3.0)");
 }
 
-stralloc        mydtline = { 0 };
-
 int
 main(int argc, char **argv)
 {
+	stralloc        mydtline = { 0 }, line = { 0 }, mailinglist = { 0 },
+					inlocal = { 0 }, outlocal = { 0 }, outhost = { 0 },
+					headerremove = { 0 }, headeradd = { 0 };
+	struct constmap headerremovemap;
+	char            inbuf[1024], outbuf[512], strnum[FMT_ULONG];
+	substdio        ssin, ssout;
 	char           *dir, *addr, *sender, *local, *action, *qqx;
+	char          **e;
 	int             flagmlwasthere, match, i, flaginheader, flagbadfield, pid, wstat,
 					tmperrno;
-	char          **e;
 	int             pf[2];
 
 	if (!(dir = argv[1]))
@@ -307,7 +290,7 @@ main(int argc, char **argv)
 void
 getversion_replier_c()
 {
-	static char    *x = "$Id: replier.c,v 1.11 2021-07-05 21:11:41+05:30 Cprogrammer Exp mbhangui $";
+	static char    *x = "$Id: replier.c,v 1.12 2021-08-29 23:27:08+05:30 Cprogrammer Exp mbhangui $";
 
 	x++;
 }

--- a/indimail-mta-x/report.c
+++ b/indimail-mta-x/report.c
@@ -1,5 +1,8 @@
 /*
  * $Log: report.c,v $
+ * Revision 1.5  2021-08-29 23:27:08+05:30  Cprogrammer
+ * define funtions as noreturn
+ *
  * Revision 1.4  2021-08-28 23:07:59+05:30  Cprogrammer
  * moved dtype enum delivery variable from variables.h to getDomainToken.h
  *
@@ -17,12 +20,13 @@
 #include <substdio.h>
 #include <subfd.h>
 #include <strerr.h>
+#include <noreturn.h>
 #include "report.h"
 #include "getDomainToken.h"
 
 extern dtype    delivery;
 
-void
+no_return void
 report(int errCode, char *s1, char *s2, char *s3, char *s4, char *s5, char *s6)
 {
 	if (delivery == local_delivery) /*- strerr_die does not return */
@@ -69,7 +73,7 @@ report(int errCode, char *s1, char *s2, char *s3, char *s4, char *s5, char *s6)
 void
 getversion_report_c()
 {
-	static char    *x = "$Id: report.c,v 1.4 2021-08-28 23:07:59+05:30 Cprogrammer Exp mbhangui $";
+	static char    *x = "$Id: report.c,v 1.5 2021-08-29 23:27:08+05:30 Cprogrammer Exp mbhangui $";
 
 	x = sccsidreporth;
 	x = sccsidgetdomainth;

--- a/indimail-mta-x/rrforward.c
+++ b/indimail-mta-x/rrforward.c
@@ -1,5 +1,8 @@
 /*
  * $Log: rrforward.c,v $
+ * Revision 1.11  2021-08-29 23:27:08+05:30  Cprogrammer
+ * define funtions as noreturn
+ *
  * Revision 1.10  2021-07-05 21:11:44+05:30  Cprogrammer
  * skip $HOME/.defaultqueue for root
  *
@@ -34,58 +37,50 @@
 #include <sys/types.h>
 #include <unistd.h>
 #include <fcntl.h>
-#include "envdir.h"
-#include "pathexec.h"
-#include "sig.h"
-#include "lock.h"
-#include "str.h"
-#include "scan.h"
-#include "seek.h"
-#include "env.h"
+#include <envdir.h>
+#include <pathexec.h>
+#include <sig.h>
+#include <lock.h>
+#include <str.h>
+#include <scan.h>
+#include <seek.h>
+#include <env.h>
+#include <strerr.h>
+#include <substdio.h>
+#include <fmt.h>
+#include <noreturn.h>
 #include "qmail.h"
-#include "strerr.h"
-#include "substdio.h"
-#include "fmt.h"
 #include "set_environment.h"
 
 #define FATAL "rrforward: fatal: "
 #define WARN  "rrforward: warn: "
-
 #define QRR_FILE ".qmailrr"
-
 #define QRR_LEN (sizeof(QRR_FILE)-1)
 #define QRR_SEPARATOR(S) (*((S)+QRR_LEN))
 #define QRR_EXTENSION(S) ((S)+QRR_LEN+1)
 
-void
+ssize_t         qqtwrite(int fd, char *buf, size_t len);
+
+static struct qmail    qqt;
+static char     inbuf[SUBSTDIO_INSIZE], outbuf[1];
+static substdio ssin = SUBSTDIO_FDBUF(read, 0, inbuf, sizeof inbuf);
+static substdio ssout = SUBSTDIO_FDBUF(qqtwrite, -1, outbuf, sizeof outbuf);
+
+no_return void
 die_nomem()
 {
 	strerr_die2x(111, FATAL, "out of memory");
 }
 
-struct qmail    qqt;
-
 ssize_t
-qqtwrite(fd, buf, len)
-	int             fd;
-	char           *buf;
-	ssize_t         len;
+qqtwrite(int fd, char *buf, size_t len)
 {
 	qmail_put(&qqt, buf, len);
 	return len;
 }
 
-char            inbuf[SUBSTDIO_INSIZE];
-char            outbuf[1];
-substdio        ssin = SUBSTDIO_FDBUF(read, 0, inbuf, sizeof inbuf);
-substdio        ssout = SUBSTDIO_FDBUF(qqtwrite, -1, outbuf, sizeof outbuf);
-
-void
-rr_forward(rrto, sender, dtline, rrnum)
-	char           *rrto;
-	char           *sender;
-	char           *dtline;
-	char           *rrnum;
+no_return void
+rr_forward(char *rrto, char *sender, char *dtline, char *rrnum)
 {
 	char           *qqx;
 	char            num[FMT_ULONG];
@@ -107,9 +102,7 @@ rr_forward(rrto, sender, dtline, rrnum)
 }
 
 int
-main(argc, argv)
-	int             argc;
-	char          **argv;
+main(int argc, char **argv)
 {
 	char            strpos[FMT_ULONG + 2];
 	char           *rrfile, *extension, *sender, *dtline;
@@ -162,14 +155,12 @@ main(argc, argv)
 	strpos[r] = '\0';
 	set_environment(WARN, FATAL, 0);
 	rr_forward(argv[pos], sender, dtline, strpos);
-	/*- Not reached */
-	return(0);
 }
 
 void
 getversion_rrforward_c()
 {
-	static char    *x = "$Id: rrforward.c,v 1.10 2021-07-05 21:11:44+05:30 Cprogrammer Exp mbhangui $";
+	static char    *x = "$Id: rrforward.c,v 1.11 2021-08-29 23:27:08+05:30 Cprogrammer Exp mbhangui $";
 
 	x++;
 }

--- a/indimail-mta-x/rrt.c
+++ b/indimail-mta-x/rrt.c
@@ -1,5 +1,8 @@
 /*
  * $Log: rrt.c,v $
+ * Revision 1.11  2021-08-29 23:27:08+05:30  Cprogrammer
+ * define funtions as noreturn
+ *
  * Revision 1.10  2021-07-05 21:11:47+05:30  Cprogrammer
  * skip $HOME/.defaultqueue for root
  *
@@ -33,24 +36,25 @@
  */
 #include <unistd.h>
 #include <errno.h>
-#include "sgetopt.h"
+#include <sgetopt.h>
+#include <case.h>
+#include <fmt.h>
+#include <str.h>
+#include <now.h>
+#include <datetime.h>
+#include <mess822.h>
+#include <date822fmt.h>
+#include <getln.h>
+#include <stralloc.h>
+#include <error.h>
+#include <envdir.h>
+#include <env.h>
+#include <strerr.h>
+#include <pathexec.h>
+#include <noreturn.h>
+#include "variables.h"
 #include "control.h"
 #include "qmail.h"
-#include "case.h"
-#include "fmt.h"
-#include "str.h"
-#include "now.h"
-#include "datetime.h"
-#include "mess822.h"
-#include "date822fmt.h"
-#include "getln.h"
-#include "stralloc.h"
-#include "error.h"
-#include "envdir.h"
-#include "env.h"
-#include "strerr.h"
-#include "pathexec.h"
-#include "variables.h"
 #include "set_environment.h"
 
 #define FATAL     "rrt: fatal: "
@@ -67,31 +71,29 @@
 #define USAGE_ERR 7
 #define PARSE_ERR 8
 
-char            strnum[FMT_ULONG];
-static char     ssoutbuf[512];
+static char     ssoutbuf[512], sserrbuf[512], strnum[FMT_ULONG];
 static substdio ssout = SUBSTDIO_FDBUF(write, 1, ssoutbuf, sizeof ssoutbuf);
-static char     sserrbuf[512];
 static substdio sserr = SUBSTDIO_FDBUF(write, 2, sserrbuf, sizeof(sserrbuf));
-char           *usage = "usage: rrt [-n][-b]\n";
-struct qmail    qqt;
-int             flagqueue = 1;
-stralloc        line = { 0 };
+static char    *usage = "usage: rrt [-n][-b]\n";
+static struct qmail    qqt;
+static int      flagqueue = 1;
+static stralloc line = { 0 };
 
-void
+no_return void
 die_fork()
 {
 	substdio_putsflush(&sserr, "rrt: fatal: unable to fork\n");
 	_exit (WRITE_ERR);
 }
 
-void
+no_return void
 die_qqperm()
 {
 	substdio_putsflush(&sserr, "rrt: fatal: permanent qmail-queue error\n");
 	_exit (100);
 }
 
-void
+no_return void
 die_qqtemp()
 {
 	substdio_putsflush(&sserr, "rrt: fatal: temporary qmail-queue error\n");
@@ -114,7 +116,7 @@ logerrf(char *s)
 		_exit (WRITE_ERR);
 }
 
-void
+no_return void
 my_error(char *s1, char *s2, int exit_val)
 {
 	logerr(s1);
@@ -238,8 +240,7 @@ parse_email()
 			break;
 		if (!mess822_ok(&line))
 			break;
-		if (!got_from && !str_diffn(line.s, "From: ", 6))
-		{
+		if (!got_from && !str_diffn(line.s, "From: ", 6)) {
 			got_from = 1;
 			line.s[line.len - 1] = 0;
 			if (!addrparse(line.s)) /*- sets addr */
@@ -488,7 +489,7 @@ main(int argc, char **argv)
 void
 getversion_rr_c()
 {
-	static char    *x = "$Id: rrt.c,v 1.10 2021-07-05 21:11:47+05:30 Cprogrammer Exp mbhangui $";
+	static char    *x = "$Id: rrt.c,v 1.11 2021-08-29 23:27:08+05:30 Cprogrammer Exp mbhangui $";
 
 	x++;
 }

--- a/indimail-mta-x/sendmail.c
+++ b/indimail-mta-x/sendmail.c
@@ -1,5 +1,8 @@
 /*
  * $Log: sendmail.c,v $
+ * Revision 1.13  2021-08-29 23:27:08+05:30  Cprogrammer
+ * define funtions as noreturn
+ *
  * Revision 1.12  2020-11-24 13:48:05+05:30  Cprogrammer
  * removed exit.h
  *
@@ -26,32 +29,34 @@
  *
  */
 #include <unistd.h>
-#include "sgetopt.h"
-#include "substdio.h"
-#include "subfd.h"
-#include "alloc.h"
+#include <sgetopt.h>
+#include <substdio.h>
+#include <subfd.h>
+#include <alloc.h>
+#include <env.h>
+#include <str.h>
+#include <noreturn.h>
 #include "auto_qmail.h"
-#include "env.h"
-#include "str.h"
 
-void
+no_return void
 nomem()
 {
 	substdio_putsflush(subfderr, "sendmail: fatal: out of memory\n");
 	_exit(111);
 }
 
-void
+no_return void
 die_usage()
 {
 	substdio_putsflush(subfderr, "sendmail: usage: sendmail [ -t ] [ -fsender ] [ -Fname ] [ -bp ] [ -bs ] [ arg ... ]\n");
 	_exit(100);
 }
 
-char           *smtpdarg[] = { "sbin/qmail-smtpd", 0 };
-void
+no_return void
 smtpd()
 {
+	char           *smtpdarg[] = { "sbin/qmail-smtpd", 0 };
+
 	if (!env_get("PROTO")) {
 		if (!env_put("RELAYCLIENT="))
 			nomem();
@@ -75,11 +80,11 @@ smtpd()
 	_exit(111);
 }
 
-char           *qreadarg[] = { "bin/qmail-qread", 0 };
-
-void
+no_return void
 mailq()
 {
+	char           *qreadarg[] = { "bin/qmail-qread", 0 };
+
 	execv(*qreadarg, qreadarg);
 	substdio_putsflush(subfderr, "sendmail: fatal: unable to run qmail-qread\n");
 	_exit(111);
@@ -113,17 +118,15 @@ do_sender(const char *s)
 	alloc_free(x);
 }
 
-int             flagh;
-char           *sender;
 
 int
 main(argc, argv)
 	int             argc;
 	char          **argv;
 {
-	int             opt, i;
-	char          **qiargv;
-	char          **arg;
+	int             opt, i, flagh;
+	char          **qiargv, **arg;
+	char           *sender;
 
 	if (chdir(auto_qmail) == -1) {
 		substdio_putsflush(subfderr, "sendmail: fatal: unable to switch to qmail home directory\n");
@@ -258,7 +261,7 @@ main(argc, argv)
 void
 getversion_sendmail_c()
 {
-	static char    *x = "$Id: sendmail.c,v 1.12 2020-11-24 13:48:05+05:30 Cprogrammer Exp mbhangui $";
+	static char    *x = "$Id: sendmail.c,v 1.13 2021-08-29 23:27:08+05:30 Cprogrammer Exp mbhangui $";
 
 	x++;
 }

--- a/indimail-mta-x/serialcmd.c
+++ b/indimail-mta-x/serialcmd.c
@@ -1,5 +1,8 @@
 /*
  * $Log: serialcmd.c,v $
+ * Revision 1.6  2021-08-29 23:27:08+05:30  Cprogrammer
+ * define funtions as noreturn
+ *
  * Revision 1.5  2021-07-05 21:24:39+05:30  Cprogrammer
  * use qgetpw interface from libqmail if USE_QPWGR is set
  *
@@ -39,88 +42,82 @@
 #include <byte.h>
 #include <env.h>
 #include <qgetpwgr.h>
+#include <noreturn.h>
 #include "quote.h"
 
 #define FATAL "serialcmd: fatal: "
 
 static int      use_pwgr;
+static stralloc line = { 0 };
+static stralloc quosender = { 0 };
+static stralloc recipient = { 0 };
+static stralloc sender = { 0 };
 
-void
+no_return void
 die_usage()
 {
 	strerr_die1x(100, "serialcmd: usage: serialcmd prefix command");
 }
 
-void
+no_return void
 die_nomem()
 {
 	strerr_die2x(111, FATAL, "out of memory");
 }
 
-void
+no_return void
 die_nohomedir()
 {
 	strerr_die2x(111, FATAL, "no home directory");
 }
 
-void
+no_return void
 die_nousername()
 {
 	strerr_die2x(111, FATAL, "no user name");
 }
 
-void
+no_return void
 die_badexit()
 {
 	strerr_die2x(111, FATAL, "child exited abnormally");
 }
 
-void
+no_return void
 die_output()
 {
 	strerr_die2sys(111, FATAL, "unable to write output: ");
 }
 
-void
+no_return void
 die_readmess()
 {
 	strerr_die2sys(111, FATAL, "unable to read file: ");
 }
 
-void
+no_return void
 die_openmess()
 {
 	strerr_die2sys(111, FATAL, "unable to open file: ");
 }
 
-void
+no_return void
 die_statmess()
 {
 	strerr_die2sys(111, FATAL, "unable to stat file: ");
 }
 
-void
+no_return void
 die_readstdin()
 {
 	strerr_die2sys(111, FATAL, "unable to read stdin: ");
 }
 
-char           *prefix;
-
-stralloc        line = { 0 };
-stralloc        quorecip = { 0 };
-stralloc        quosender = { 0 };
-stralloc        recipient = { 0 };
-stralloc        sender = { 0 };
-
 void
-result(fnam, code, statmsg)
-	stralloc        fnam;
-	int             code;
-	char           *statmsg;
+result(stralloc *fnam, int code, char *statmsg)
 {
 
-	if (!stralloc_copyb(&line, fnam.s, fnam.len))
+	if (!stralloc_copyb(&line, fnam->s, fnam->len))
 		die_nomem();
 	switch (code)
 	{
@@ -251,7 +248,7 @@ makeenv(void)
 }
 
 void
-runcmd(char **cmd, int fd, stralloc fnam)
+runcmd(char **cmd, int fd, stralloc *fnam)
 {
 	int             pid;
 	int             pipedesc[2];
@@ -263,8 +260,7 @@ runcmd(char **cmd, int fd, stralloc fnam)
 	if (status == -1)
 		strerr_die2sys(111, FATAL, "unable to open pipe: ");
 	lseek(fd, (off_t) 0, SEEK_SET);
-	pid = fork();
-	if (pid == -1)
+	if ((pid = fork()) == -1)
 		strerr_die2sys(111, FATAL, "unable to fork: ");
 	if (pid == 0) {
 		if (dup2(fd, 0) == -1)
@@ -305,10 +301,7 @@ runcmd(char **cmd, int fd, stralloc fnam)
 }
 
 void
-doit(fd, argv, fnam)
-	int             fd;
-	char           *argv[];
-	stralloc        fnam;
+doit(int fd, char **argv, stralloc *fnam)
 {
 	char            messbuf[4096];
 	substdio        ssmess;
@@ -411,11 +404,10 @@ main(int argc, char *argv[])
 		die_readstdin();
 	if (!match)
 		die_readstdin();
-	fd = open_read(fname.s);
-	if (fd == -1)
+	if ((fd = open_read(fname.s)) == -1)
 		die_openmess();
 
-	doit(fd, argv, fname);
+	doit(fd, argv, &fname);
 	/*- Not reached */
 	return(0);
 }
@@ -423,7 +415,7 @@ main(int argc, char *argv[])
 void
 getversion_serialcmd_c()
 {
-	static char    *x = "$Id: serialcmd.c,v 1.5 2021-07-05 21:24:39+05:30 Cprogrammer Exp mbhangui $";
+	static char    *x = "$Id: serialcmd.c,v 1.6 2021-08-29 23:27:08+05:30 Cprogrammer Exp mbhangui $";
 
 	x++;
 }

--- a/indimail-mta-x/slowq-start.c
+++ b/indimail-mta-x/slowq-start.c
@@ -1,5 +1,8 @@
 /*
  * $Log: slowq-start.c,v $
+ * Revision 1.4  2021-08-29 23:27:08+05:30  Cprogrammer
+ * define funtions as noreturn
+ *
  * Revision 1.3  2021-06-27 10:39:22+05:30  Cprogrammer
  * uidnit new argument to disable/enable error on missing uids
  *
@@ -16,19 +19,15 @@
 #include <fcntl.h>
 #include <grp.h>
 #include <str.h>
-#include "fd.h"
-#include "env.h"
-#include "alloc.h"
-#include "prot.h"
+#include <fd.h>
+#include <env.h>
+#include <alloc.h>
+#include <prot.h>
+#include <setuserid.h>
+#include <noreturn.h>
 #include "auto_uids.h"
-#include "setuserid.h"
 
-char           *(qsargs[]) = { "slowq-send", 0};
-char           *(qcargs[]) = { "qmail-clean", 0};
-char           *(qlargs[]) = { "qmail-lspawn", "./Mailbox", 0};
-char           *(qrargs[]) = { "qmail-rspawn", 0};
-
-void
+no_return void
 die()
 {
 	_exit(111);
@@ -101,16 +100,16 @@ closepipes()
 	close(pi6[1]);
 }
 
-int             verbose;
-
 int
-main(argc, argv)
-	int             argc;
-	char          **argv;
+main(int argc, char **argv)
 {
 	char           *set_supplementary_groups;
 	gid_t          *gidset;
 	int             ngroups;
+	char           *(qsargs[]) = { "slowq-send", 0};
+	char           *(qcargs[]) = { "qmail-clean", 0};
+	char           *(qlargs[]) = { "qmail-lspawn", "./Mailbox", 0};
+	char           *(qrargs[]) = { "qmail-rspawn", 0};
 
 	set_supplementary_groups = env_get("USE_SETGROUPS");
 	if (chdir("/") == -1)
@@ -276,7 +275,7 @@ main(argc, argv)
 void
 getversion_slowq_start_c()
 {
-	static char    *x = "$Id: slowq-start.c,v 1.3 2021-06-27 10:39:22+05:30 Cprogrammer Exp mbhangui $";
+	static char    *x = "$Id: slowq-start.c,v 1.4 2021-08-29 23:27:08+05:30 Cprogrammer Exp mbhangui $";
 
 	x++;
 }

--- a/indimail-mta-x/spfquery.c
+++ b/indimail-mta-x/spfquery.c
@@ -1,5 +1,8 @@
 /*
  * $Log: spfquery.c,v $
+ * Revision 1.7  2021-08-29 23:27:08+05:30  Cprogrammer
+ * define funtions as noreturn
+ *
  * Revision 1.6  2020-11-24 13:49:42+05:30  Cprogrammer
  * removed exit.h
  *
@@ -19,25 +22,31 @@
  * Initial revision
  *
  */
-#include "substdio.h"
-#include "subfd.h"
-#include "stralloc.h"
-#include "alloc.h"
+#include <unistd.h>
+#include <substdio.h>
+#include <subfd.h>
+#include <stralloc.h>
+#include <alloc.h>
 #include "dns.h"
+#include <noreturn.h>
 #ifdef USE_SPF
 #include "spf.h"
-#include <unistd.h>
 
-void
-die(e, s)
-	int             e;
-	char           *s;
+char           *local = "localhost";
+stralloc        addr = { 0 };
+stralloc        helohost = { 0 };
+stralloc        spflocal = { 0 };
+stralloc        spfguess = { 0 };
+stralloc        spfexp = { 0 };
+
+no_return void
+die(int e, char *s)
 {
 	substdio_putsflush(subfderr, s);
 	_exit(e);
 }
 
-void
+no_return void
 die_usage()
 {
 	die(100,
@@ -46,31 +55,20 @@ die_usage()
 		"[<local rules>] [<best guess rules>]\n");
 }
 
-void
+no_return void
 die_nomem()
 {
 	die(111, "fatal: out of memory\n");
 }
 
-stralloc        addr = { 0 };
-stralloc        helohost = { 0 };
-stralloc        spflocal = { 0 };
-stralloc        spfguess = { 0 };
-stralloc        spfexp = { 0 };
-
-char           *local = "localhost";
-
 int
-main(argc, argv)
-	int             argc;
-	char          **argv;
+main(int argc, char **argv)
 {
 	stralloc        sa = { 0 };
 	int             r;
 
 	if (argc < 4)
 		die_usage();
-
 	if (!stralloc_copys(&helohost, argv[2]))
 		die_nomem();
 	if (!stralloc_0(&helohost))
@@ -81,24 +79,21 @@ main(argc, argv)
 	if (!stralloc_0(&addr))
 		die_nomem();
 
-	if (argc > 4)
-	{
+	if (argc > 4) {
 		if (!stralloc_copys(&spflocal, argv[4]))
 			die_nomem();
 		if (spflocal.len && !stralloc_0(&spflocal))
 			die_nomem();
 	}
 
-	if (argc > 5)
-	{
+	if (argc > 5) {
 		if (!stralloc_copys(&spfguess, argv[5]))
 			die_nomem();
 		if (spfguess.len && !stralloc_0(&spfguess))
 			die_nomem();
 	}
 
-	if (argc > 6)
-	{
+	if (argc > 6) {
 		if (!stralloc_copys(&spfexp, argv[6]))
 			die_nomem();
 	} else
@@ -136,8 +131,7 @@ main(argc, argv)
 		break;
 	}
 
-	if (r == SPF_FAIL)
-	{
+	if (r == SPF_FAIL) {
 		substdio_puts(subfdout, ": ");
 		if (!spfexplanation(&sa))
 			die_nomem();
@@ -168,7 +162,7 @@ main(argc, argv)
 void
 getversion_spfquery_c()
 {
-	static char    *x = "$Id: spfquery.c,v 1.6 2020-11-24 13:49:42+05:30 Cprogrammer Exp mbhangui $";
+	static char    *x = "$Id: spfquery.c,v 1.7 2021-08-29 23:27:08+05:30 Cprogrammer Exp mbhangui $";
 
 	x++;
 }

--- a/indimail-mta-x/srsfilter.c
+++ b/indimail-mta-x/srsfilter.c
@@ -1,5 +1,8 @@
 /*
  * $Log: srsfilter.c,v $
+ * Revision 1.4  2021-08-29 23:27:08+05:30  Cprogrammer
+ * define funtions as noreturn
+ *
  * Revision 1.3  2020-11-24 13:48:31+05:30  Cprogrammer
  * removed exit.h
  *
@@ -13,32 +16,28 @@
 #include "hassrs.h"
 #ifdef HAVESRS
 #include <unistd.h>
-#include "sig.h"
-#include "env.h"
+#include <sig.h>
+#include <env.h>
+#include <strerr.h>
+#include <substdio.h>
+#include <fmt.h>
+#include <stralloc.h>
+#include <noreturn.h>
 #include "qmail.h"
-#include "strerr.h"
-#include "substdio.h"
-#include "fmt.h"
-#include "stralloc.h"
 #include "srs.h"
 
 #define FATAL  "srsfilter: fatal: "
 #define IGNORE "srsfilter: ignore: "
 
-void
+static struct qmail    qqt;
+static stralloc line = { 0 };
+static int      flagbody = 0, flagnewline = 0, flagto = 0, seento = 0;
+
+no_return void
 die_nomem()
 {
 	strerr_die2x(111, FATAL, "out of memory");
 }
-
-struct qmail    qqt;
-
-stralloc        line = { 0 };
-
-int             flagbody = 0;
-int             flagnewline = 0;
-int             flagto = 0;
-int             seento = 0;
 
 void
 newheader()
@@ -120,37 +119,25 @@ mywrite(fd, buf, len)
 	}
 }
 
-char            inbuf[SUBSTDIO_INSIZE];
-char            outbuf[1];
-substdio        ssin = SUBSTDIO_FDBUF(read, 0, inbuf, sizeof inbuf);
-substdio        ssout = SUBSTDIO_FDBUF(mywrite, -1, outbuf, sizeof outbuf);
-
-char            num[FMT_ULONG];
-
 int
-main(argc, argv)
-	int             argc;
-	char          **argv;
+main(int argc, char **argv)
 {
-	char           *ext2;
-	char           *host;
-	char           *sender;
-	char           *qqx;
+	char           *ext2, *host, *sender, *qqx;
+	char            inbuf[SUBSTDIO_INSIZE], outbuf[1], num[FMT_ULONG];
+	substdio        ssin = SUBSTDIO_FDBUF(read, 0, inbuf, sizeof inbuf);
+	substdio        ssout = SUBSTDIO_FDBUF(mywrite, -1, outbuf, sizeof outbuf);
 
 	sig_pipeignore();
 	if (!(sender = env_get("SENDER")))
 		strerr_die2x(100, FATAL, "SENDER not set");
-	if (*sender) {
-	/*
-	 * Return zero, the message will not bounce back 
-	 */
+	if (*sender) /*- Return zero, the message will not bounce back */
 		strerr_die2x(0, IGNORE, "SENDER must be empty");
-	}
 	if (!(ext2 = env_get("EXT2")))
 		strerr_die2x(100, FATAL, "EXT2 not set");
 	if (!(host = env_get("HOST")))
 		strerr_die2x(100, FATAL, "HOST not set");
-	switch (srsreverse(ext2)) {
+	switch (srsreverse(ext2))
+	{
 	case -3:
 		strerr_die2x(100, FATAL, srs_error.s);
 		break;
@@ -207,7 +194,7 @@ main(argc, argv)
 void
 getversion_srsfilter_c()
 {
-	static char    *x = "$Id: srsfilter.c,v 1.3 2020-11-24 13:48:31+05:30 Cprogrammer Exp mbhangui $";
+	static char    *x = "$Id: srsfilter.c,v 1.4 2021-08-29 23:27:08+05:30 Cprogrammer Exp mbhangui $";
 
 	x++;
 }

--- a/indimail-mta-x/tcp-env.c
+++ b/indimail-mta-x/tcp-env.c
@@ -1,5 +1,8 @@
 /*
  * $Log: tcp-env.c,v $
+ * Revision 1.14  2021-08-29 23:27:08+05:30  Cprogrammer
+ * define funtions as noreturn
+ *
  * Revision 1.13  2021-07-07 08:53:42+05:30  Cprogrammer
  * removed setting of BOUNCEMAIL, WARNMAILx
  *
@@ -35,33 +38,32 @@
 #include <unistd.h>
 #include <sys/socket.h>
 #include <netinet/in.h>
-#include "sig.h"
-#include "stralloc.h"
-#include "str.h"
+#include <sig.h>
+#include <stralloc.h>
+#include <str.h>
+#include <env.h>
+#include <fmt.h>
+#include <scan.h>
+#include <subgetopt.h>
+#include <byte.h>
+#include <case.h>
+#include <noreturn.h>
+
 #include "socket.h"
-#include "env.h"
-#include "fmt.h"
-#include "scan.h"
-#include "subgetopt.h"
 #include "ip.h"
 #include "hassalen.h"
 #ifdef USE_SPF
 #include "strsalloc.h"
 #endif
 #include "dns.h"
-#include "byte.h"
 #include "remoteinfo.h"
-#include "case.h"
 
-union sockunion salocal;
-unsigned long   localport;
-stralloc        localname = { 0 };
-
-union sockunion saremote;
-unsigned long   remoteport;
-stralloc        remotename = { 0 };
-
-char            temp[IPFMT + FMT_ULONG];
+static union sockunion salocal;
+static union sockunion saremote;
+static unsigned long   localport;
+static unsigned long   remoteport;
+static stralloc localname = { 0 };
+static stralloc remotename = { 0 };
 
 #ifdef IN6_IS_ADDR_V4MAPPED
 void
@@ -86,21 +88,18 @@ mappedtov4(union sockunion *sa)
 #define mappedtov4(A)
 #endif
 
-void
+no_return void
 die()
 {
 	_exit(111);
 }
 
 int
-main(argc, argv)
-	int             argc;
-	char           *argv[];
+main(int argc, char **argv)
 {
-	int             dummy;
 	char           *proto;
-	int             opt;
-	int             flagremoteinfo;
+	int             opt, flagremoteinfo, dummy;
+	char            temp[IPFMT + FMT_ULONG];
 	unsigned long   timeout;
 #ifdef USE_SPF
 	strsalloc       ssa = { 0 };
@@ -334,7 +333,7 @@ main(argc, argv)
 void
 getversion_tcp_env_c()
 {
-	static char    *x = "$Id: tcp-env.c,v 1.13 2021-07-07 08:53:42+05:30 Cprogrammer Exp mbhangui $";
+	static char    *x = "$Id: tcp-env.c,v 1.14 2021-08-29 23:27:08+05:30 Cprogrammer Exp mbhangui $";
 
 	x++;
 }

--- a/indimail-mta-x/testzero.c
+++ b/indimail-mta-x/testzero.c
@@ -1,5 +1,8 @@
 /*
  * $Log: testzero.c,v $
+ * Revision 1.3  2021-08-29 23:27:08+05:30  Cprogrammer
+ * define funtions as noreturn
+ *
  * Revision 1.2  2020-11-24 13:48:40+05:30  Cprogrammer
  * removed exit.h
  *
@@ -8,27 +11,28 @@
  *
  */
 #include <unistd.h>
-#include "uint32.h"
-#include "scan.h"
-#include "strerr.h"
-#include "cdb_make.h"
+#include <uint32.h>
+#include <scan.h>
+#include <strerr.h>
+#include <cdb_make.h>
+#include <noreturn.h>
 
 #define FATAL "testzero: fatal: "
 
-void
+no_return void
 die_write(void)
 {
 	strerr_die2sys(111, FATAL, "unable to write: ");
 }
 
-static char     key[4];
-static char     data[65536];
-struct cdb_make c;
 
 int
 main(int argc, char **argv)
 {
 	unsigned long   loop;
+	char            key[4];
+	char            data[65536];
+	struct          cdb_make c;
 
 	if (!*argv)
 		_exit(0);
@@ -50,7 +54,7 @@ main(int argc, char **argv)
 void
 getversion_testzero_c()
 {
-	static char    *x = "$Id: testzero.c,v 1.2 2020-11-24 13:48:40+05:30 Cprogrammer Exp mbhangui $";
+	static char    *x = "$Id: testzero.c,v 1.3 2021-08-29 23:27:08+05:30 Cprogrammer Exp mbhangui $";
 
 	x++;
 }

--- a/indimail-mta-x/tls.c
+++ b/indimail-mta-x/tls.c
@@ -1,5 +1,8 @@
 /*
  * $Log: tls.c,v $
+ * Revision 1.9  2021-08-29 23:27:08+05:30  Cprogrammer
+ * define funtions as noreturn
+ *
  * Revision 1.8  2021-05-26 10:47:57+05:30  Cprogrammer
  * replaced strerror() with error_str()
  *
@@ -29,13 +32,14 @@
 #include "error.h"
 #include <unistd.h>
 #include <string.h>
+#include <noreturn.h>
 #include <openssl/ssl.h>
 #include <openssl/err.h>
 
 int             smtps = 0;
 SSL            *ssl = NULL;
 
-void
+no_return void
 ssl_exit(int status)
 {
 	if (ssl) {
@@ -84,7 +88,7 @@ ssl_strerror()
 void
 getversion_tls_c()
 {
-	static char    *x = "$Id: tls.c,v 1.8 2021-05-26 10:47:57+05:30 Cprogrammer Exp mbhangui $";
+	static char    *x = "$Id: tls.c,v 1.9 2021-08-29 23:27:08+05:30 Cprogrammer Exp mbhangui $";
 
 	x++;
 }

--- a/indimail-mta-x/tokenize.c
+++ b/indimail-mta-x/tokenize.c
@@ -1,5 +1,8 @@
 /*
  * $Log: tokenize.c,v $
+ * Revision 1.3  2021-08-29 23:27:08+05:30  Cprogrammer
+ * define funtions as noreturn
+ *
  * Revision 1.2  2004-10-22 20:31:49+05:30  Cprogrammer
  * added RCS id
  *
@@ -8,24 +11,23 @@
  *
  */
 #include <unistd.h>
-#include "substdio.h"
-#include "strerr.h"
-#include "subfd.h"
-#include "getln.h"
-#include "mess822.h"
+#include <substdio.h>
+#include <strerr.h>
+#include <subfd.h>
+#include <getln.h>
+#include <mess822.h>
+#include <noreturn.h>
 
 #define FATAL "tokenize: fatal: "
 
-void
+no_return void
 nomem()
 {
 	strerr_die2x(111, FATAL, "out of memory");
 }
 
 void
-myput(buf, len)
-	char           *buf;
-	int             len;
+myput(char *buf, int len)
 {
 	char            ch;
 
@@ -40,19 +42,14 @@ myput(buf, len)
 	}
 }
 
-stralloc        line = { 0 };
-int             match;
-
-stralloc        tokens = { 0 };
 
 int
 main()
 {
-	int             i;
-	int             j;
+	int             i, j, match;
+	stralloc        line = { 0 }, tokens = { 0 };
 
-	for (;;)
-	{
+	for (;;) {
 		if (getln(subfdin, &line, &match, '\n') == -1)
 			strerr_die2sys(111, FATAL, "unable to read input: ");
 		if (!line.len)
@@ -69,40 +66,35 @@ main()
 		if (!mess822_token(&tokens, line.s))
 			nomem();
 
-		for (j = i = 0; j < tokens.len; ++j)
-			if (!tokens.s[j])
-			{
+		for (j = i = 0; j < tokens.len; ++j) {
+			if (!tokens.s[j]) {
 				if (tokens.s[i] == ' ')
 					substdio_puts(subfdout, "space\n");
 				else
 				if (tokens.s[i] == '\t')
 					substdio_puts(subfdout, "tab\n");
 				else
-				if (tokens.s[i] == '=')
-				{
+				if (tokens.s[i] == '=') {
 					substdio_puts(subfdout, "string {");
 					myput(tokens.s + i + 1, j - i - 1);
 					substdio_puts(subfdout, "}\n");
 				} else
-				if (tokens.s[i] == '(')
-				{
+				if (tokens.s[i] == '(') {
 					substdio_puts(subfdout, "comment {");
 					myput(tokens.s + i + 1, j - i - 1);
 					substdio_puts(subfdout, "}\n");
-				} else
-				{
+				} else {
 					substdio_puts(subfdout, "special ");
 					myput(tokens.s + i, j - i);
 					substdio_puts(subfdout, "\n");
 				}
 				i = j + 1;
 			}
-
+		}
 		substdio_puts(subfdout, "\n");
 		if (!match)
 			break;
 	}
-
 	substdio_flush(subfdout);
 	_exit(0);
 }
@@ -110,7 +102,7 @@ main()
 void
 getversion_tokenize_c()
 {
-	static char    *x = "$Id: tokenize.c,v 1.2 2004-10-22 20:31:49+05:30 Cprogrammer Stab mbhangui $";
+	static char    *x = "$Id: tokenize.c,v 1.3 2021-08-29 23:27:08+05:30 Cprogrammer Exp mbhangui $";
 
 	x++;
 }

--- a/indimail-mta-x/uacl.c
+++ b/indimail-mta-x/uacl.c
@@ -1,5 +1,8 @@
 /*
  * $Log: uacl.c,v $
+ * Revision 1.7  2021-08-29 23:27:08+05:30  Cprogrammer
+ * define funtions as noreturn
+ *
  * Revision 1.6  2021-06-13 17:36:34+05:30  Cprogrammer
  * removed chdir(auto_qmail)
  *
@@ -26,6 +29,7 @@
 #include <env.h>
 #include <subfd.h>
 #include <strerr.h>
+#include <noreturn.h>
 #include "qregex.h"
 #include "control.h"
 #include "matchregex.h"
@@ -33,11 +37,6 @@
 #include "wildmat.h"
 
 #define FATAL "uacl: fatal: "
-
-/*- accesslist */
-int             acclistok = 0;
-static stralloc acclist = { 0 };
-int             qregex = 0;
 
 void
 out(char *str)
@@ -57,7 +56,7 @@ flush()
 	return;
 }
 
-void
+no_return void
 die_control()
 {
 	substdio_putsflush(subfderr, "uacl: unable to read controls (#4.3.0)\n");
@@ -65,7 +64,7 @@ die_control()
 	_exit(111);
 }
 
-void
+no_return void
 die_nomem()
 {
 	substdio_putsflush(subfderr, "uacl: out of memory\n");
@@ -73,7 +72,7 @@ die_nomem()
 	_exit(111);
 }
 
-void
+no_return void
 die_usage()
 {
 	substdio_putsflush(subfderr, "usage: uacl sender recipient\n");
@@ -81,7 +80,7 @@ die_usage()
 	_exit(111);
 }
 
-void
+no_return void
 die_regex(char *str)
 {
 	substdio_puts(subfderr, "uacl: regex failed: ");
@@ -96,7 +95,8 @@ int
 main(int argc, char **argv)
 {
 	char           *x;
-	int             i;
+	int             i, qregex = 0, acclistok = 0;
+	stralloc        acclist = { 0 };
 
 	if (argc != 3)
 		die_usage();
@@ -117,7 +117,7 @@ main(int argc, char **argv)
 void
 getversion_uacl_c()
 {
-	static char    *x = "$Id: uacl.c,v 1.6 2021-06-13 17:36:34+05:30 Cprogrammer Exp mbhangui $";
+	static char    *x = "$Id: uacl.c,v 1.7 2021-08-29 23:27:08+05:30 Cprogrammer Exp mbhangui $";
 
 	x = sccsidwildmath;
 	x++;

--- a/indimail-mta-x/udplogger.c
+++ b/indimail-mta-x/udplogger.c
@@ -1,5 +1,8 @@
 /*
  * $Log: udplogger.c,v $
+ * Revision 1.6  2021-08-29 23:27:08+05:30  Cprogrammer
+ * define funtions as noreturn
+ *
  * Revision 1.5  2020-09-16 19:09:07+05:30  Cprogrammer
  * FreeBSD fix
  *
@@ -28,30 +31,16 @@
 #define __USE_GNU
 #include <netdb.h>
 #include <errno.h>
+#include <sgetopt.h>
+#include <subfd.h>
+#include <strerr.h>
+#include <sig.h>
+#include <fmt.h>
+#include <scan.h>
+#include <byte.h>
+#include <error.h>
+#include <noreturn.h>
 #include "haveip6.h"
-#include "sgetopt.h"
-#include "subfd.h"
-#include "strerr.h"
-#include "sig.h"
-#include "fmt.h"
-#include "scan.h"
-#include "byte.h"
-#include "error.h"
-
-union sockunion
-{
-	struct sockaddr     sa;
-	struct sockaddr_in  sa4;
-#ifdef IPV6
-	struct sockaddr_in6 sa6;
-#endif
-};
-
-#if defined(LIBC_HAS_IP6) && defined(IPV6)
-int             noipv6 = 0;
-#else
-int             noipv6 = 1;
-#endif
 
 #define DYNAMIC_BUF 1
 #define MAXLOGDATASIZE 2000
@@ -62,9 +51,17 @@ int             noipv6 = 1;
 #define FATAL "udplogger: fatal: "
 #define WARN  "udplogger: warning: "
 
-unsigned long   seqno;
+union sockunion
+{
+	struct sockaddr     sa;
+	struct sockaddr_in  sa4;
+#ifdef IPV6
+	struct sockaddr_in6 sa6;
+#endif
+};
+static unsigned long seqno;
 
-void
+no_return void
 die_nomem()
 {
 	if (substdio_flush(subfdout) == -1)
@@ -78,7 +75,7 @@ die_nomem()
 	_exit(1);
 }
 
-void
+no_return void
 die_write()
 {
 	if (substdio_flush(subfdout) == -1)
@@ -149,7 +146,7 @@ sigusr1()
 	return;
 }
 
-void
+no_return void
 sigterm()
 {
 	sig_block(SIGTERM);
@@ -158,8 +155,6 @@ sigterm()
 	_exit(0);
 }
 
-char           *usage = "usage: udplogger [-t timeout] [-p port] ipaddr:port";
-
 int
 main(int argc, char **argv)
 {
@@ -167,7 +162,13 @@ main(int argc, char **argv)
 	char            strnum[FMT_ULONG];
 	unsigned long   timeout;
 	char           *ipaddr = 0;
+	char           *usage = "usage: udplogger [-t timeout] [-p port] ipaddr:port";
 	char            serv[FMT_ULONG];
+#if defined(LIBC_HAS_IP6) && defined(IPV6)
+	int             noipv6 = 0;
+#else
+	int             noipv6 = 1;
+#endif
 #ifdef DYNAMIC_BUF
 	char           *rdata = 0, *buf = 0;
 	int             bufsize = MAXLOGDATASIZE;
@@ -393,7 +394,7 @@ main(int argc, char **argv)
 void
 getversion_udplogger_c()
 {
-	static char    *x = "$Id: udplogger.c,v 1.5 2020-09-16 19:09:07+05:30 Cprogrammer Exp mbhangui $";
+	static char    *x = "$Id: udplogger.c,v 1.6 2021-08-29 23:27:08+05:30 Cprogrammer Exp mbhangui $";
 
 	x++;
 }

--- a/indimail-mta-x/whois.c
+++ b/indimail-mta-x/whois.c
@@ -1,5 +1,8 @@
 /*
  * $Log: whois.c,v $
+ * Revision 1.4  2021-08-29 23:27:08+05:30  Cprogrammer
+ * define funtions as noreturn
+ *
  * Revision 1.3  2018-05-30 12:10:23+05:30  Cprogrammer
  * fixed newline getting appended to whois server variable
  *
@@ -22,19 +25,22 @@
 #include <unistd.h>
 #include <sys/types.h>
 #include <sys/socket.h>
-#include "subfd.h"
-#include "sgetopt.h"
-#include "strerr.h"
-#include "str.h"
+#include <subfd.h>
+#include <sgetopt.h>
+#include <strerr.h>
+#include <str.h>
+#include <stralloc.h>
+#include <noreturn.h>
 #include "tcpopen.h"
-#include "stralloc.h"
 
 #define FATAL "whois: fatal: "
 
-int     verbose;
-
 int		get_whois_data(char *);
 int		whois_query(char *, char *, stralloc *);
+
+static int      verbose;
+static stralloc whois_server = {0}, response_1 = {0},
+				response_2 = {0}, message = {0};
 
 void
 out(char *str)
@@ -54,7 +60,7 @@ flush()
 	return;
 }
 
-void
+no_return void
 die_nomem()
 {
 	substdio_flush(subfdout);
@@ -102,13 +108,11 @@ main(int argc, char **argv)
 	return (get_whois_data(arg));
 }
 
-stralloc whois_server = {0};
-
 char *
 str_whois(char *resp, int resp_len)
 {
-	char		*pch, *wch;
-	int          len;
+	char		   *pch, *wch;
+	int             len;
 
 	whois_server.len = 0;
 	if ((pch = strstr(resp, "whois."))) {
@@ -128,8 +132,6 @@ str_whois(char *resp, int resp_len)
 /*
  * Get the whois data of a domain
  */
-stralloc response_1 = {0}, response_2 = {0};
-
 int
 get_whois_data(char *domain)
 {
@@ -217,8 +219,6 @@ get_whois_data(char *domain)
 /*
  * Perform a whois query to a server and record the response
  */
-stralloc        message = {0};
-
 int
 whois_query(char *server, char *query, stralloc *response)
 {
@@ -255,7 +255,7 @@ whois_query(char *server, char *query, stralloc *response)
 void
 getversion_whois_c()
 {
-	static char    *x = "$Id: whois.c,v 1.3 2018-05-30 12:10:23+05:30 Cprogrammer Exp mbhangui $";
+	static char    *x = "$Id: whois.c,v 1.4 2021-08-29 23:27:08+05:30 Cprogrammer Exp mbhangui $";
 
 	x++;
 }


### PR DESCRIPTION
1. include noreturn.h from libqmail defining macro no_return
2. use no_return macro to declare funtions that do not return back to caller