### PR TITLE
ucspi-tcp - define functions not returning as no_return

### DIFF
--- a/ucspi-tcp-x/dotls.c
+++ b/ucspi-tcp-x/dotls.c
@@ -1,5 +1,8 @@
 /*
  * $Log: dotls.c,v $
+ * Revision 1.7  2021-08-30 12:47:59+05:30  Cprogrammer
+ * define funtions as noreturn
+ *
  * Revision 1.6  2021-05-12 21:01:23+05:30  Cprogrammer
  * replace pathexec() with upathexec()
  *
@@ -42,6 +45,7 @@
 #include <gen_allocdefs.h>
 #include <getln.h>
 #include <timeoutwrite.h>
+#include <noreturn.h>
 #include "upathexec.h"
 #include "tls.h"
 
@@ -49,7 +53,7 @@
 #define HUGECAPATEXT  5000
 
 #ifndef	lint
-static char     sccsid[] = "$Id: dotls.c,v 1.6 2021-05-12 21:01:23+05:30 Cprogrammer Exp mbhangui $";
+static char     sccsid[] = "$Id: dotls.c,v 1.7 2021-08-30 12:47:59+05:30 Cprogrammer Exp mbhangui $";
 #endif
 
 int             do_bulk();
@@ -62,22 +66,22 @@ void            flush_data();
 void            flush_io();
 void            flush();
 
-struct substdio ssin, ssto, smtpin, smtpto;
-unsigned long   dtimeout = 60;
-stralloc        certfile;
-stralloc        capatext;
-stralloc        sauninit;
-stralloc        line;
-char            strnum[FMT_ULONG];
-int             linemode = 1;
 struct scommd
 {
 	char           *text;
 	int             (*fun) (char *, char *, int);
 	void            (*flush) (void);
 };
+static substdio ssin, ssto, smtpin, smtpto;
+static unsigned long   dtimeout = 60;
+static stralloc certfile;
+static stralloc capatext;
+static stralloc sauninit;
+static stralloc line;
+static char     strnum[FMT_ULONG];
+static int      linemode = 1;
 
-void
+no_return void
 usage(void)
 {
 	strerr_die1x(100, "usage: dotls"

--- a/ucspi-tcp-x/fixcrio.c
+++ b/ucspi-tcp-x/fixcrio.c
@@ -1,5 +1,8 @@
 /*
  * $Log: fixcrio.c,v $
+ * Revision 1.4  2021-08-30 12:47:59+05:30  Cprogrammer
+ * define funtions as noreturn
+ *
  * Revision 1.3  2021-05-12 21:01:51+05:30  Cprogrammer
  * replace pathexec() with upathexec()
  *
@@ -12,28 +15,29 @@
  */
 #include <unistd.h>
 #include <signal.h>
-#include "sig.h"
-#include "strerr.h"
-#include "byte.h"
+#include <sig.h>
+#include <strerr.h>
+#include <byte.h>
+#include <fd.h>
+#include <noreturn.h>
 #include "iopause.h"
 #include "upathexec.h"
-#include "fd.h"
 
 #define FATAL "fixcrio: fatal: "
 
-char            prebuf[256];
-int             leftstatus = 0;
-char            leftbuf[512];
-int             leftlen;
-int             leftpos;
-int             leftflagcr = 0;
-int             rightstatus = 0;
-char            rightbuf[512];
-int             rightlen;
-int             rightpos;
-int             rightflagcr = 0;
+static char     prebuf[256];
+static char     leftbuf[512];
+static char     rightbuf[512];
+static int      leftstatus = 0;
+static int      leftlen;
+static int      leftpos;
+static int      leftflagcr = 0;
+static int      rightstatus = 0;
+static int      rightlen;
+static int      rightpos;
+static int      rightflagcr = 0;
 
-void
+no_return void
 doit(int fdleft, int fdright)
 {
 	struct taia     stamp;
@@ -48,33 +52,28 @@ doit(int fdleft, int fdright)
 	int             i;
 	char            ch;
 
-	for (;;)
-	{
+	for (;;) {
 		xlen = 0;
 		io0 = 0;
-		if (leftstatus == 0)
-		{
+		if (leftstatus == 0) {
 			io0 = &x[xlen++];
 			io0->fd = 0;
 			io0->events = IOPAUSE_READ;
 		}
 		ioleft = 0;
-		if (leftstatus == 1)
-		{
+		if (leftstatus == 1) {
 			ioleft = &x[xlen++];
 			ioleft->fd = fdleft;
 			ioleft->events = IOPAUSE_WRITE;
 		}
 		ioright = 0;
-		if (rightstatus == 0)
-		{
+		if (rightstatus == 0) {
 			ioright = &x[xlen++];
 			ioright->fd = fdright;
 			ioright->events = IOPAUSE_READ;
 		}
 		io1 = 0;
-		if (rightstatus == 1)
-		{
+		if (rightstatus == 1) {
 			io1 = &x[xlen++];
 			io1->fd = 1;
 			io1->events = IOPAUSE_WRITE;
@@ -83,20 +82,15 @@ doit(int fdleft, int fdright)
 		taia_uint(&deadline, 3600);
 		taia_add(&deadline, &stamp, &deadline);
 		iopause(x, xlen, &deadline, &stamp);
-		if (io0 && io0->revents)
-		{
-			r = read(0, prebuf, sizeof prebuf);
-			if (r <= 0)
-			{
+		if (io0 && io0->revents) {
+			if ((r = read(0, prebuf, sizeof prebuf)) <= 0) {
 				leftstatus = -1;
 				close(fdleft);
-			} else
-			{
+			} else {
 				leftstatus = 1;
 				leftpos = 0;
 				leftlen = 0;
-				for (i = 0; i < r; ++i)
-				{
+				for (i = 0; i < r; ++i) {
 					ch = prebuf[i];
 					if (ch == '\n')
 						if (!leftflagcr)
@@ -106,25 +100,20 @@ doit(int fdleft, int fdright)
 				}
 			}
 		}
-		if (ioleft && ioleft->revents)
-		{
-			r = write(fdleft, leftbuf + leftpos, leftlen - leftpos);
-			if (r == -1)
+		if (ioleft && ioleft->revents) {
+			if ((r = write(fdleft, leftbuf + leftpos, leftlen - leftpos)) == -1)
 				break;
 			leftpos += r;
 			if (leftpos == leftlen)
 				leftstatus = 0;
 		}
-		if (ioright && ioright->revents)
-		{
-			r = read(fdright, prebuf, sizeof prebuf);
-			if (r <= 0)
+		if (ioright && ioright->revents) {
+			if ((r = read(fdright, prebuf, sizeof prebuf)) <= 0)
 				break;
 			rightstatus = 1;
 			rightpos = 0;
 			rightlen = 0;
-			for (i = 0; i < r; ++i)
-			{
+			for (i = 0; i < r; ++i) {
 				ch = prebuf[i];
 				if (ch == '\n')
 					if (!rightflagcr)
@@ -133,10 +122,8 @@ doit(int fdleft, int fdright)
 				rightflagcr = (ch == '\r');
 			}
 		}
-		if (io1 && io1->revents)
-		{
-			r = write(1, rightbuf + rightpos, rightlen - rightpos);
-			if (r == -1)
+		if (io1 && io1->revents) {
+			if ((r = write(1, rightbuf + rightpos, rightlen - rightpos)) == -1)
 				break;
 			rightpos += r;
 			if (rightpos == rightlen)
@@ -183,7 +170,7 @@ main(int argc, char **argv, char **envp)
 void
 getversion_fixcrio_c()
 {
-	static char    *x = "$Id: fixcrio.c,v 1.3 2021-05-12 21:01:51+05:30 Cprogrammer Exp mbhangui $";
+	static char    *x = "$Id: fixcrio.c,v 1.4 2021-08-30 12:47:59+05:30 Cprogrammer Exp mbhangui $";
 
 	x++;
 }

--- a/ucspi-tcp-x/installer.c
+++ b/ucspi-tcp-x/installer.c
@@ -1,5 +1,8 @@
 /*
  * $Log: installer.c,v $
+ * Revision 1.19  2021-08-29 23:27:08+05:30  Cprogrammer
+ * define funtions as noreturn
+ *
  * Revision 1.18  2021-08-05 20:52:44+05:30  Cprogrammer
  * fixed bug of skipping files in check mode
  *
@@ -76,6 +79,7 @@
 #include <byte.h>
 #include <scan.h>
 #include <fmt.h>
+#include <noreturn.h>
 
 static stralloc target = { 0 };
 static char    *user, *group, *to;
@@ -86,7 +90,7 @@ static substdio ssin, ssout;
 static uid_t    my_uid;
 static int      dofix, missing_ok, create_paths;
 
-void
+no_return void
 nomem()
 {
 	strerr_die2x(111, FATAL, "out of memory");
@@ -527,7 +531,7 @@ doit(stralloc *line, int uninstall, int check)
 
 }
 
-void
+no_return void
 die_usage()
 {
 	const char     *usage_str =
@@ -595,7 +599,7 @@ main(int argc, char **argv)
 void
 getversion_installer_c()
 {
-	static const char *x = "$Id: installer.c,v 1.18 2021-08-05 20:52:44+05:30 Cprogrammer Exp mbhangui $";
+	static const char *x = "$Id: installer.c,v 1.19 2021-08-29 23:27:08+05:30 Cprogrammer Exp mbhangui $";
 
 	if (x)
 		x++;

--- a/ucspi-tcp-x/rblsmtpd.c
+++ b/ucspi-tcp-x/rblsmtpd.c
@@ -1,5 +1,8 @@
 /*
  * $Log: rblsmtpd.c,v $
+ * Revision 1.24  2021-08-30 12:47:59+05:30  Cprogrammer
+ * define funtions as noreturn
+ *
  * Revision 1.23  2021-05-12 21:03:37+05:30  Cprogrammer
  * replace pathexec with upathexec
  *
@@ -23,7 +26,7 @@
  * replace environ with envp to pass full environment variable list in tcpserver to rbl()
  *
  * Revision 1.16  2017-03-30 22:59:08+05:30  Cprogrammer
- * prefix rbl with ip6_scan(), dns_txt(), smtp_mail(), smtp_rcpt(), smtpcommands - avoid duplicate symb in rblsmtpd.so with qmail_smtpd.so
+ * prefix ip6_scan(), dns_txt(), smtp_mail(), smtp_rcpt(), smtpcommands with rbl - avoid duplicate symb in rblsmtpd.so with qmail_smtpd.so
  *
  * Revision 1.15  2017-03-01 22:52:13+05:30  Cprogrammer
  * reset optind as it gets called in tcpserver and rblsmtpd.so might be loaded as shared object
@@ -93,27 +96,28 @@
 #ifdef IPV6
 #include "ip6.h"
 #endif
+#include <noreturn.h>
 
 #define FATAL "rblsmtpd: fatal: "
 
 #ifndef	lint
-static char     sccsid[] = "$Id: rblsmtpd.c,v 1.23 2021-05-12 21:03:37+05:30 Cprogrammer Exp mbhangui $";
+static char     sccsid[] = "$Id: rblsmtpd.c,v 1.24 2021-08-30 12:47:59+05:30 Cprogrammer Exp mbhangui $";
 #endif
 
-void
+no_return void
 nomem(void)
 {
 	strerr_die2x(111, FATAL, "out of memory");
 }
 
-void
+no_return void
 usage(void)
 {
 	strerr_die1x(100, "usage: rblsmtpd -r base [ -b ] [ -R ] [ -t timeout ] [ -a base ] [-W] [-w delay] smtpd [ arg ... ]");
 }
 
-char           *ip_env, *rbl_greeting, *rbl_ehlo;
-char            pid_str[FMT_ULONG] = "?PID?";
+static char    *ip_env, *rbl_greeting, *rbl_ehlo;
+static char     pid_str[FMT_ULONG] = "?PID?";
 static stralloc addr = { 0 };
 static stralloc ip_reverse;
 
@@ -497,7 +501,7 @@ greet()
 }
 
 void
-quit()
+no_return quit()
 {
   substdio_put(&out, "221 ", 4);
   substdio_puts(&out, rbl_greeting);
@@ -505,7 +509,7 @@ quit()
   _exit(0);
 }
 
-void
+no_return void
 drop()
 {
 	_exit(0);
@@ -523,7 +527,7 @@ struct commands rbl_smtpcommands[] = {
 	{0, reject, 0}
 };
 
-void
+no_return void
 rblsmtpd_f(void)
 {
 	int             i;
@@ -560,7 +564,7 @@ rblsmtpd_f(void)
 	_exit(0);
 }
 
-int
+no_return void
 rblsmtpd(int argc, char **argv, char **envp)
 {
 	int             flagwantdefaultrbl = 1;
@@ -661,15 +665,13 @@ rblsmtpd(int argc, char **argv, char **envp)
 		rblsmtpd_f();
 	upathexec_run(*argv, argv, envp);
 	strerr_die4sys(111, FATAL, "unable to run ", *argv, ": ");
-	/*- Not reached */
-	return (0);
 }
 
 #ifdef MAIN
 int
 main(int argc, char **argv, char **envp)
 {
-	return (rblsmtpd(argc, argv, envp));
+	rblsmtpd(argc, argv, envp);
 }
 #endif
 

--- a/ucspi-tcp-x/recordio.c
+++ b/ucspi-tcp-x/recordio.c
@@ -1,5 +1,8 @@
 /*
  * $Log: recordio.c,v $
+ * Revision 1.4  2021-08-30 12:47:59+05:30  Cprogrammer
+ * define funtions as noreturn
+ *
  * Revision 1.3  2021-05-12 21:03:45+05:30  Cprogrammer
  * replace pathexec with upathexec
  *
@@ -11,38 +14,44 @@
  *
  */
 #include <unistd.h>
-#include "sig.h"
-#include "substdio.h"
-#include "strerr.h"
-#include "str.h"
-#include "byte.h"
-#include "fmt.h"
+#include <sig.h>
+#include <substdio.h>
+#include <strerr.h>
+#include <str.h>
+#include <byte.h>
+#include <fmt.h>
+#include <fd.h>
+#include <noreturn.h>
 #include "iopause.h"
-#include "fd.h"
 #include "upathexec.h"
 
 #define FATAL "recordio: fatal: "
 
-char            pid[FMT_ULONG];
-
-char            recordbuf[512];
-substdio        ssrecord = SUBSTDIO_FDBUF(write, 2, recordbuf, sizeof recordbuf);
+static char     pid[FMT_ULONG];
+static char     recordbuf[512];
+static char     leftbuf[256];
+static char     rightbuf[256];
+static substdio ssrecord = SUBSTDIO_FDBUF(write, 2, recordbuf, sizeof recordbuf);
+static int      leftstatus = 0;
+static int      leftlen;
+static int      leftpos;
+static int      rightstatus = 0;
+static int      rightlen;
+static int      rightpos;
 
 void
 record(char *buf, int len, char *direction)	/*- 1 <= len <= 256 */
 {
 	int             i;
 
-	while (len)
-	{
+	while (len) {
 		substdio_puts(&ssrecord, pid);
 		substdio_puts(&ssrecord, direction);
 
 		i = byte_chr(buf, len, '\n');
 		substdio_put(&ssrecord, buf, i);
 
-		if (i == len)
-		{
+		if (i == len) {
 			substdio_puts(&ssrecord, "+\n");
 			substdio_flush(&ssrecord);
 			return;
@@ -55,18 +64,8 @@ record(char *buf, int len, char *direction)	/*- 1 <= len <= 256 */
 	}
 }
 
-int             leftstatus = 0;
-char            leftbuf[256];
-int             leftlen;
-int             leftpos;
-
-int             rightstatus = 0;
-char            rightbuf[256];
-int             rightlen;
-int             rightpos;
-
 /*- copy 0 -> fdleft, copy fdright -> 1 */
-void
+no_return void
 doit(int fdleft, int fdright)
 {
 	struct taia     stamp;
@@ -211,7 +210,7 @@ main(int argc, char **argv, char **envp)
 void
 getversion_recordio_c()
 {
-	static char    *x = "$Id: recordio.c,v 1.3 2021-05-12 21:03:45+05:30 Cprogrammer Exp mbhangui $";
+	static char    *x = "$Id: recordio.c,v 1.4 2021-08-30 12:47:59+05:30 Cprogrammer Exp mbhangui $";
 
 	x++;
 }

--- a/ucspi-tcp-x/tcpclient.c
+++ b/ucspi-tcp-x/tcpclient.c
@@ -1,5 +1,8 @@
 /*
  * $Log: tcpclient.c,v $
+ * Revision 1.21  2021-08-30 12:47:59+05:30  Cprogrammer
+ * define funtions as noreturn
+ *
  * Revision 1.20  2021-05-12 21:04:42+05:30  Cprogrammer
  * replaced pathexec with upathexec
  *
@@ -104,22 +107,23 @@
 #include <getln.h>
 #include <ndelay.h>
 #endif
+#include <noreturn.h>
 
 #define FATAL "tcpclient: fatal: "
 
 #ifndef	lint
-static char     sccsid[] = "$Id: tcpclient.c,v 1.20 2021-05-12 21:04:42+05:30 Cprogrammer Exp mbhangui $";
+static char     sccsid[] = "$Id: tcpclient.c,v 1.21 2021-08-30 12:47:59+05:30 Cprogrammer Exp mbhangui $";
 #endif
 
 extern int      socket_tcpnodelay(int);
 
-void
+no_return void
 nomem(void)
 {
 	strerr_die2x(111, FATAL, "out of memory");
 }
 
-void
+no_return void
 usage(void)
 {
 	strerr_die1x(100, "usage: tcpclient"
@@ -146,39 +150,39 @@ usage(void)
 	 " host port [program]");
 }
 
-int             verbosity = 1;
-int             flagdelay = 1;
-int             flagremoteinfo = 1;
-int             flagremotehost = 1;
-unsigned long   itimeout = 26;
-unsigned long   ctimeout[2] = { 2, 58 };
-unsigned long   dtimeout = 300;
+static int      verbosity = 1;
+static int      flagdelay = 1;
+static int      flagremoteinfo = 1;
+static int      flagremotehost = 1;
+static unsigned long   itimeout = 26;
+static unsigned long   ctimeout[2] = { 2, 58 };
+static unsigned long   dtimeout = 300;
 #ifdef IPV6
-int             forcev6;
-char            iplocal[16] = {0,0,0,0, 0,0,0,0, 0,0,0,0, 0,0,0,0};
-char            ipremote[16];
-char            ipstr[IP6_FMT];
-uint32          netif;
+static int      forcev6;
+static char     iplocal[16] = {0,0,0,0, 0,0,0,0, 0,0,0,0, 0,0,0,0};
+static char     ipremote[16];
+static char     ipstr[IP6_FMT];
+static uint32   netif;
 #else
-char            iplocal[4] = {0, 0, 0, 0};
-char            ipremote[4];
-char            ipstr[IP4_FMT];
+static char     iplocal[4] = {0, 0, 0, 0};
+static char     ipremote[4];
+static char     ipstr[IP4_FMT];
 #endif
-uint16          portlocal;
-char           *forcelocal;
-uint16          portremote;
-char           *hostname;
+static uint16   portlocal;
+static uint16   portremote;
+static char    *forcelocal;
+static char    *hostname;
 static stralloc addresses;
 static stralloc moreaddresses;
 static stralloc tmp;
 static stralloc fqdn;
-char            strnum[FMT_ULONG], strnum2[FMT_ULONG];
-char            seed[128];
+static char     strnum[FMT_ULONG], strnum2[FMT_ULONG];
+static char     seed[128];
 #ifdef TLS
-struct stralloc certfile;
+static struct stralloc certfile;
 #endif
 
-void
+no_return void
 sigterm()
 {
 	_exit(0);

--- a/ucspi-tcp-x/tcprulescheck.c
+++ b/ucspi-tcp-x/tcprulescheck.c
@@ -1,5 +1,8 @@
 /*
  * $Log: tcprulescheck.c,v $
+ * Revision 1.5  2021-08-30 12:47:59+05:30  Cprogrammer
+ * define funtions as noreturn
+ *
  * Revision 1.4  2020-08-03 17:27:59+05:30  Cprogrammer
  * replaced buffer with substdio
  *
@@ -20,9 +23,10 @@
 #include <env.h>
 #include <open.h>
 #include <unistd.h>
+#include <noreturn.h>
 #include "rules.h"
 
-void
+no_return void
 found(char *data, unsigned int datalen)
 {
 	unsigned int    next0;

--- a/ucspi-tcp-x/tcpserver.c
+++ b/ucspi-tcp-x/tcpserver.c
@@ -1,5 +1,8 @@
 /*
  * $Log: tcpserver.c,v $
+ * Revision 1.76  2021-08-30 12:47:59+05:30  Cprogrammer
+ * define funtions as noreturn
+ *
  * Revision 1.75  2021-06-15 08:24:25+05:30  Cprogrammer
  * renamed pathexec.. functions to upathexec to avoid clash with libqmail
  *
@@ -235,6 +238,7 @@
 #include <error.h>
 #include <strerr.h>
 #include <sig.h>
+#include <noreturn.h>
 #ifdef DARWIN
 #define opteof -1
 #else
@@ -255,7 +259,7 @@
 #include "auto_home.h"
 
 #ifndef	lint
-static char     sccsid[] = "$Id: tcpserver.c,v 1.75 2021-06-15 08:24:25+05:30 Cprogrammer Exp mbhangui $";
+static char     sccsid[] = "$Id: tcpserver.c,v 1.76 2021-08-30 12:47:59+05:30 Cprogrammer Exp mbhangui $";
 #endif
 
 #ifdef IPV6
@@ -345,7 +349,7 @@ static int      flagdeny;
 static int      flagallownorules;
 static char    *fnrules;
 
-void
+no_return void
 drop_nomem(void)
 {
 	strerr_die2sys(111, DROP, "out of memory");
@@ -398,7 +402,7 @@ env(char *s, char *t)
 		drop_nomem();
 }
 
-void
+no_return void
 drop_rules(void)
 {
 	strerr_die4sys(111, DROP, "unable to read ", fnrules, ": ");
@@ -1078,7 +1082,7 @@ done:
 }
 #endif /*- #ifdef HAS_MYSQL */
 
-void
+no_return void
 usage(void)
 {
 	strerr_warn1(
@@ -1270,7 +1274,7 @@ print_ip()
 	return;
 }
 
-void
+no_return void
 sigterm()
 {
 	_exit(0);


### PR DESCRIPTION
1. include noreturn.h from libqmail defining macro no_return
2. use no_return macro to declare funtions that do not return back to caller