### PR TITLE
Qmail queue error codes

### DIFF
--- a/indimail-mta-x/Makefile
+++ b/indimail-mta-x/Makefile
@@ -1330,7 +1330,7 @@ auto_qmail.o custom_error.o getqueue.o dns.lib socket.lib rt.lib
 	$(dynamic_option) `cat dns.lib socket.lib rt.lib`
 
 qmail-multi.o: \
-compile qmail-multi.c qmulti.h mailfilter.h conf-queue
+compile qmail-multi.c qmulti.h qmail.h mailfilter.h conf-queue
 	./compile `grep -h -v "^#" conf-queue` qmail-multi.c
 
 qmail-multi.8: \
@@ -1349,7 +1349,7 @@ custom_error.o getqueue.o rt.lib
 	$(dynamic_option) `cat rt.lib`
 
 qmail-spamfilter.o: \
-compile qmail-spamfilter.c qmulti.h
+compile qmail-spamfilter.c qmulti.h qmail.h
 	./compile qmail-spamfilter.c
 
 qmail-spamfilter.8: \
@@ -1361,11 +1361,12 @@ qmail-spamfilter.9 conf-prefix conf-qmail
 
 qmulti.o: \
 compile qmulti.c auto_qmail.h control.h qmulti.h qmail.h \
-auto_prefix.h qscheduler.h custom_error.h haslibrt.h conf-queue
+auto_prefix.h qscheduler.h custom_error.h haslibrt.h qmail.h \
+conf-queue
 	./compile `grep -h -v "^#" conf-queue` qmulti.c
 
 mailfilter.o: \
-compile mailfilter.c mailfilter.h qmulti.h
+compile mailfilter.c mailfilter.h qmulti.h qmail.h
 	./compile mailfilter.c
 
 spawn-filter: \

--- a/indimail-mta-x/doc/ChangeLog
+++ b/indimail-mta-x/doc/ChangeLog
@@ -71,6 +71,10 @@ o SRS decoding in qmail-smtpd avoiding the need to create virtualdomain for
     open_control_files1() and open_control_files2()
 - 17/10/2022
 41. qmail-dkim.c, qmail-dk.c: replace all '%' characters with domain
+42. qmail.c, qmail.h: use exit code defines from qmail.h
+43. qmulti.c, qmail-spamfilter.c, qmail-queue.c, qmail-qfilter.c,
+	qmail-multi.c, qmail-dkim.c, qmail-dk.c, mailfilter.c: use exit code
+	defines from qmail.h
 
 * Thu 08 Sep 2022 12:31:45 +0000 Manvendra Bhangui <indimail-mta@indimail.org> 3.0.1-1.1%{?dist}
 Release 3.0.1 Start 21/05/2022 End 08/09/2022

--- a/indimail-mta-x/qmail-inject.9
+++ b/indimail-mta-x/qmail-inject.9
@@ -13,9 +13,8 @@ qmail-inject \- preprocess and send a mail message
 
 .SH DESCRIPTION
 .B qmail-inject
-reads a mail message from its standard input,
-adds appropriate information to the message header,
-and invokes
+reads a mail message from its standard input, adds appropriate information
+to the message header, and invokes
 .B qmail-queue
 to send the message to one or more recipients.
 
@@ -31,10 +30,8 @@ for information on how
 rewrites header fields.
 
 .B qmail-inject
-normally exits 0.
-It exits 100 if it was invoked improperly
-or if there is a severe syntax error in the message.
-It exits 111 for temporary errors.
+normally exits 0. It exits 100 if it was invoked improperly or if there is
+a severe syntax error in the message.  It exits 111 for temporary errors.
 
 .SH "ENVIRONMENT VARIABLES"
 For the convenience of users who do not run
@@ -55,8 +52,7 @@ whichever comes first.
 
 The host name is normally set by the
 .I defaulthost
-control
-but can be overridden with
+control but can be overridden with
 .B QMAILHOST
 or
 .BR MAILHOST .
@@ -67,11 +63,9 @@ The personal name is
 or
 .BR NAME .
 
-The default envelope sender address is the same as the
-default
+The default envelope sender address is the same as the default
 .B From
-address,
-but it can be overridden with
+address, but it can be overridden with
 .B QMAILSUSER
 and
 .BR QMAILSHOST .
@@ -79,41 +73,34 @@ It may also be modified by the
 .B r
 and
 .B m
-letters described below.
-Bounces will be sent to this address.
+letters described below. Bounces will be sent to this address.
 
 If
 .B QMAILMFTFILE
 is set,
 .B qmail-inject
-reads a list of mailing list addresses,
-one per line,
-from that file.
-If To+Cc includes one of those addresses (without regard to case),
+reads a list of mailing list addresses, one per line, from that file. If
+To+Cc includes one of those addresses (without regard to case),
 .B qmail-inject
-adds a Mail-Followup-To field
-with all the To+Cc addresses.
+adds a Mail-Followup-To field with all the To+Cc addresses.
 .B qmail-inject
-does not add Mail-Followup-To
-to a message that already has one.
+does not add Mail-Followup-To to a message that already has one.
 
 If
 .B QMAILQUEUE
 environment variable is set to PREFIX/sbin/qmail-multi,
 .B qmail-inject
-gets the ability to multiplex queues. See qmail-multi(8).
+gets the ability to multiplex queues and filter emails. See qmail-multi(8).
 
 The
 .B QMAILINJECT
-environment variable
-can contain any of the following letters:
+environment variable can contain any of the following letters:
 
 .TP
 .B c
 Use address-comment style for the
 .B From
-field.
-Normally
+field. Normally
 .B qmail-inject
 uses name-address style.
 
@@ -121,11 +108,10 @@ uses name-address style.
 .B s
 Do not look at any incoming
 .B Return-Path
-field.
-Normally, if
+field. Normally, if
 .B Return-Path
-is supplied, it sets the envelope sender address,
-overriding all environment variables.
+is supplied, it sets the envelope sender address, overriding all
+environment variables.
 .B Return-Path
 is deleted in any case.
 
@@ -145,8 +131,7 @@ field created by
 .B i
 Delete any incoming
 .B Message-ID
-field.
-Normally, if
+field. Normally, if
 .B Message-ID
 is supplied, it overrides the usual
 .B Message-ID
@@ -157,8 +142,8 @@ field created by
 .B r
 Use a per-recipient VERP.
 .B qmail-inject
-will append each recipient address to the envelope sender
-of the copy going to that recipient.
+will append each recipient address to the envelope sender of the copy going
+to that recipient.
 
 .TP
 .B m
@@ -182,20 +167,17 @@ set, it additionally uses environment set according to files in
 .B \-a
 Send the message to all addresses given as
 .I recip
-arguments;
-do not use header recipient addresses.
+arguments; do not use header recipient addresses.
 
 .TP
 .B \-h
-Send the message to all header recipient addresses.
-For non-forwarded messages, this means
-the addresses listed under
+Send the message to all header recipient addresses. For non-forwarded
+messages, this means the addresses listed under
 .BR To ,
 .BR Cc ,
 .BR Bcc ,
 .BR Apparently-To .
-For forwarded messages, this means
-the addresses listed under
+For forwarded messages, this means the addresses listed under
 .BR Resent-To ,
 .BR Resent-Cc ,
 .BR Resent-Bcc .
@@ -211,13 +193,12 @@ Send the message to all addresses given as
 arguments.
 If no
 .I recip
-arguments are supplied,
-send the message to all header recipient addresses.
+arguments are supplied, send the message to all header recipient addresses.
 
 .TP
 .B \-H
-Send the message to all header recipient addresses,
-and to all addresses given as
+Send the message to all header recipient addresses, and to all addresses
+given as
 .I recip
 arguments.
 
@@ -227,8 +208,7 @@ Pass
 .I sender
 to
 .B qmail-queue
-as the envelope sender address.
-This overrides
+as the envelope sender address. This overrides
 .B Return-Path
 and all environment variables.
 
@@ -255,19 +235,16 @@ otherwise the literal name
 .BR defaultdomain ,
 which is probably not what you want.
 .B qmail-inject
-adds this name to any host name without dots,
-including
+adds this name to any host name without dots, including
 .I defaulthost
 if
 .I defaulthost
-does not have dots.
-(Exception: see
+does not have dots. (Exception: see
 .IR plusdomain .)
 
 The
 .B QMAILDEFAULTDOMAIN
-environment variable
-overrides
+environment variable overrides
 .IR defaultdomain .
 
 .TP 5
@@ -275,17 +252,14 @@ overrides
 Default host name.
 Default:
 .IR me ,
-if that is supplied;
-otherwise the literal name
+if that is supplied; otherwise the literal name
 .BR defaulthost ,
 which is probably not what you want.
 .B qmail-inject
 adds this name to any address without a host name.
 .I defaulthost
-need not be the current host's name.
-For example,
-you may prefer that outgoing mail show
-just your domain name.
+need not be the current host's name. For example, you may prefer that
+outgoing mail show just your domain name.
 
 The
 .B QMAILDEFAULTHOST
@@ -302,13 +276,11 @@ otherwise the literal name
 .BR idhost ,
 which is certainly not what you want.
 .I idhost
-need not be the current host's name.
-For example, you may prefer to use fake
-host names in Message-IDs.
-However,
+need not be the current host's name. For example, you may prefer to use
+fake host names in Message-IDs. However,
 .I idhost
-must be a fully-qualified name within your domain,
-and each host in your domain should use a different
+must be a fully-qualified name within your domain, and each host in your
+domain should use a different
 .IR idhost .
 
 The
@@ -326,13 +298,12 @@ otherwise the literal name
 .BR plusdomain ,
 which is probably not what you want.
 .B qmail-inject
-adds this name to any host name that ends with a plus sign,
-including
+adds this name to any host name that ends with a plus sign, including
 .I defaulthost
 if
 .I defaulthost
-ends with a plus sign.
-If a host name does not have dots but ends with a plus sign,
+ends with a plus sign. If a host name does not have dots but ends with a
+plus sign,
 .B qmail-inject
 uses
 .IR plusdomain ,
@@ -356,19 +327,21 @@ overrides the value in this control file.
 
 .TP 5
 .I domainqueue
-Specific queue can be assigned to recipient domains. The format of this file is of the
-form
+Specific queue can be assigned to recipient domains. The format of this
+file is of the form
 
 domain:QUEUEDIR=queue_dir
 
-where domain is the recipient domain and queue_dir is any queue which is part of
-indimail's queue collection. You could also specify a set of queues for a domain.
+where domain is the recipient domain and queue_dir is any queue which is
+part of indimail's queue collection. You could also specify a set of queues
+for a domain.
 
 domain:QUEUE_COUNT=5,QUEUE_START=6,QUEUE_BASE=/var/indimail/queue
 
-specifies that any emails to *@domain be queued in /var/indimail/queue/queue[6,7,8,9,10]
-You can use \fIdomainqueue\fR to queue mails for certain domains into specific domains and
-specify individual concurrencies for these queues (see qmail-send(8)). e.g. having
+specifies that any emails to *@domain be queued in
+/var/indimail/queue/queue[6,7,8,9,10]. You can use \fIdomainqueue\fR to
+queue mails for certain domains into specific domains and specify
+individual concurrencies for these queues (see qmail-send(8)). e.g. having
 
 yahoo.com:QUEUEDIR=/var/indimail/queue/queue6
 in @controldir@/domainqueue and
@@ -380,15 +353,16 @@ will set 10 as the remote concurrency for all emails sent to yahoo.com
 
 .TP 5
 .I envrules
-Specific environment variables can be set for specific senders.
-The format of this file is of the form                                       
+Specific environment variables can be set for specific senders. The format
+of this file is of the form
+
 pat:envar1=val,envar2=val,...]
+
 where pat is a regular expression which matches a sender. envar1, envar2
 are list of environment variables to be set.
 
-The name of the control file can be overriden by the environment
-variable FROMRULES. The following environment variables used
-by
+The name of the control file can be overriden by the environment variable
+FROMRULES. The following environment variables used by
 .B qmail-queue
 can be set by using envrules.
 

--- a/indimail-mta-x/qmail-multi.c
+++ b/indimail-mta-x/qmail-multi.c
@@ -1,5 +1,8 @@
 /*
  * $Log: qmail-multi.c,v $
+ * Revision 1.3  2022-10-17 19:44:45+05:30  Cprogrammer
+ * use exit codes defines from qmail.h
+ *
  * Revision 1.2  2021-08-29 23:27:08+05:30  Cprogrammer
  * define functions as noreturn
  *
@@ -13,6 +16,7 @@
 #include <noreturn.h>
 #include "qmulti.h"
 #include "mailfilter.h"
+#include "qmail.h"
 
 #define DEATH 86400	/*- 24 hours; _must_ be below q-s's OSSIFIED (36 hours) */
 
@@ -20,13 +24,13 @@ no_return void
 sigalrm()
 {
 	/*- thou shalt not clean up here */
-	_exit(52);
+	_exit(QQ_TIMEOUT);
 }
 
 no_return void
 sigbug()
 {
-	_exit(81);
+	_exit(QQ_INTERNAL_BUG);
 }
 
 int
@@ -47,7 +51,7 @@ main(int argc, char **argv)
 void
 getversion_qmail_multi_c()
 {
-	static char    *x = "$Id: qmail-multi.c,v 1.2 2021-08-29 23:27:08+05:30 Cprogrammer Exp mbhangui $";
+	static char    *x = "$Id: qmail-multi.c,v 1.3 2022-10-17 19:44:45+05:30 Cprogrammer Exp mbhangui $";
 
 	x = sccsidqmultih;
 	x = sccsidmailfilterh;

--- a/indimail-mta-x/qmail.c
+++ b/indimail-mta-x/qmail.c
@@ -1,5 +1,5 @@
 /*
- * $Id: qmail.c,v 1.33 2022-10-04 23:43:37+05:30 Cprogrammer Exp mbhangui $
+ * $Id: qmail.c,v 1.34 2022-10-17 19:44:15+05:30 Cprogrammer Exp mbhangui $
  */
 #include <unistd.h>
 #include <substdio.h>
@@ -188,100 +188,102 @@ qmail_close(struct qmail *qq)
 	switch (exitcode)
 	{
 	case 115: /*- compatibility */
-	case 11:
+	case QQ_ENVELOPE_TOO_LONG:
 		return "Dqq envelope address too long (#5.1.3)";
-	case 31:
+	case QQ_PERM_MSG_REJECT:
 		return "Dqq mail server permanently rejected message (#5.3.0)";
-	case 32:
+	case QQ_SPAM_THRESHOLD:
 		return "Dqq spam or junk mail threshold exceeded (#5.7.1)"; /*- qmail-spamfiter */
-	case 33:
+	case QQ_VIRUS_IN_MSG:
 		return "Dqq message contains virus (#5.7.1)";
-	case 34:
+	case QQ_BANNED_ATTACHMENT:
 		return "Dqq message contains banned attachment (#5.7.1)";
-	case 35:
+	case QQ_NO_PRIVATE_KEY:
 		return "Dqq private key file does not exist (#5.3.5)";
-	case 50:
+	case QQ_VIRUS_SCANNER_PRIV:
 		return "Zqq unable to get privilege to run virus scanner (#4.3.0)"; /*- qhpsi */
-	case 51:
+	case QQ_OUT_OF_MEMORY:
 		return "Zqq out of memory (#4.3.0)";
-	case 52:
+	case QQ_TIMEOUT:
 		return "Zqq timeout (#4.3.0)";
-	case 53:
+	case QQ_DUP_ERR:
+		return "Zqq trouble duplicating file descriptors (#4.3.0)";
+	case QQ_WRITE_ERR:
 		return "Zqq write error or disk full (#4.3.0)";
-	case 0:
+	case QQ_OK:
 		if (!qq->flagerr)
 			return "";
 		/*- fall through */
-	case 54:
+	case QQ_READ_ERR:
 		return "Zqq read error (#4.3.0)";
-	case 55:
+	case QQ_CONFIG_ERR:
 		return "Zqq unable to read configuration (#4.3.0)";
-	case 56:
+	case QQ_NETWORK:
 		return "Zqq trouble making network connection (#4.3.0)";
-	case 57:
+	case QQ_OPEN_SHARED_OBJ:
 		return "Zqq unable to open shared object/plugin (#4.3.0)";
-	case 58:
+	case QQ_RESOLVE_SHARED_SYM:
 		return "Zqq unable to resolve symbol in shared object/plugin (#4.3.0)";
-	case 59:
+	case QQ_CLOSE_SHARED_OBJ:
 		return "Zqq unable to close shared object/plugin (#4.3.0)";
-	case 60:
+	case QQ_PIPE_SOCKET:
 		return "Zqq trouble creating pipes/sockets (#4.3.0)";
-	case 61:
+	case QQ_CHDIR:
 		return "Zqq trouble in home directory (#4.3.0)";
-	case 62:
+	case QQ_MESS_FILE:
 		return "Zqq unable to access mess file (#4.3.0)";
-	case 63:
+	case QQ_CD_ROOT:
 		return "Zqq trouble doing cd to root directory (#4.3.0)";
-	case 64:
+	case QQ_FSYNC_ERR:
 		return "Zqq trouble syncing message to disk (#4.3.0)";
-	case 65:
+	case QQ_INTD_FILE:
 		return "Zqq trouble creating files in intd. (#4.3.0)";
-	case 66:
+	case QQ_LINK_TODO_INTD:
 		return "Zqq trouble linking todofn to intdfn (#4.3.0)";
-	case 67:
+	case QQ_LINK_MESS_PID:
 		return "Zqq trouble linking messfn to pidfn (#4.3.0)";
-	case 68:
+	case QQ_TMP_FILES:
 		return "Zqq trouble creating temporary files (#4.3.0)";
-	case 69:
+	case QQ_SYNCDIR_ERR:
 		return "Zqq trouble syncing dir to disk (#4.3.0)";
-	case 70:
+	case QQ_PID_FILE:
 		return "Zqq trouble with pid file (#4.3.0)";
-	case 71:
+	case QQ_TEMP_MSG_REJECT:
 		return "Zqq mail server temporarily rejected message (#4.3.0)";
-	case 72:
+	case QQ_CONN_TIMEOUT:
 		return "Zqq connection to mail server timed out (#4.4.1)";
-	case 73:
+	case QQ_CONN_REJECT:
 		return "Zqq connection to mail server rejected (#4.4.1)";
-	case 74:
+	case QQ_CONN_FAILED:
 		return "Zqq communication with mail server failed (#4.4.2)";
-	case 75:
+	case QQ_EXEC_FAILED:
 		return "Zqq unable to exec (#4.3.0)";
-	case 76:
+	case QQ_TEMP_SPAM_FILTER:
 		return "Zqq temporary problem with SPAM filter (#4.3.0)";
-	case 77: /*- thanks to problem repoted by peter cheng */
+	case QQ_QHPSI_TEMP_ERR: /*- thanks to problem repoted by peter cheng */
 		return "Zqq unable to run QHPSI scanner (#4.3.0)";
-	case 78:
+	case QQ_GET_UID_GID:
 		return "Zqq trouble getting uids/gids (#4.3.0)";
-	case 79:
+	case QQ_ENVELOPE_FMT_ERR:
 		return "Zqq envelope format error (#4.3.0)";
-	case 80:
+	case QQ_REMOVE_INTD_ERR:
 		return "Zqq trouble removing intdfn";
 	case 91:
 		/*- fall through */
-	case 81:
+	case QQ_INTERNAL_BUG:
 		return "Zqq internal bug (#4.3.0)";
-	case 87: /*-*/
+	case QQ_SYSTEM_MISCONFIG: /*-*/
 		return "Zqq mail system incorrectly configured. (#4.3.5)";
 	case 82: /*- compatability with simscan, notqmail, etc */
-	case 120:
+	case QQ_EXEC_QMAILQUEUE:
 		return "Zqq unable to exec qq (#4.3.0)";
-	case 121: /*-*/
+	case QQ_FORK_ERR: /*-*/
 		return "Zqq unable to fork (#4.3.0)";
-	case 122: /*-*/
+	case QQ_WAITPID_SURPRISE: /*-*/
 		return "Zqq waitpid surprise (#4.3.0)";
-	case 123: /*-*/
+	case QQ_CRASHED: /*-*/
 		return "Zqq crashed (#4.3.0)";
-	case 88: /*- custom error */
+	case QQ_CUSTOM_ERR: /*- custom error */
 		if (qq->fdc != -1 && len > 2)
 			return errstr;
 		return "Zqq temporary problem (#4.3.0)";
@@ -295,13 +297,16 @@ qmail_close(struct qmail *qq)
 void
 getversion_qmail_c()
 {
-	static char    *x = "$Id: qmail.c,v 1.33 2022-10-04 23:43:37+05:30 Cprogrammer Exp mbhangui $";
+	static char    *x = "$Id: qmail.c,v 1.34 2022-10-17 19:44:15+05:30 Cprogrammer Exp mbhangui $";
 
 	x++;
 }
 
 /*
  * $Log: qmail.c,v $
+ * Revision 1.34  2022-10-17 19:44:15+05:30  Cprogrammer
+ * use exit codes defines from qmail.h
+ *
  * Revision 1.33  2022-10-04 23:43:37+05:30  Cprogrammer
  * set ERROR_FD to -1 to disable custom error
  *

--- a/indimail-mta-x/qmail.h
+++ b/indimail-mta-x/qmail.h
@@ -1,5 +1,8 @@
 /*
  * $Log: qmail.h,v $
+ * Revision 1.8  2022-10-17 19:44:36+05:30  Cprogrammer
+ * define qmail-queue exit codes
+ *
  * Revision 1.7  2022-10-04 23:43:51+05:30  Cprogrammer
  * added comments
  *
@@ -47,5 +50,54 @@ void            qmail_to(struct qmail *, char *);
 void            qmail_fail(struct qmail *);
 char           *qmail_close(struct qmail *);
 unsigned long   qmail_qp(struct qmail *);
+
+#define QQ_OK                  0
+#define QQ_ENVELOPE_TOO_LONG  11
+#define QQ_PERM_MSG_REJECT    31
+#define QQ_SPAM_THRESHOLD     32
+#define QQ_VIRUS_IN_MSG       33
+#define QQ_BANNED_ATTACHMENT  34
+#define QQ_NO_PRIVATE_KEY     35
+/*- define errors > 40 */
+#define QQ_DUP_ERR            41
+#define QQ_VIRUS_SCANNER_PRIV 50
+#define QQ_OUT_OF_MEMORY      51
+#define QQ_TIMEOUT            52
+#define QQ_WRITE_ERR          53
+#define QQ_READ_ERR           54
+#define QQ_CONFIG_ERR         55
+#define QQ_NETWORK            56
+#define QQ_OPEN_SHARED_OBJ    57
+#define QQ_RESOLVE_SHARED_SYM 58
+#define QQ_CLOSE_SHARED_OBJ   59
+#define QQ_PIPE_SOCKET        60
+#define QQ_CHDIR              61
+#define QQ_MESS_FILE          62
+#define QQ_CD_ROOT            63
+#define QQ_FSYNC_ERR          64
+#define QQ_INTD_FILE          65
+#define QQ_LINK_TODO_INTD     66
+#define QQ_LINK_MESS_PID      67
+#define QQ_TMP_FILES          68
+#define QQ_SYNCDIR_ERR        69
+#define QQ_PID_FILE           70
+#define QQ_TEMP_MSG_REJECT    71
+#define QQ_CONN_TIMEOUT       72
+#define QQ_CONN_REJECT        73
+#define QQ_CONN_FAILED        74
+#define QQ_EXEC_FAILED        75
+#define QQ_TEMP_SPAM_FILTER   76
+#define QQ_QHPSI_TEMP_ERR     77
+#define QQ_GET_UID_GID        78
+#define QQ_ENVELOPE_FMT_ERR   79
+#define QQ_REMOVE_INTD_ERR    80
+#define QQ_INTERNAL_BUG       81
+#define QQ_REMOVE_PID_ERR     83
+#define QQ_SYSTEM_MISCONFIG   87
+#define QQ_CUSTOM_ERR         88
+#define QQ_EXEC_QMAILQUEUE   120
+#define QQ_FORK_ERR          121
+#define QQ_WAITPID_SURPRISE  122
+#define QQ_CRASHED           123
 
 #endif

--- a/indimail-mta-x/replier.c
+++ b/indimail-mta-x/replier.c
@@ -1,5 +1,8 @@
 /*
  * $Log: replier.c,v $
+ * Revision 1.13  2022-10-17 19:45:16+05:30  Cprogrammer
+ * collapsed multiple stralloc lines
+ *
  * Revision 1.12  2021-08-29 23:27:08+05:30  Cprogrammer
  * define functions as noreturn
  *
@@ -131,9 +134,8 @@ main(int argc, char **argv)
 					tmperrno;
 	int             pf[2];
 
-	if (!(dir = argv[1]))
-		usage();
-	if (!(addr = argv[2]))
+	if (!(dir = argv[1]) ||
+			!(addr = argv[2]))
 		usage();
 	umask(022);
 	sig_ignore(SIGPIPE);
@@ -143,9 +145,7 @@ main(int argc, char **argv)
 	if (chdir(dir) == -1)
 		strerr_die4sys(111, FATAL, "unable to switch to ", dir, ": ");
 	if ((sender = env_get("SENDER"))) {
-		if (!*sender)
-			strerr_die2x(100, FATAL, "I don't reply to bounce messages (#5.7.2)");
-		if (str_equal(sender, "#@[]"))
+		if (!*sender || str_equal(sender, "#@[]"))
 			strerr_die2x(100, FATAL, "I don't reply to bounce messages (#5.7.2)");
 	}
 	if (!(local = env_get("LOCAL")))
@@ -205,17 +205,12 @@ main(int argc, char **argv)
 	for (i = 0; i < headeradd.len; ++i)
 		if (!headeradd.s[i])
 			headeradd.s[i] = '\n';
-	if (!stralloc_copys(&mydtline, "Delivered-To: replier "))
-		nomem();
-	if (!stralloc_cat(&mydtline, &outlocal))
-		nomem();
-	if (!stralloc_cats(&mydtline, action))
-		nomem();
-	if (!stralloc_cats(&mydtline, "@"))
-		nomem();
-	if (!stralloc_catb(&mydtline, outhost.s, outhost.len))
-		nomem();
-	if (!stralloc_cats(&mydtline, "\n"))
+	if (!stralloc_copys(&mydtline, "Delivered-To: replier ") ||
+			!stralloc_cat(&mydtline, &outlocal) ||
+			!stralloc_cats(&mydtline, action) ||
+			!stralloc_cats(&mydtline, "@") ||
+			!stralloc_catb(&mydtline, outhost.s, outhost.len) ||
+			!stralloc_cats(&mydtline, "\n"))
 		nomem();
 	myputs("Mailing-List: ");
 	put(mailinglist.s, mailinglist.len);
@@ -249,13 +244,10 @@ main(int argc, char **argv)
 	}
 	if (flagmlwasthere)
 		strerr_die2x(100, FATAL, "message already has Mailing-List (#5.7.2)");
-	if (!stralloc_copy(&line, &outlocal))
-		nomem();
-	if (!stralloc_cats(&line, "return-@"))
-		nomem();
-	if (!stralloc_cat(&line, &outhost))
-		nomem();
-	if (!stralloc_0(&line))
+	if (!stralloc_copy(&line, &outlocal) ||
+			!stralloc_cats(&line, "return-@") ||
+			!stralloc_cat(&line, &outhost) ||
+			!stralloc_0(&line))
 		nomem();
 	qmail_from(&qq, line.s);
 	substdio_fdbuf(&ssout, mywrite, -1, outbuf, sizeof(outbuf));
@@ -290,7 +282,7 @@ main(int argc, char **argv)
 void
 getversion_replier_c()
 {
-	static char    *x = "$Id: replier.c,v 1.12 2021-08-29 23:27:08+05:30 Cprogrammer Exp mbhangui $";
+	static char    *x = "$Id: replier.c,v 1.13 2022-10-17 19:45:16+05:30 Cprogrammer Exp mbhangui $";
 
 	x++;
 }


### PR DESCRIPTION
qmail-queue uses hard coded exit codes in qmail.c. This creates a problem for any code that uses qmail_open(). They too have to use this hard-coded exit codes. Having this exit codes defined in qmail.h as defines simplifies qmail_open() and also reduces the chances of using the wrong exit code.