### PR TITLE
TLS/SSL functions moved to dossl.c

### DIFF
--- a/indimail-mta-x/.gitignore
+++ b/indimail-mta-x/.gitignore
@@ -465,3 +465,4 @@ INPUT
 MAN
 SBIN
 SHARED
+dossl.o

--- a/indimail-mta-x/Makefile
+++ b/indimail-mta-x/Makefile
@@ -472,7 +472,7 @@ socket.lib
 
 dns.o: \
 compile dns.c ip.h ipalloc.h strsalloc.h dns.h tlsarralloc.h \
-conf-tls conf-spf conf-domainkeys conf-ip
+conf-tls conf-spf conf-domainkeys conf-ip conf-tlsa
 	./compile `grep -h -v "^#" conf-tls conf-spf conf-domainkeys \
 		conf-ip conf-tlsa` dns.c
 
@@ -550,13 +550,13 @@ compile dnstxt.c strsalloc.h dns.h dnsdoe.h ip.h
 
 dnstlsarr: \
 load dnstlsarr.o dns.o dnsdoe.o ip.o tlsarralloc.o ipalloc.o \
-starttls.o strsalloc.o socket_v4mappedprefix.o socket_v6any.o \
-auto_control.o variables.o control.o socket_tcp.o \
+strsalloc.o socket_v4mappedprefix.o socket_v6any.o dossl.o \
+auto_control.o variables.o control.o socket_tcp.o starttls.o\
 auto_sysconfdir.o socket_tcp6.o timeoutconn.o socket_v6loopback.o \
 socket_ip4loopback.o dns.lib socket.lib tls.lib
 	./load dnstlsarr dns.o dnsdoe.o tlsarralloc.o ip.o ipalloc.o \
-	starttls.o strsalloc.o socket_v4mappedprefix.o socket_v6any.o \
-	auto_control.o socket_tcp.o socket_tcp6.o timeoutconn.o \
+	strsalloc.o socket_v4mappedprefix.o socket_v6any.o starttls.o \
+	auto_control.o socket_tcp.o socket_tcp6.o timeoutconn.o dossl.o \
 	auto_sysconfdir.o socket_v6loopback.o socket_ip4loopback.o \
 	variables.o control.o `cat dns.lib socket.lib tls.lib` $(QMAILLIB)
 
@@ -1563,7 +1563,7 @@ compile pidopen.h pidopen.c
 
 hastlsa.h: trytlsa.c compile load dns.lib \
 dns.o tlsarralloc.o ip.o socket_v4mappedprefix.o \
-socket_v6any.o ipalloc.o strsalloc.o
+socket_v6any.o ipalloc.o strsalloc.o conf-tlsa
 	( ( ./compile `grep -h -v "^#" conf-tlsa` \
 	trytlsa.c && ./load trytlsa dns.o tlsarralloc.o \
 	ip.o socket_v4mappedprefix.o socket_v6any.o \
@@ -1600,14 +1600,14 @@ tryidn2.c compile load conf-smtputf8
 
 qmail-remote: \
 load qmail-remote.o control.o timeoutconn.o tcpto.o dns.o ip.o \
-ipalloc.o strsalloc.o ipme.o quote.o variables.o \
+ipalloc.o strsalloc.o ipme.o quote.o variables.o dossl.o \
 auto_sysconfdir.o auto_control.o socket_ip4loopback.o \
 socket_v6loopback.o socket_v6any.o tlsarralloc.o \
 qr_digest_md5.o fn_handler.o query_skt.o tlsacheck.o \
 dns.lib socket.lib socket_v4mappedprefix.o cdb_match.o \
 socket_tcp.o socket_tcp6.o idn2.lib gsasl.lib
 	./load qmail-remote control.o tlsacheck.o auto_control.o \
-	timeoutconn.o tcpto.o dns.o ip.o socket_ip4loopback.o \
+	timeoutconn.o tcpto.o dns.o ip.o socket_ip4loopback.o dossl.o \
 	auto_sysconfdir.o socket_v6loopback.o socket_v6any.o ipalloc.o \
 	socket_v4mappedprefix.o strsalloc.o ipme.o quote.o fn_handler.o \
 	qr_digest_md5.o query_skt.o tlsarralloc.o variables.o cdb_match.o \
@@ -1627,11 +1627,16 @@ qmail-remote.9 conf-qmail conf-sysconfdir conf-libexec
 qmail-remote.o: \
 compile qmail-remote.c control.h dns.h quote.h ip.h auto_sysconfdir.h \
 ipalloc.h query_skt.h ipme.h tcpto.h timeoutconn.h haveip6.h socket.h \
-variables.h auto_control.h cdb_match.h haslibgsasl.h \
+variables.h auto_control.h cdb_match.h haslibgsasl.h dossl.h \
 hastlsa.h tlsacheck.h fn_handler.h tlsarralloc.h hassmtputf8.h batv.h \
 conf-tls conf-ip conf-batv conf-mxps conf-smtputf8
 	./compile `grep -h -v "^#" conf-tls conf-ip conf-mxps \
 		conf-batv` qmail-remote.c
+
+dossl.o: \
+compile dossl.c variables.h control.h auto_sysconfdir.h \
+dossl.h hastlsa.h auto_control.h conf-tls
+	./compile `grep -h -v "^#" conf-tls` dossl.c
 
 qmail-send: \
 load qmail-send.o qsutil.o control.o newfield.o prioq.o \
@@ -3470,10 +3475,10 @@ load qmail-daned.o ip.o socket_v6any.o socket_v4mappedprefix.o \
 variables.o auto_control.o control.o ipalloc.o dns.o dnsdoe.o \
 strsalloc.o socket_tcp.o socket_tcp6.o timeoutconn.o tlsarralloc.o \
 socket_ip4loopback.o socket_v6loopback.o auto_sysconfdir.o \
-cdb_match.o starttls.o dns.lib tls.lib
+dossl.o cdb_match.o starttls.o dns.lib tls.lib
 	./load qmail-daned auto_control.o auto_sysconfdir.o \
 	cdb_match.o ip.o socket_v6any.o socket_v4mappedprefix.o \
-	tlsarralloc.o variables.o control.o ipalloc.o dns.o \
+	dossl.o tlsarralloc.o variables.o control.o ipalloc.o dns.o \
 	dnsdoe.o strsalloc.o socket_tcp.o socket_tcp6.o timeoutconn.o \
 	socket_ip4loopback.o socket_v6loopback.o starttls.o \
 	`cat dns.lib tls.lib` $(QMAILLIB)
@@ -3493,7 +3498,8 @@ qmail-daned.9 conf-qmail conf-sysconfdir
 
 starttls.o: compile starttls.c conf-tls hastlsa.h conf-ip \
 socket.h ip.h dns.h control.h variables.h tlsacheck.h \
-ipalloc.h tlsarralloc.h auto_control.h auto_sysconfdir.h haveip6.h
+ipalloc.h tlsarralloc.h auto_control.h auto_sysconfdir.h \
+dossl.h haveip6.h
 	./compile `grep -h -v "^#" conf-ip conf-tls` starttls.c
 
 tlsacheck.o: \

--- a/indimail-mta-x/TARGETS
+++ b/indimail-mta-x/TARGETS
@@ -692,3 +692,4 @@ INPUT
 MAN
 SBIN
 SHARED
+dossl.o

--- a/indimail-mta-x/dnstlsarr.c
+++ b/indimail-mta-x/dnstlsarr.c
@@ -1,5 +1,5 @@
 /*
- * $Id: dnstlsarr.c,v 1.16 2023-01-03 19:42:24+05:30 Cprogrammer Exp mbhangui $
+ * $Id: dnstlsarr.c,v 1.17 2023-01-06 17:31:49+05:30 Cprogrammer Exp mbhangui $
  */
 #include "substdio.h"
 #include "subfd.h"
@@ -8,7 +8,6 @@
 #include <sys/types.h>
 #include <sys/socket.h>
 #include <unistd.h>
-#include <tls.h>
 #include <stralloc.h>
 #include <fmt.h>
 #include <sgetopt.h>
@@ -20,12 +19,12 @@
 #include "control.h"
 #include "starttls.h"
 
-char            temp[IPFMT + FMT_ULONG];
+static char     temp[IPFMT + FMT_ULONG];
+static stralloc sahost = { 0 };
 int             timeoutdata = 300;
 int             timeoutconn = 60;
 int             verbose;
 stralloc        helohost = { 0 };
-stralloc        sahost = { 0 };
 
 void
 pusage()
@@ -40,9 +39,7 @@ pusage()
 }
 
 int
-main(argc, argv)
-	int             argc;
-	char          **argv;
+main(int argc, char **argv)
 {
 	int             opt, k, j, i, query_mx = 0, verify = 0;
 	char           *port = "25", *host = (char *) 0;
@@ -221,6 +218,9 @@ main(argc, argv)
 #else
 #warning "not compiled with -DHASTLSA -DTLS"
 #include <unistd.h>
+int             timeoutdata = 300;
+int             timeoutconn = 60;
+
 int
 main()
 {
@@ -233,7 +233,7 @@ main()
 void
 getversion_dnstlsarr_c()
 {
-	static char    *x = "$Id: dnstlsarr.c,v 1.16 2023-01-03 19:42:24+05:30 Cprogrammer Exp mbhangui $";
+	static char    *x = "$Id: dnstlsarr.c,v 1.17 2023-01-06 17:31:49+05:30 Cprogrammer Exp mbhangui $";
 
 #if defined(HASTLSA) && defined(TLS)
 	x = sccsidstarttlsh;
@@ -243,6 +243,10 @@ getversion_dnstlsarr_c()
 
 /*
  * $Log: dnstlsarr.c,v $
+ * Revision 1.17  2023-01-06 17:31:49+05:30  Cprogrammer
+ * changed scope of variables te,, sahost to static
+ * added timeoutdata, timeconn variables for dossl.c
+ *
  * Revision 1.16  2023-01-03 19:42:24+05:30  Cprogrammer
  * include tls.h from libqmail
  *

--- a/indimail-mta-x/doc/CREDITS.md
+++ b/indimail-mta-x/doc/CREDITS.md
@@ -94,44 +94,44 @@ The site http://qmail.org and the qmail mailing list for wealth of information
 	- maxhop control file
 	- The qmail-link-sync patch for simple fix to the non-synchronous link() problem of qmail on Linux filesystems
 64. Paul Gregg - ENFORCE\_FQDN\_HELO patch 29/08/2003
-67. Nick Leverton - Qmail Holdremote Patch
-68. PLDaniels - ripMIME/altermime
-69. evaluate - evaluate algebraic strings(C) 2000-2002 Kyzer/CSG. http://www.kyzer.me.uk/code/evaluate/
-70. "Marcus Williams" marcus at quintic.co.uk. - make seekable patch
-71. daemontools patches from (additional signals to svc, svscan logging http://www.gluelogic.com/code/daemontools/)
-73. Jos Backus - timed log rotation for multilog
-74. Alin-Adrian Anton - Fixed qmail-smtpd vulnurability for very long header lines
-76. http://members.elysium.pl/brush/qmail-smtpd-auth/ SMTP AUTH
-77. Zach White <zwhite@netlsd.org> 20010812 http://www.netable.com/~dburkes/qmail-smtpd-requireauth/ Require AUTH
-78. http://www.elysium.pl/members/brush/cmd5checkpw/ CRAM-MD5 Checkpassword RFC-2554, RFC-2222 compliance
-79. Rask Ingemann Lambertsen - who provided the original RELAY Patch
-80. Markus Stumpf - provided the original LOGGING patch
-81. Charles Cazabon - Author of the NULL-Sender modification
-82. Bjoern Kalkbrenner - Initial auther of the qmail-smtp-auth-send patch.
-83. Peter Ladwig - had the idea to use hard tarpitting in case of too many invalid RECIPIENTS.
-84. Flash Secure Menu Shell - WWW: http://www.netsoc.ucd.ie/flash/ Author: Steve Fegan
-85. Levent Serinol - MySQL support to tcpserver
-86. mpack/munpack from CMU
-87. Richard Lyons - moresmtproutes patch
-88. Andrew Richard's early talker patch
-89. Animesh Bansriyar for his idea to limit some users to receiving only local email.
-90. Flavio Curti for qmail-queue custom error patch
-91. Fred McIntyre for suggesting DKIMSIGNOPTIONS and other improvements to qmail-dkim
-92. Jason Haar <jhaar at users.sourceforge.net> for his tls-cert-check script
-93. Andrew Richard, John Levine for Greylisting - http://www.gossamer-threads.com/lists/qmail/users/136740?page=last
-94. Bounce Address Tag Validation - John Levine, Joerg Backschues
-95. Alexey Mahotkin <alexm at hsys.msk.ru> for pam support functions and new pam-checkpwd program
-95. Jeremy Kister - X-Originating-IP header qmail-1.03.originip-field.patch [http://jeremy.kister.net/code/qmail-1.03.originip-field.patch]
-96. Joerg Backschues - badremotehost check function (Ability to block hosts listed in badhost)
-97. James Raftery - real envelope recipient after host name canonicalization
-98. Russ Nelson's QMTP patch for qmail-remote
-99. DNSBL Support (DNS Blacklist) Author "Fabio Busatto" <fabio.busatto at sikurezza.org>
-100. Pieter Droogendijk <pieter at binky.org.uk> http://binky.org.uk - URL parsing code for SURBL
-101. Marcelo Coelho - qmail-srs-0.8.patch and libsrs2 - http://www.libsrs2.org
-102. Roberto Puzzanghera <roberto.puzzanghera at gmail.com> - using FORCE\_TLS environment variable to force TLS during AUTH
-103. Ed Neville - allow multiple Delivered-To in qmail-local using control file maxdeliveredo
-104. Ed Neville - configure TLS method in control/tlsclientmethod (qmail-smtpd), control/tlsservermethod (qmail-remote)
-105. Bruce Guenter - qmail-remote patch to reduce cpu
-106. Rolf Eike Beer <eike@sf-mail.de> gen\_allocdefs.h, GEN\_ALLOC refactoring changes to fix memory overflow
-107. Fefe - felix-libowfat@fefe.de for functions taken from libowfat & ipv6 in ucspi-tcp
-108. RFC 6530-32 EAI - Adapted from Arnt Gulbrandsen / EH Hoffman unicode address support patch for qmail.
+65. Nick Leverton - Qmail Holdremote Patch
+66. PLDaniels - ripMIME/altermime
+67. evaluate - evaluate algebraic strings(C) 2000-2002 Kyzer/CSG. http://www.kyzer.me.uk/code/evaluate/
+68. "Marcus Williams" marcus at quintic.co.uk. - make seekable patch
+69. daemontools patches from (additional signals to svc, svscan logging http://www.gluelogic.com/code/daemontools/)
+70. Jos Backus - timed log rotation for multilog
+71. Alin-Adrian Anton - Fixed qmail-smtpd vulnurability for very long header lines
+72. http://members.elysium.pl/brush/qmail-smtpd-auth/ SMTP AUTH
+73. Zach White <zwhite@netlsd.org> 20010812 http://www.netable.com/~dburkes/qmail-smtpd-requireauth/ Require AUTH
+74. http://www.elysium.pl/members/brush/cmd5checkpw/ CRAM-MD5 Checkpassword RFC-2554, RFC-2222 compliance
+75. Rask Ingemann Lambertsen - who provided the original RELAY Patch
+76. Markus Stumpf - provided the original LOGGING patch
+77. Charles Cazabon - Author of the NULL-Sender modification
+78. Bjoern Kalkbrenner - Initial auther of the qmail-smtp-auth-send patch.
+79. Peter Ladwig - had the idea to use hard tarpitting in case of too many invalid RECIPIENTS.
+80. Flash Secure Menu Shell - WWW: http://www.netsoc.ucd.ie/flash/ Author: Steve Fegan
+81. Levent Serinol - MySQL support to tcpserver
+82. mpack/munpack from CMU
+83. Richard Lyons - moresmtproutes patch
+84. Andrew Richard's early talker patch
+85. Animesh Bansriyar for his idea to limit some users to receiving only local email.
+86. Flavio Curti for qmail-queue custom error patch
+87. Fred McIntyre for suggesting DKIMSIGNOPTIONS and other improvements to qmail-dkim
+88. Jason Haar <jhaar at users.sourceforge.net> for his tls-cert-check script
+89. Andrew Richard, John Levine for Greylisting - http://www.gossamer-threads.com/lists/qmail/users/136740?page=last
+90. Bounce Address Tag Validation - John Levine, Joerg Backschues
+91. Alexey Mahotkin <alexm at hsys.msk.ru> for pam support functions and new pam-checkpwd program
+92. Jeremy Kister - X-Originating-IP header qmail-1.03.originip-field.patch [http://jeremy.kister.net/code/qmail-1.03.originip-field.patch]
+93. Joerg Backschues - badremotehost check function (Ability to block hosts listed in badhost)
+94. James Raftery - real envelope recipient after host name canonicalization
+95. Russ Nelson's QMTP patch for qmail-remote
+96. DNSBL Support (DNS Blacklist) Author "Fabio Busatto" <fabio.busatto at sikurezza.org>
+97. Pieter Droogendijk <pieter at binky.org.uk> http://binky.org.uk - URL parsing code for SURBL
+98. Marcelo Coelho - qmail-srs-0.8.patch and libsrs2 - http://www.libsrs2.org
+99. Roberto Puzzanghera <roberto.puzzanghera at gmail.com> - using FORCE\_TLS environment variable to force TLS during AUTH
+100. Ed Neville - allow multiple Delivered-To in qmail-local using control file maxdeliveredo
+101. Ed Neville - configure TLS method in control/tlsclientmethod (qmail-smtpd), control/tlsservermethod (qmail-remote)
+102. Bruce Guenter - qmail-remote patch to reduce cpu
+103. Rolf Eike Beer <eike@sf-mail.de> gen\_allocdefs.h, GEN\_ALLOC refactoring changes to fix memory overflow
+104. Fefe - felix-libowfat@fefe.de for functions taken from libowfat & ipv6 in ucspi-tcp
+105. RFC 6530-32 EAI - Adapted from Arnt Gulbrandsen / EH Hoffman unicode address support patch for qmail.

--- a/indimail-mta-x/doc/ChangeLog
+++ b/indimail-mta-x/doc/ChangeLog
@@ -197,6 +197,12 @@ o qmail-remote can use credentials stored in remote_auth.cdb using simple or
 110.qmail-greyd.c, qmail-daned.c, udplogger.c: removed __USE_GNU
 - 04/02/2023
 111.starttls.c: fixed incorrect setting of smtptext
+- 06/02/2023
+112.startls.c, qmail-remote.c: moved tls/ssl functions to dossl.c
+113.dossl.c, dossl.h: tls/ssl support functions for qmail-remote,
+    qmail-daned, dnstlsarr
+114.qmail-daned, qmail-remote, dnstlsarr, Makefile: Link with dossl.o
+115.smtpd.c: Fixed compilation for non-tls
 
 * Thu 08 Sep 2022 12:31:45 +0000 Manvendra Bhangui <indimail-mta@indimail.org> 3.0.1-1.1%{?dist}
 Release 3.0.1 Start 21/05/2022 End 08/09/2022

--- a/indimail-mta-x/dossl.c
+++ b/indimail-mta-x/dossl.c
@@ -1,0 +1,687 @@
+/*
+ * $Id: dossl.c,v 1.1 2023-01-06 17:43:57+05:30 Cprogrammer Exp mbhangui $
+ */
+#include "hastlsa.h"
+#if defined(TLS) || defined(TLSA)
+#include <unistd.h>
+#include <openssl/x509v3.h>
+#include <openssl/x509.h>
+#include <openssl/err.h>
+#include <openssl/ssl.h>
+#include <sys/stat.h>
+#include <str.h>
+#include <error.h>
+#include <subfd.h>
+#include <case.h>
+#include <env.h>
+#include <stralloc.h>
+#include <tls.h>
+#include <alloc.h>
+#include <fmt.h>
+#include "variables.h"
+#include "control.h"
+#include "dossl.h"
+#include "auto_sysconfdir.h"
+#include "auto_control.h"
+
+#ifdef TLS
+extern int      smtpcode();
+
+static SSL_CTX *ctx;
+static stralloc saciphers, tlsFilename, clientcert, certdir_s;
+
+extern char    *certdir;
+extern int      timeoutconn;
+extern int      timeoutdata;
+extern substdio smtpto;
+
+/*-
+ * don't want to fail handshake if certificate can't be verified
+ */
+int
+verify_cb(int preverify_ok, X509_STORE_CTX *ctx_dummy)
+{
+	return 1;
+}
+
+int
+match_partner(char *s, int len, char *fqdn)
+{
+	if (!case_diffb(fqdn, len, (char *) s) && !fqdn[len])
+		return 1;
+	/*- we also match if the name is *.domainname */
+	if (*s == '*') {
+		const char     *domain = fqdn + str_chr(fqdn, '.');
+		if (!case_diffb((char *) domain, --len, (char *) ++s) && !domain[len])
+			return 1;
+	}
+	return 0;
+}
+
+void
+do_pkix(SSL *ssl, char *servercert, char *fqdn,
+		void(*tlsquit)(const char *s1, char *s2, char *s3, char *s4, char *s5, stralloc *s),
+		void(*mem_err)(),
+		void(*do_quit)(char *s1, char *s2, int code, int err),
+		stralloc *stext)
+{
+	X509           *peercert;
+	STACK_OF(GENERAL_NAME) *gens;
+	int             r, i = 0;
+	char           *t;
+
+	/*- PKIX */
+	if ((r = SSL_get_verify_result(ssl)) != X509_V_OK) {
+		t = (char *) X509_verify_cert_error_string(r);
+		if (!stralloc_copyb(stext, "TLS unable to verify server with ", 33) ||
+				!stralloc_cats(stext, servercert) ||
+				!stralloc_catb(stext, ": ", 2) ||
+				!stralloc_cats(stext, t))
+			mem_err();
+		tlsquit("Z", "TLS unable to verify server with ", servercert, ": ", t, 0);
+	}
+	if (!(peercert = SSL_get_peer_certificate(ssl))) {
+		if (!stralloc_copyb(stext, "TLS unable to verify server ", 28) ||
+				!stralloc_cats(stext, fqdn) ||
+				!stralloc_catb(stext, ": no certificate provided", 25))
+			mem_err();
+		tlsquit("Z", "TLS unable to verify server ", fqdn, ": no certificate provided", 0, 0);
+	}
+
+	/*-
+	 * RFC 2595 section 2.4: find a matching name
+	 * first find a match among alternative names
+	 */
+	if ((gens = X509_get_ext_d2i(peercert, NID_subject_alt_name, 0, 0))) {
+		for (i = 0, r = sk_GENERAL_NAME_num(gens); i < r; ++i) {
+			const GENERAL_NAME *gn = sk_GENERAL_NAME_value(gens, i);
+			if (gn->type == GEN_DNS)
+				if (match_partner((char *) gn->d.ia5->data, gn->d.ia5->length, fqdn))
+					break;
+		}
+		sk_GENERAL_NAME_pop_free(gens, GENERAL_NAME_free);
+	}
+
+	/*- no alternative name matched, look up commonName */
+	if (!gens || i >= r) {
+		stralloc        peer = { 0 };
+		X509_NAME      *subj = X509_get_subject_name(peercert);
+		if ((i = X509_NAME_get_index_by_NID(subj, NID_commonName, -1)) >= 0) {
+#if OPENSSL_VERSION_NUMBER >= 0x10100000L
+			X509_NAME_ENTRY *xnet;
+			xnet = X509_NAME_get_entry(subj, i);
+			ASN1_STRING    *s = X509_NAME_ENTRY_get_data(xnet);
+#else
+			const ASN1_STRING *s = X509_NAME_get_entry(subj, i)->value;
+#endif
+			if (s) {
+				peer.len = s->length;
+				peer.s = (char *) s->data;
+			}
+		}
+		if (peer.len <= 0) {
+			if (!stralloc_copyb(stext, "TLS unable to verify server ", 28) ||
+					!stralloc_cats(stext, fqdn) ||
+					!stralloc_catb(stext, ": certificate contains no valid commonName", 42))
+				mem_err();
+			tlsquit("Z", "TLS unable to verify server ", fqdn, ": certificate contains no valid commonName", 0, 0);
+		}
+		if (!match_partner((char *) peer.s, peer.len, fqdn)) {
+			if (!stralloc_copyb(stext, "TLS unable to verify server ", 28) ||
+					!stralloc_cats(stext, fqdn) ||
+					!stralloc_catb(stext, ": received certificate for ", 27) ||
+					!stralloc_cat(stext, &peer) ||
+					!stralloc_0(stext))
+				mem_err();
+			tlsquit("Z", "TLS unable to verify server ", fqdn, ": received certificate for ", 0, &peer);
+		}
+	}
+	X509_free(peercert);
+	return;
+}
+
+/*
+ * 1. returns 0 --> fallback to non-tls
+ *    if certs do not exist
+ *    host is in notlshosts
+ *    smtps == 0 and tls session cannot be initiated
+ * 2. returns 1 if tls session was initiated
+ * 3. exits on error, if smtps == 1 and tls session did not succeed
+ */
+int
+do_tls(SSL **ssl, int pkix, int smtps, int smtpfd, int *needtlsauth,
+		char **scert, char *fqdn, char *_host, int hostlen,
+		void(*tlsquit)(const char *s1, char *s2, char *s3, char *s4, char *s5, stralloc *s),
+		void(*mem_err)(),
+		void(*ctrl_err)(),
+		void(*write_err)(),
+		void(*do_quit)(char *s1, char *s2, int code, int e),
+		stralloc *stext,
+		saa *ehlokw,
+		int verbose)
+{
+	int             code, i = 0, _needtlsauth = 0;
+	static char     ssl_initialized;
+	const char     *ciphers = NULL;
+	char           *t, *servercert = NULL, *certfile;
+	static SSL     *myssl;
+	stralloc        ssl_option = { 0 };
+	int             method_fail;
+
+	if (needtlsauth)
+		*needtlsauth = 0;
+	if (scert)
+		*scert = NULL;
+	/*-
+	 * do_tls() gets called in do_smtp()
+	 * if do_smtp() returns for trying next mx
+	 * we need to re-initialize
+	 */
+	if (ctx) {
+		SSL_CTX_free(ctx);
+		ctx = (SSL_CTX *) 0;
+	}
+	if (myssl) {
+		SSL_free(myssl);
+		myssl = NULL;
+	}
+	if (!certdir && !(certdir = env_get("CERTDIR"))) {
+		if (!stralloc_copys(&certdir_s, auto_sysconfdir) ||
+				!stralloc_catb(&certdir_s, "/certs", 6) ||
+				!stralloc_0(&certdir_s))
+			mem_err();
+		certdir = certdir_s.s;
+	}
+	if (!stralloc_copys(&clientcert, certdir) ||
+			!stralloc_append(&clientcert, "/"))
+		mem_err();
+	certfile = ((certfile = env_get("CLIENTCERT")) ? certfile : "clientcert.pem");
+	if (!stralloc_cats(&clientcert, certfile) ||
+			!stralloc_0(&clientcert))
+		mem_err();
+	if (access(clientcert.s, F_OK)) {
+		if (errno != error_noent)
+			ctrl_err("Unable to read client certificate", clientcert.s);
+		return (0);
+	}
+	if (fqdn) {
+		struct stat     st;
+		if (!stralloc_copys(&tlsFilename, certdir) ||
+				!stralloc_catb(&tlsFilename, "/tlshosts/", 10) ||
+				!stralloc_catb(&tlsFilename, fqdn, str_len(fqdn)) ||
+				!stralloc_catb(&tlsFilename, ".pem", 4) ||
+				!stralloc_0(&tlsFilename))
+			mem_err();
+		if (stat(tlsFilename.s, &st)) {
+			_needtlsauth = 0;
+			if (needtlsauth)
+				*needtlsauth = 0;
+			if (!stralloc_copys(&tlsFilename, certdir) ||
+					!stralloc_catb(&tlsFilename, "/notlshosts/", 12) ||
+					!stralloc_catb(&tlsFilename, fqdn, str_len(fqdn) + 1) ||
+					!stralloc_0(&tlsFilename)) /*- fqdn */
+				mem_err();
+			if (!stat(tlsFilename.s, &st))
+				return (0);
+			if (hostlen) {
+				if (!stralloc_copys(&tlsFilename, certdir) ||
+						!stralloc_catb(&tlsFilename, "/notlshosts/", 12) ||
+						!stralloc_catb(&tlsFilename, _host, hostlen) ||
+						!stralloc_0(&tlsFilename)) /*- domain */
+					mem_err();
+				if (!stat(tlsFilename.s, &st))
+					return (0);
+			}
+			if (!stralloc_copys(&tlsFilename, certdir) ||
+					!stralloc_catb(&tlsFilename, "/tlshosts/exhaustivelist", 24) ||
+					!stralloc_0(&tlsFilename))
+				mem_err();
+			if (!stat(tlsFilename.s, &st))
+				return (0);
+		} else { /*- servercert for fqdn, domain, host exists */
+			if (scert)
+				*scert = tlsFilename.s;
+			servercert = tlsFilename.s;
+			_needtlsauth = 1;
+			if (needtlsauth)
+				*needtlsauth = 1;
+		}
+	}
+
+	if (!smtps) {
+		stralloc       *saptr = ehlokw->sa;
+		unsigned int    len = ehlokw->len;
+
+		/*- look for STARTTLS among EHLO keywords */
+		for (; len && case_diffs(saptr->s, "STARTTLS"); ++saptr, --len);
+		if (!len) {
+			if (!_needtlsauth) /*- file certdir/notlshosts/fqdn.pem doesn't exist */
+				return (0);
+			if (!stralloc_copyb(stext, "No TLS achieved while ", 22) ||
+					!stralloc_cats(stext, servercert) ||
+					!stralloc_catb(stext, " exists", 7))
+				mem_err();
+			tlsquit("Z", "No TLS achieved while", tlsFilename.s, " exists", 0, 0);
+		}
+	}
+
+	if (!ssl_initialized++)
+		SSL_library_init();
+	if (!controldir && !(controldir = env_get("CONTROLDIR")))
+		controldir = auto_control;
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
+	if (control_rldef(&ssl_option, "tlsclientmethod", 0, "TLSv1_2") != 1)
+#else
+	if (control_rldef(&ssl_option, "tlsclientmethod", 0, "TLSv1_3") != 1)
+#endif
+		ctrl_err("Unable to read control files", "tlsclientmethod");
+	if (!stralloc_0(&ssl_option))
+		mem_err();
+	if (!(ctx = set_tls_method(ssl_option.s, client, &method_fail))) {
+		if (!smtps && !_needtlsauth)
+			return (0);
+		t = myssl_error();
+		if (!stralloc_copyb(stext, "TLS error initializing ctx: ", 28) ||
+				!stralloc_cats(stext, t))
+			mem_err();
+		switch (method_fail)
+		{
+		case 1:
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
+			tlsquit("Z", "TLS Supported methods: SSLv23, SSLv3, TLSv1, TLSv1_1, TLSv1_2", t, 0, 0, 0);
+#else
+			tlsquit("Z", "TLS Supported methods: TLSv1, TLSv1_1, TLSv1_2 TLSv1_3", t, 0, 0, 0);
+#endif
+			break;
+		case 2:
+			tlsquit("Z", "TLS error initializing SSLv23 ctx: ", t, 0, 0, 0);
+			break;
+		case 3:
+			tlsquit("Z", "TLS error initializing SSLv3 ctx: ", t, 0, 0, 0);
+			break;
+		case 4:
+			tlsquit("Z", "TLS error initializing TLSv1 ctx: ", t, 0, 0, 0);
+			break;
+		case 5:
+			tlsquit("Z", "TLS error initializing TLSv1_1 ctx: ", t, 0, 0, 0);
+			break;
+		case 6:
+			tlsquit("Z", "TLS error initializing TLSv1_2 ctx: ", t, 0, 0, 0);
+			break;
+		case 7:
+			tlsquit("Z", "TLS error initializing TLSv1_3 ctx: ", t, 0, 0, 0);
+			break;
+		}
+	}
+
+	if (_needtlsauth) {
+		if (!SSL_CTX_load_verify_locations(ctx, servercert, NULL)) {
+			t = myssl_error();
+			if (!stralloc_copyb(stext, "TLS unable to load ", 19) ||
+					!stralloc_cats(stext, servercert) ||
+					!stralloc_catb(stext, ": ", 2) ||
+					!stralloc_cats(stext, t))
+				mem_err();
+			SSL_CTX_free(ctx);
+			ctx = (SSL_CTX *) 0;
+			tlsquit("Z", "TLS unable to load ", servercert, ": ", t, 0);
+		}
+		/*- set the callback here; SSL_set_verify didn't work before 0.9.6c */
+		SSL_CTX_set_verify(ctx, SSL_VERIFY_PEER, verify_cb);
+	}
+
+	/*- let the other side complain if it needs a cert and we don't have one */
+	if (SSL_CTX_use_certificate_chain_file(ctx, clientcert.s))
+#if OPENSSL_VERSION_NUMBER >= 0x30000000L
+		SSL_CTX_use_PrivateKey_file(ctx, clientcert.s, SSL_FILETYPE_PEM);
+#else
+		SSL_CTX_use_RSAPrivateKey_file(ctx, clientcert.s, SSL_FILETYPE_PEM);
+#endif
+
+	if (!(myssl = SSL_new(ctx))) {
+		t = myssl_error();
+		if (!smtps && !_needtlsauth) {
+			SSL_CTX_free(ctx);
+			ctx = (SSL_CTX *) 0;
+			return (0);
+		}
+		if (!stralloc_copyb(stext, "TLS error initializing ssl: ", 28) ||
+				!stralloc_cats(stext, t))
+			mem_err();
+		SSL_CTX_free(ctx);
+		ctx = (SSL_CTX *) 0;
+		tlsquit("Z", "TLS error initializing ssl: ", t, 0, 0, 0);
+	} else {
+		SSL_CTX_free(ctx);
+		ctx = (SSL_CTX *) 0;
+	}
+
+	if (!smtps) {
+		if (substdio_putflush(&smtpto, "STARTTLS\r\n", 10) == -1) {
+			SSL_free(myssl);
+			myssl = NULL;
+			write_err();
+		}
+		if (verbose == 2)
+			substdio_putsflush(subfdout, "Client: STARTTLS\n");
+	}
+
+	/*- while the server is preparing a response, do something else */
+	if (!ciphers) {
+		if (control_readfile(&saciphers, "tlsclientciphers", 0) == -1) {
+			while (SSL_shutdown(myssl) == 0)
+				usleep(100);
+			SSL_free(myssl);
+			myssl = NULL;
+			ctrl_err("Unable to read control file", "tlsclientciphers");
+		}
+		if (saciphers.len) {
+			/*- convert all '\0's except the last one to ':' */
+			for (i = 0; i < saciphers.len - 1; ++i)
+				if (!saciphers.s[i])
+					saciphers.s[i] = ':';
+			ciphers = saciphers.s;
+		}
+	}
+	SSL_set_cipher_list(myssl, ciphers);
+
+	/*- SSL_set_options(myssl, SSL_OP_NO_TLSv1); */
+	SSL_set_fd(myssl, smtpfd);
+
+	/*- read the response to STARTTLS */
+	if (!smtps) {
+		if (smtpcode() != 220) {
+			while (SSL_shutdown(myssl) == 0)
+				usleep(100);
+			SSL_free(myssl);
+			myssl = NULL;
+			if (!_needtlsauth)
+				return (0);
+			if (!stralloc_copyb(stext, "STARTTLS rejected while ", 24) ||
+					!stralloc_cats(stext, tlsFilename.s) ||
+					!stralloc_catb(stext, " exists", 7))
+				mem_err();
+			tlsquit("Z", "STARTTLS rejected while ", tlsFilename.s, " exists", 0, 0);
+		}
+	}
+	*ssl = myssl;
+	if (ssl_timeoutconn(timeoutconn, smtpfd, smtpfd, myssl) <= 0) {
+		t = myssl_error_str();
+		if (!stralloc_copyb(stext, "TLS connect failed: ", 20) ||
+				!stralloc_cats(stext, t))
+			mem_err();
+		tlsquit("Z", "TLS connect failed: ", t, 0, 0, 0);
+	}
+	if (smtps && (code = smtpcode()) != 220)
+		do_quit("ZTLS Connected to ", " but greeting failed", code, -1);
+	if (pkix && _needtlsauth) /*- 220 ready for tls */
+		do_pkix(myssl, servercert, fqdn, tlsquit, mem_err, do_quit, stext);
+	return (1);
+}
+#endif /*- ifdef TLS */
+
+#ifdef HASTLSA
+/*-
+ * USAGE
+ * 0, 1, 2, 3, 255
+ * 255 PrivCert
+ *
+ * SELECTOR
+ * --------
+ * 0, 1, 255
+ * 255 PrivSel
+ *
+ * Matching Type
+ * -------------
+ * 0, 1, 2, 255
+ * 255 PrivMatch
+ *
+ * Return Value
+ * 0   - match target certificate & payload data
+ * 1,2 - successful match
+ */
+stralloc        certData = { 0 };
+stralloc        hextmp = { 0 };
+int
+tlsa_vrfy_records(SSL *ssl, char *certDataField, int usage, int selector,
+		int match_type, char *fqdn,
+		void(*tlsquit)(const char *s1, char *s2, char *s3, char *s4, char *s5, stralloc *s),
+		void(*mem_err)(),
+		stralloc *stext,
+		void(*out)(),
+		void(*flush)(),
+		char **err_str, int verbose)
+{
+#if OPENSSL_VERSION_NUMBER >= 0x10100000L
+	EVP_MD_CTX     *mdctx;
+#else
+	EVP_MD_CTX     *mdctx;
+	EVP_MD_CTX      _mdctx;
+#endif
+	const EVP_MD   *md = NULL;
+	BIO            *membio = NULL;
+	EVP_PKEY       *pkey = NULL;
+	X509           *xs = NULL;
+	STACK_OF(X509) *sk;
+	static char     errbuf[256];
+	char            buffer[1024], hex[2];
+	unsigned char   md_value[EVP_MAX_MD_SIZE];
+	unsigned char  *ptr;
+	char           *cp;
+	int             i, len, e;
+	unsigned int    md_len;
+
+	if (!ssl)
+		return (-1);
+	switch (usage)
+	{
+	/*- Trust anchor */
+	case 0: /*- PKIX-TA(0) maps to DANE-TA(2) */
+		/*- flow through */
+	case 2: /*- DANE-TA(2) */
+		usage = 2;
+		break;
+	case 1: /*- PKIX-EE(1) maps to DANE-EE(3) */
+		/*- flow through */
+	case 3: /*- DANE-EE(3) */
+		usage = 3;
+		break;
+	default:
+		return (-2);
+	}
+	switch (selector) /*- match full certificate or subjectPublicKeyInfo */
+	{
+	case 0: /*- Cert(0) - match full certificate   data/SHA256fingerprint/SHA512fingerprint */
+		break;
+	case 1: /*- SPKI(1) - match subject public key data/SHA256fingerprint/SHA512fingerprint  */
+		break;
+	default:
+		return (-2);
+	}
+	switch (match_type) /*- sha256, sha512 */
+	{
+	case 0: /*- Full(0) - match full cert data or subjectPublicKeyInfo data */
+		break;
+	case 1: /*- SHA256(1) fingerprint - servers should publish this mandatorily */
+		md = EVP_get_digestbyname("sha256");
+		break;
+	case 2: /*- SHA512(2)  fingerprint - servers should not exclusively publish this */
+		md = EVP_get_digestbyname("sha512");
+		break;
+	default:
+		return (-2);
+	}
+	/*- SSL_ctrl(ssl, SSL_SET_TLSEXT_HOSTNAME, TLSEXT_NAMETYPE_host_name, servername); -*/
+	if (!(sk =  SSL_get_peer_cert_chain(ssl))) {
+		if (stext) {
+			if (!stralloc_copyb(stext, "TLS unable to verify server ", 28) ||
+					!stralloc_cats(stext, fqdn) ||
+					!stralloc_catb(stext, ": no certificate provided", 25))
+				mem_err();
+		}
+		tlsquit("Z", "TLS unable to verify server ", fqdn, ": no certificate provided", 0, 0);
+	}
+	/*-
+	 * the server certificate is generally presented
+	 * as the first certificate in the stack along with
+	 * the remaining chain.
+	 * last certificate in the list is a trust anchor
+	 * 5.2.2.  Trust Anchor Digests and Server Certificate Chain
+	 * https://tools.ietf.org/html/rfc7671
+	 *
+	 * for Usage 2, check the last  certificate - sk_X509_value(sk, sk_509_num(sk) - 1)
+	 * for Usage 3, check the first certificate - sk_X509_value(sk, 0)
+	 */
+	/*- for (i = (usage == 2 ? 1 : 0); i < (usage == 2 ? sk_X509_num(sk) : 1); i++) -*/
+	i = (usage == 2 ? sk_X509_num(sk) - 1 : 0);
+	xs = sk_X509_value(sk, i);
+	/*- 
+	 * DANE Validation 
+	 * server cert - X = 2
+	 * anchor cert - X = 3
+	 * case 1 - match full certificate data -                            - X 0 0
+	 * case 2 - match full subjectPublicKeyInfo data                     - X 1 0
+	 * case 3 - match  SHA512/SHA256 fingerprint of full certificate     - X 0 1, X 0 2
+	 * case 4 - match  SHA512/SHA256 fingerprint of subjectPublicKeyInfo - X 1 1, X 1 2
+	 */
+	if (match_type == 0 && selector == 0) { /*- match full certificate data */
+		if (!(membio = BIO_new(BIO_s_mem()))) {
+			*err_str = ERR_error_string(ERR_get_error(), errbuf);
+			tlsquit("Z", "DANE unable to create membio: ", *err_str, 0, 0, 0);
+		}
+		if (!PEM_write_bio_X509(membio, xs)) {
+			*err_str = ERR_error_string(ERR_get_error(), errbuf);
+			tlsquit("Z", "DANE unable to create write to membio: ", *err_str, 0, 0, 0);
+		}
+		for (certData.len = 0;;) {
+			if (!BIO_gets(membio, buffer, sizeof(buffer) - 2))
+				break;
+			if (str_start(buffer, "-----BEGIN CERTIFICATE-----"))
+				continue;
+			if (str_start(buffer, "-----END CERTIFICATE-----"))
+				continue;
+			buffer[i = str_chr(buffer, '\n')] = '\0';
+			if (!stralloc_cats(&certData, buffer))
+				mem_err();
+		}
+		if (!stralloc_0(&certData))
+			mem_err();
+		certData.len--;
+		BIO_free_all(membio);
+		e = str_diffn(certData.s, certDataField, certData.len);
+			return (0);
+		if (verbose && out && flush) {
+			out(e == 0 ? "matched " : "failed  ");
+			out(usage == 2 ? "full anchorCert\n" : "full serverCert\n");
+			out(certDataField);
+			out("\n");
+			flush();
+		}
+		return (e);
+	}
+	if (match_type == 0 && selector == 1) { /*- match full subjectPublicKeyInfo data */
+		if (!(membio = BIO_new(BIO_s_mem()))) {
+			*err_str = ERR_error_string(ERR_get_error(), errbuf);
+			tlsquit("Z", "DANE unable to create membio: ", *err_str, 0, 0, 0);
+		}
+		if (!(pkey = X509_get_pubkey(xs))) {
+			*err_str = ERR_error_string(ERR_get_error(), errbuf);
+			tlsquit("Z", "DANE unable to get pubkey: ", *err_str, 0, 0, 0);
+		}
+		if (!PEM_write_bio_PUBKEY(membio, pkey)) {
+			*err_str = ERR_error_string(ERR_get_error(), errbuf);
+			tlsquit("Z", "DANE unable to write pubkey to membio: ", *err_str, 0, 0, 0);
+		}
+		for (;;) {
+			if (!BIO_gets(membio, buffer, sizeof(buffer) - 2))
+				break;
+			if (str_start(buffer, "-----BEGIN PUBLIC KEY-----"))
+				continue;
+			if (str_start(buffer, "-----END PUBLIC KEY-----"))
+				continue;
+			buffer[i = str_chr(buffer, '\n')] = '\0';
+			if (!stralloc_cats(&certData, buffer))
+				mem_err();
+		}
+		if (!stralloc_0(&certData))
+			mem_err();
+		certData.len--;
+		BIO_free_all(membio);
+		if (!str_diffn(certData.s, certDataField, certData.len))
+			return (0);
+		return (1);
+	}
+	/*- SHA512/SHA256 fingerprint of full certificate */
+	if ((match_type == 2 || match_type == 1) && selector == 0) {
+		if (!X509_digest(xs, md, md_value, &md_len))
+			tlsquit("Z", "TLS Unable to get peer cerficatte digest", 0, 0, 0, 0);
+		for (i = hextmp.len = 0; i < md_len; i++) {
+			fmt_hexbyte(hex, (md_value + i)[0]);
+			if (!stralloc_catb(&hextmp, hex, 2))
+				mem_err();
+		}
+		cp = hextmp.s;
+		if (!str_diffn(certDataField, (char *) cp, hextmp.len))
+			return (0);
+		return (1);
+	}
+	/*- SHA512/SHA256 fingerprint of subjectPublicKeyInfo */
+	if ((match_type == 2 || match_type == 1) && selector == 1) {
+		unsigned char  *tmpbuf = (unsigned char *) 0;
+
+#if OPENSSL_VERSION_NUMBER >= 0x10100000L
+		if (!(mdctx = EVP_MD_CTX_new()))
+			mem_err();
+#else
+		mdctx = &_mdctx;
+#endif
+		if (!(pkey = X509_get_pubkey(xs)))
+			tlsquit("Z", "TLS Unable to get public key", 0, 0, 0, 0);
+		if (!EVP_DigestInit_ex(mdctx, md, NULL))
+			tlsquit("Z", "TLS Unable to initialize EVP Digest", 0, 0, 0, 0);
+		if ((len = i2d_PUBKEY(pkey, NULL)) < 0)
+			tlsquit("", "TLS failed to encode public key", 0, 0, 0, 0);
+		if (!(tmpbuf = (unsigned char *) OPENSSL_malloc(len * sizeof(char))))
+			mem_err();
+		ptr = tmpbuf;
+		if ((len = i2d_PUBKEY(pkey, &ptr)) < 0)
+			tlsquit("Z", "TLS failed to encode public key", 0, 0, 0, 0);
+		if (!EVP_DigestUpdate(mdctx, tmpbuf, len))
+			tlsquit("Z", "TLS Unable to update EVP Digest", 0, 0, 0, 0);
+		OPENSSL_free(tmpbuf);
+		if (!EVP_DigestFinal_ex(mdctx, md_value, &md_len))
+			tlsquit("Z", "TLS Unable to compute EVP Digest", 0, 0, 0, 0);
+		for (i = hextmp.len = 0; i < md_len; i++) {
+			fmt_hexbyte(hex, (md_value + i)[0]);
+			if (!stralloc_catb(&hextmp, hex, 2))
+				mem_err();
+		}
+#if OPENSSL_VERSION_NUMBER >= 0x10100000L
+		EVP_MD_CTX_free(mdctx);
+#else
+		EVP_MD_CTX_cleanup(mdctx);
+#endif
+		cp = hextmp.s;
+		if (!str_diffn(certDataField, (char *) cp, hextmp.len))
+			return (0);
+		return (1);
+	}
+	return (1);
+}
+#endif /*- #ifdef HASTLSA */
+#endif /*- #ifdef TLS */
+
+void
+getversion_dossl_c()
+{
+	static char    *x = "$Id: dossl.c,v 1.1 2023-01-06 17:43:57+05:30 Cprogrammer Exp mbhangui $";
+
+	x++;
+}
+
+/*
+ * $Log: dossl.c,v $
+ * Revision 1.1  2023-01-06 17:43:57+05:30  Cprogrammer
+ * Initial revision
+ *
+ */

--- a/indimail-mta-x/dossl.h
+++ b/indimail-mta-x/dossl.h
@@ -1,0 +1,28 @@
+/*
+ * $Id: dossl.h,v 1.1 2023-01-06 17:44:26+05:30 Cprogrammer Exp mbhangui $
+ */
+#ifndef _DOSSL_H_
+#define _DOSSL_H_
+
+#include <openssl/ssl.h>
+#include <stralloc.h>
+#include <gen_alloc.h>
+#include <gen_allocdefs.h>
+
+GEN_ALLOC_typedef(saa, stralloc, sa, len, a)
+#ifdef TLS
+void            do_pkix(SSL *, char *, char *,
+                    void (*)(const char *, char *, char *, char *, char *, stralloc *), void(*)(),
+                    void(*)(char *, char *, int, int), stralloc *);
+int             do_tls(SSL **, int, int, int, int *, char **, char *, char *, int,
+                    void (*tlsquit)(const char *, char *, char *, char *, char *, stralloc *),
+                    void(*)(), void(*)(), void(*)(),
+                    void(*)(char *, char *, int, int), stralloc *, saa * _ehlokw, int);
+#endif
+#ifdef HASTLSA
+int
+                tlsa_vrfy_records(SSL *, char *, int, int, int, char *,
+                    void (*)(const char *, char *, char *, char *, char *, stralloc *),
+                    void(*)(), stralloc *, void(*out)(), void(*flush)(), char **, int);
+#endif
+#endif /*- _DOSSL_H_ */

--- a/indimail-mta-x/qmail-daned.c
+++ b/indimail-mta-x/qmail-daned.c
@@ -1,10 +1,9 @@
 /*
- * $Id: qmail-daned.c,v 1.32 2023-01-03 23:55:03+05:30 Cprogrammer Exp mbhangui $
+ * $Id: qmail-daned.c,v 1.33 2023-01-06 17:33:20+05:30 Cprogrammer Exp mbhangui $
  */
 #include "hastlsa.h"
 #include "subfd.h"
 #if defined(HASTLSA) && defined(TLS)
-#include <tls.h>
 #include <sys/socket.h>
 #include <netinet/in.h>
 #include <arpa/inet.h>
@@ -1239,6 +1238,7 @@ main(int argc, char **argv)
 #else
 #warning "TLSA, TLS code not compiled"
 #include <unistd.h>
+int             timeoutconn = 60;
 int
 main()
 {
@@ -1252,7 +1252,7 @@ main()
 void
 getversion_qmail_dane_c()
 {
-	static char    *x = "$Id: qmail-daned.c,v 1.32 2023-01-03 23:55:03+05:30 Cprogrammer Exp mbhangui $";
+	static char    *x = "$Id: qmail-daned.c,v 1.33 2023-01-06 17:33:20+05:30 Cprogrammer Exp mbhangui $";
 
 #if defined(HASTLSA) && defined(TLS)
 	x = sccsidstarttlsh;
@@ -1264,6 +1264,9 @@ getversion_qmail_dane_c()
 
 /*
  * $Log: qmail-daned.c,v $
+ * Revision 1.33  2023-01-06 17:33:20+05:30  Cprogrammer
+ * added timeoutconn variable
+ *
  * Revision 1.32  2023-01-03 23:55:03+05:30  Cprogrammer
  * removed __USE_GNU
  *


### PR DESCRIPTION
1. startls.c, qmail-remote.c: moved tls/ssl functions to dossl.c
2. dossl.c, dossl.h: tls/ssl support functions for qmail-remote, qmail-daned, dnstlsarr
3. qmail-daned, qmail-remote, dnstlsarr, Makefile: Link with dossl.o
4. smtpd.c: Fixed compilation for non-tls
5. doc/CREDITS: fixed numbering