### PR TITLE
added Ed25519-SHA256 cryptography method for DKIM

### DIFF
--- a/indimail-mta-x/dk-filter.sh
+++ b/indimail-mta-x/dk-filter.sh
@@ -1,5 +1,5 @@
 #
-# $Id: dk-filter.sh,v 1.31 2022-11-09 20:15:17+05:30 Cprogrammer Exp mbhangui $
+# $Id: dk-filter.sh,v 1.32 2023-01-26 22:26:01+05:30 Cprogrammer Exp mbhangui $
 #
 get_dkimkeys()
 {
@@ -164,7 +164,7 @@ if [ -z "$NODKIM" -a -n "$DKIMVERIFY" ] ; then
 fi
 /bin/cat > /tmp/dk.$$
 if [ $dkimsign -eq 1 ] ; then
-	# DKIMSIGNOPTIONS="-z 1 -b 2 -x - -y $dkimselector -s $dkimkeyfn"
+	# DKIMSIGNOPTIONS="-z 1 -x - -y $dkimselector -s $dkimkeyfn"
 	set -- $(getopt lqthb:c:d:i:x:z:y:s: $DKIMSIGNOPTIONS)
 	bopt=0
 	xopt=0
@@ -237,9 +237,6 @@ if [ $dkimsign -eq 1 ] ; then
 	done
 	if [ $zopt -eq 0 ] ; then
 		dkimopts="$dkimopts -z 1"
-	fi
-	if [ $bopt -eq 0 ] ; then
-		dkimopts="$dkimopts -b 2"
 	fi
 	if [ $xopt -eq 0 ] ; then
 		dkimopts="$dkimopts -x -"
@@ -356,6 +353,9 @@ exec 0</tmp/dk.$$
 exit $?
 #
 # $Log: dk-filter.sh,v $
+# Revision 1.32  2023-01-26 22:26:01+05:30  Cprogrammer
+# removed setting redundant -b option
+#
 # Revision 1.31  2022-11-09 20:15:17+05:30  Cprogrammer
 # replaced deprecated egrep with grep -E
 #

--- a/indimail-mta-x/dknewkey.9
+++ b/indimail-mta-x/dknewkey.9
@@ -3,7 +3,7 @@
 dknewkey \- create a new domain key
 
 .SH SYNOPSIS
-\fBdknewkey\fR [-\fBd\fR \fIdomain\fR | --\fBdomain\fR \fIdomain\fR]
+\fBdknewkey\fR [-\fBt\fR \fItype\fR] [-\fBd\fR \fIdomain\fR | --\fBdomain\fR \fIdomain\fR]
 [-\fBb\fR | --\fBbits\fR \fIbits\fR] [-\fBf\fR | --\fBforce\fR]
 \fIselector\fR
 
@@ -19,7 +19,13 @@ or
 
 .SH DESCRIPTION
 .B dknewkey
-creates a new key, and prints the associated DNS record (public key) on stdout.
+generates new DKIM keys and prints the associated DNS record (public key)
+on stdout. For RSA keys, it defaults to 2048 bit key size. This is
+controlled by the \fIbits\fR variable. ed25519 keys do not have a variable
+size. For RSA keys k=sha256 is now included in the public DNS record to
+prevent inadvertent use with the now obsolete sha1 hash algorithm (See RFC
+8301).
+
 .I selector
 is the file which will hold the private key. Additionally \fIselector.pub\fR
 containing the public key will be created.
@@ -39,9 +45,12 @@ uses the following
 .B openssl
 command to generate the private/public keys
 .IP \[bu] 2
-openssl -genrsa -out \fIselector\fR \fIbits\fR
+openssl -genrsa -out \fIselector\fR \fIbits\fR # for RSA
+.IP \[bu]
+openssl genpkey -algorithm Ed25519 -out \fIselector\fR # for Ed25519
 .IP \[bu]
 openssl rsa -in \fIselector\fR -out \fIselector.pub\fR -pubout -outform PEM
+
 
 .SH OPTIONS
 .TP
@@ -53,6 +62,11 @@ print DKIM public key for selector \fIselector\fR, domain \fIdomain\fR. If
 .TP
 -\fBr\fR | --\fBremove\fR
 remove DKIM keys for selector \fIselector\fR, domain \fIdomain\fR
+
+.TP
+-\fBt\fR \fItype\fR | --\fBtype\fR \fItype\fR
+Key type to use for cryptography method. Valid values are rsa and ed25519.
+Defaults to rsa.
 
 .TP
 -\fBd\fR \fIdomain\fR | --\fBdomain\fR \fIdomain\fR

--- a/indimail-mta-x/doc/ChangeLog
+++ b/indimail-mta-x/doc/ChangeLog
@@ -248,6 +248,10 @@ o qmail-remote can use credentials stored in remote_auth.cdb using simple or
     replaced qprintf with subprintf
 - 21/01/2023
 136.Added flags to warn issues with variadic functions
+- 26/01/2023
+137.dknewkey.sh: added option to generate ed25519 DKIM keys
+138.qmail-dkim.c, dk-filter.sh: removed setting redundant -b option
+139.qmail-dkim.c: update verification message to include ED25519 failure
 
 * Thu 08 Sep 2022 12:31:45 +0000 Manvendra Bhangui <indimail-mta@indimail.org> 3.0.1-1.1%{?dist}
 Release 3.0.1 Start 21/05/2022 End 08/09/2022

--- a/indimail-mta-x/qmail-dkim.9
+++ b/indimail-mta-x/qmail-dkim.9
@@ -53,7 +53,6 @@ You can set various DKIM options in getopt style, by setting the environment var
 .B DKIMSIGNOPTIONS
 
 .nf
-b <standard>         1 - allman, 2 - ietf or 3 - both
 c <canonicalization> r for relaxed [DEFAULT], s - simple,
                      t relaxed/simple, u - simple/relaxed
 l                    include body length tag
@@ -66,12 +65,12 @@ i <identity>         the identity, if not provided it will not be included
 x <expire_time>      the expire time in seconds since epoch
                      ( DEFAULT = current time + 604800)
                      if set to - then it will not be included
-z <hash>             1 for sha1, 2 for sha256, 3 for both
+z <hash>             1 for RSA-SHA1, 2 for RSA-SHA256, 3 for both, 4 for Ed25519-SHA256
 .fi
 
 .EX
-DKIMSIGNOPTIONS="-b 1 -c r -q"
-sets allman standard, with relaxed canonicalization and include query method tag
+DKIMSIGNOPTIONS="-z 2 -c r -q"
+Use RSA SHA256 hash, set relaxed canonicalization and include query method tag
 .EE
 
 Apart from setting

--- a/indimail-mta-x/qmail-dkim.c
+++ b/indimail-mta-x/qmail-dkim.c
@@ -1,5 +1,5 @@
 /*
- * $Id: qmail-dkim.c,v 1.68 2022-10-17 19:44:32+05:30 Cprogrammer Exp mbhangui $
+ * $Id: qmail-dkim.c,v 1.69 2023-01-26 22:32:01+05:30 Cprogrammer Exp mbhangui $
  */
 #include "hasdkim.h"
 #ifdef HASDKIM
@@ -517,11 +517,11 @@ writeHeaderNexit(int ret, int origRet, int resDKIMSSP, int resDKIMADSP, int useS
 		code = "X.7.5";
 		break;
 	case DKIM_SIGNATURE_BAD:	/*- -3 */
-		dkimStatus = "signature error: RSA verify failed";
+		dkimStatus = "signature error: RSA/ED25519 verify failed";
 		code = "X.7.5";
 		break;
 	case DKIM_SIGNATURE_BAD_BUT_TESTING:
-		dkimStatus = "signature error: RSA verify failed but testing";
+		dkimStatus = "signature error: RSA/ED25519 verify failed but testing";
 		code = "X.7.5";
 		break;
 	case DKIM_SIGNATURE_EXPIRED:
@@ -777,7 +777,6 @@ dkim_setoptions(DKIMSignOptions *opts, char *signOptions)
 	int             ch, argc;
 	char          **argv;
 
-	opts->nIncludeBodyHash = DKIM_BODYHASH_IETF_1;
 	opts->nCanon = DKIM_SIGN_RELAXED;					/*- c */
 	opts->nIncludeBodyLengthTag = 0;					/*- l */
 	opts->nIncludeQueryMethod = 0;						/*- q */
@@ -804,21 +803,6 @@ dkim_setoptions(DKIMSignOptions *opts, char *signOptions)
 		switch (ch)
 		{
 		case 'b':
-			switch (*optarg)
-			{
-			case '1':
-				opts->nIncludeBodyHash = DKIM_BODYHASH_ALLMAN_1;
-				break;
-			case '2':
-				opts->nIncludeBodyHash = DKIM_BODYHASH_IETF_1;
-				break;
-			case '3':
-				opts->nIncludeBodyHash = DKIM_BODYHASH_BOTH;
-				break;
-			default:
-				free_makeargs(argv);
-				return (1);
-			}
 			break;
 		case 'c':
 			switch (*optarg)
@@ -1206,7 +1190,7 @@ main(argc, argv)
 void
 getversion_qmail_dkim_c()
 {
-	static char    *x = "$Id: qmail-dkim.c,v 1.68 2022-10-17 19:44:32+05:30 Cprogrammer Exp mbhangui $";
+	static char    *x = "$Id: qmail-dkim.c,v 1.69 2023-01-26 22:32:01+05:30 Cprogrammer Exp mbhangui $";
 
 #ifdef HASDKIM
 	x = sccsidmakeargsh;
@@ -1220,6 +1204,10 @@ getversion_qmail_dkim_c()
 
 /*
  * $Log: qmail-dkim.c,v $
+ * Revision 1.69  2023-01-26 22:32:01+05:30  Cprogrammer
+ * removed setting redundant -b option
+ * update verification message to include ED25519 failure
+ *
  * Revision 1.68  2022-10-17 19:44:32+05:30  Cprogrammer
  * use exit codes defines from qmail.h
  *

--- a/indimail-mta-x/qmail-dkim.c
+++ b/indimail-mta-x/qmail-dkim.c
@@ -1,5 +1,5 @@
 /*
- * $Id: qmail-dkim.c,v 1.69 2023-01-26 22:32:01+05:30 Cprogrammer Exp mbhangui $
+ * $Id: qmail-dkim.c,v 1.69 2023-01-26 22:59:19+05:30 Cprogrammer Exp mbhangui $
  */
 #include "hasdkim.h"
 #ifdef HASDKIM
@@ -859,7 +859,7 @@ dkim_setoptions(DKIMSignOptions *opts, char *signOptions)
 				opts->nHash = DKIM_HASH_SHA256;
 				break;
 			case '3':
-				opts->nHash = DKIM_HASH_SHA1_AND_256;
+				opts->nHash = DKIM_HASH_SHA1_AND_SHA256;
 				break;
 			default:
 				free_makeargs(argv);
@@ -1190,7 +1190,7 @@ main(argc, argv)
 void
 getversion_qmail_dkim_c()
 {
-	static char    *x = "$Id: qmail-dkim.c,v 1.69 2023-01-26 22:32:01+05:30 Cprogrammer Exp mbhangui $";
+	static char    *x = "$Id: qmail-dkim.c,v 1.69 2023-01-26 22:59:19+05:30 Cprogrammer Exp mbhangui $";
 
 #ifdef HASDKIM
 	x = sccsidmakeargsh;
@@ -1204,7 +1204,7 @@ getversion_qmail_dkim_c()
 
 /*
  * $Log: qmail-dkim.c,v $
- * Revision 1.69  2023-01-26 22:32:01+05:30  Cprogrammer
+ * Revision 1.69  2023-01-26 22:59:19+05:30  Cprogrammer
  * removed setting redundant -b option
  * update verification message to include ED25519 failure
  *

--- a/libdkim-x/dkim.9
+++ b/libdkim-x/dkim.9
@@ -14,8 +14,16 @@ exercises the dkim library. Both signing and verification merely print out the D
 They do not keep a copy of the input file. You will need to do something like this:
 
 .EX
- (./dkim -s INDIMAIL/control/domainkeys/dog </tmp/testmsg; cat /tmp/testmsg)\
+This example verifies using DNS
+
+ (./dkim -s INDIMAIL/control/domainkeys/dog </tmp/testmsg; cat /tmp/testmsg)\\
  | ./dkim -v
+
+This example does not use DNS. Useful for testing
+
+ (./dkim -z 4 -s /tmp/domainkeys/efgh </tmp/mail.txt;cat /tmp/mail.txt) \\
+ | ./dkim -v -T \\
+ "v=DKIM1; k=ed25519; t=y; p=MCowBQYDK2VwAyEAokZUL1G6RmS4IWfCpCX3xjGKhVssoM4KfKpkmW8IERg="
 .EE
 
 .SH OPTIONS
@@ -47,30 +55,34 @@ ADU9NbAcpDh+E2YQwzCX
 .TP
 -l
 include body length tag when signing. Honor body length tag when verifying
+
 .TP
 -q
 include query method tag
+
 .TP
 -t
 include a timestamp tag
+
 .TP
 -f
 issue error if not all message's From headers are in signature
+
 .TP
 -S
 Allow unsigned subject in signature
+
 .TP
 -h
 include Copied Headers. This adds the z= tag with a list of the message's
 original headers and may differ from the headers listed in the h= tag. This
 tag may be used by some mailbox providers in the process of diagnosing a
 verification error. Its value is not well defined.
+
 .TP
 -p \fIssp\fR | \fIadsp\fR
 0 - disable practice (default), 1- SSP, or 2 - ADSP verification
-.TP
--b \fIstandard\fR
-1 - allman, 2 - ietf or 3 - both
+
 .TP
 -c \fIcanonicalization\fR
 r for relaxed [DEFAULT], s - simple, t relaxed/simple, u - simple/relaxed
@@ -78,21 +90,31 @@ r for relaxed [DEFAULT], s - simple, t relaxed/simple, u - simple/relaxed
 .TP
 -d \fIdomain\fR
 the domain tag, if not provided, determined from the return-path/sender/from header
+
 .TP
 -i \fIidentity\fR
 the identity, if not provided it will not be included
+
 .TP
 -x \fIexpire_time\fR
 the expire time in seconds since epoch ( DEFAULT = current time + 604800). If set to - then it will not be included
+
 .TP
 -z \fIhash\fR
-1 for sha1, 2 for sha256, 3 for both
+1 - sha1, 2 - sha256, 3 - sha1+sha256
+
 .TP
 -y \fIselector\fR
 the selector tag DEFAULT=private
+
 .TP
 -s \fIprivkeyfile\fR
 sign the message using the private key in privkeyfile
+
+.TP
+-T \fIselectorRecord\fR
+Bypass DNS and use \fIselectorRecord\fR instead of fetching the record using DNS.
+
 .TP
 -H
 this help

--- a/libdkim-x/dkim.h
+++ b/libdkim-x/dkim.h
@@ -1,5 +1,8 @@
 /*
  * $Log: dkim.h,v $
+ * Revision 1.10  2023-01-26 22:38:16+05:30  Cprogrammer
+ * added definition for DKIM_HASH_ED25519
+ *
  * Revision 1.9  2021-08-28 21:41:40+05:30  Cprogrammer
  * added DKIMSignReplaceSelector to replace selector
  *
@@ -57,79 +60,78 @@ extern          "C" {
 #endif
 
 #include <time.h>
-// DKIM Body hash versions
-#define DKIM_BODYHASH_ALLMAN_1	1
-#define DKIM_BODYHASH_IETF_1	2
-#define DKIM_BODYHASH_BOTH		DKIM_BODYHASH_ALLMAN_1 | DKIM_BODYHASH_IETF_1
 
-// DKIM hash algorithms
-#define DKIM_HASH_SHA1			1
-#define DKIM_HASH_SHA256		2
-#define DKIM_HASH_SHA1_AND_256  DKIM_HASH_SHA1 | DKIM_HASH_SHA256
+/* DKIM hash algorithms */
+#define DKIM_HASH_SHA1              1
+#define DKIM_HASH_SHA256            2
+#define DKIM_HASH_SHA1_AND_SHA256   3
+#define DKIM_HASH_ED25519           4
 
-// DKIM canonicalization methods
-#define DKIM_CANON_SIMPLE		1
-#define DKIM_CANON_NOWSP		2
-#define DKIM_CANON_RELAXED		3
+/* DKIM canonicalization methods */
+#define DKIM_CANON_SIMPLE           1
+#define DKIM_CANON_NOWSP            2
+#define DKIM_CANON_RELAXED          3
 
 #define DKIM_SIGN_SIMPLE			MAKELONG(DKIM_CANON_SIMPLE,DKIM_CANON_SIMPLE)
 #define DKIM_SIGN_SIMPLE_RELAXED	MAKELONG(DKIM_CANON_RELAXED,DKIM_CANON_SIMPLE)
 #define DKIM_SIGN_RELAXED			MAKELONG(DKIM_CANON_RELAXED,DKIM_CANON_RELAXED)
 #define DKIM_SIGN_RELAXED_SIMPLE	MAKELONG(DKIM_CANON_SIMPLE,DKIM_CANON_RELAXED)
 
-// DKIM_SUCCESS                                 // verify result: all signatures verified
-// signature result: signature verified
-#define DKIM_SUCCESS						 0	// operation successful
-#define DKIM_FINISHED_BODY					 1	// process result: no more message body is needed
-#define DKIM_PARTIAL_SUCCESS				 2	// verify result: at least one but not all signatures verified
-#define DKIM_NEUTRAL						 3	// verify result: no signatures verified but message is not suspicous
-#define DKIM_SUCCESS_BUT_EXTRA				 4	// signature result: signature verified but it did not include all of the body
-#define DKIM_3PS_SIGNATURE					 5	// 3rd-party signature
+/*
+ * DKIM_SUCCESS                                 verify result: all signatures verified
+ * signature result: signature verified
+ */
+#define DKIM_SUCCESS                          0 /* operation successful */
+#define DKIM_FINISHED_BODY                    1 /* process result: no more message body is needed */
+#define DKIM_PARTIAL_SUCCESS                  2 /* verify result: at least one but not all signatures verified */
+#define DKIM_NEUTRAL                          3 /* verify result: no signatures verified but message is not suspicous */
+#define DKIM_SUCCESS_BUT_EXTRA                4 /* signature result: signature verified but it did not include all of the body */
+#define DKIM_3PS_SIGNATURE                    5 /* 3rd-party signature */
 
-// DKIM Error codes
-#define DKIM_FAIL							-1	// verify error: message is suspicious
-#define DKIM_BAD_SYNTAX						-2	// signature error: DKIM-Signature could not parse or has bad tags/values
-#define DKIM_SIGNATURE_BAD					-3	// signature error: RSA verify failed
-#define DKIM_SIGNATURE_BAD_BUT_TESTING		-4	// signature error: RSA verify failed but testing
-#define DKIM_SIGNATURE_EXPIRED				-5	// signature error: x= is old
-#define DKIM_SELECTOR_INVALID				-6	// signature error: selector doesn't parse or contains invalid values
-#define DKIM_SELECTOR_GRANULARITY_MISMATCH	-7	// signature error: selector g= doesn't match i=
-#define DKIM_SELECTOR_KEY_REVOKED			-8	// signature error: selector p= empty
-#define DKIM_SELECTOR_DOMAIN_NAME_TOO_LONG	-9	// signature error: selector domain name too long to request
-#define DKIM_SELECTOR_DNS_TEMP_FAILURE		-10	// signature error: temporary dns failure requesting selector
-#define DKIM_SELECTOR_DNS_PERM_FAILURE		-11	// signature error: permanent dns failure requesting selector
-#define DKIM_SELECTOR_PUBLIC_KEY_INVALID	-12	// signature error: selector p= value invalid or wrong format
-#define DKIM_NO_SIGNATURES					-13	// process error, no sigs
-#define DKIM_NO_VALID_SIGNATURES			-14	// process error, no valid sigs
-#define DKIM_BODY_HASH_MISMATCH				-15	// sigature verify error: message body does not hash to bh value
-#define DKIM_SELECTOR_ALGORITHM_MISMATCH	-16	// signature error: selector h= doesn't match signature a=
-#define DKIM_STAT_INCOMPAT					-17	// signature error: incompatible v=
-#define DKIM_UNSIGNED_FROM                  -18 // signature error: not all message's From headers in signature
-#define DKIM_OUT_OF_MEMORY                  -19 // memory allocation failed
-#define DKIM_INVALID_CONTEXT                -20 // DKIMContext structure invalid for this operation
-#define DKIM_NO_SENDER                      -21 // signing error: Could not find From: or Sender: header in message
-#define DKIM_BAD_PRIVATE_KEY                -22 // signing error: Could not parse private key
-#define DKIM_BUFFER_TOO_SMALL               -23 // signing error: Buffer passed in is not large enough
-#define DKIM_MAX_ERROR                      -24 // set this to 1 greater than the highest error code (but negative)
+/* DKIM Error codes */
+#define DKIM_FAIL                            -1 /* verify error: message is suspicious */
+#define DKIM_BAD_SYNTAX                      -2 /* signature error: DKIM-Signature could not parse or has bad tags/values */
+#define DKIM_SIGNATURE_BAD                   -3 /* signature error: RSA/ED25519 verify failed */
+#define DKIM_SIGNATURE_BAD_BUT_TESTING       -4 /* signature error: RSA/ED25519 verify failed but testing */
+#define DKIM_SIGNATURE_EXPIRED               -5 /* signature error: x= is old */
+#define DKIM_SELECTOR_INVALID                -6 /* signature error: selector doesn't parse or contains invalid values */
+#define DKIM_SELECTOR_GRANULARITY_MISMATCH   -7 /* signature error: selector g= doesn't match i= */
+#define DKIM_SELECTOR_KEY_REVOKED            -8 /* signature error: selector p= empty */
+#define DKIM_SELECTOR_DOMAIN_NAME_TOO_LONG   -9 /* signature error: selector domain name too long to request */
+#define DKIM_SELECTOR_DNS_TEMP_FAILURE      -10 /* signature error: temporary dns failure requesting selector */
+#define DKIM_SELECTOR_DNS_PERM_FAILURE      -11 /* signature error: permanent dns failure requesting selector */
+#define DKIM_SELECTOR_PUBLIC_KEY_INVALID    -12 /* signature error: selector p= value invalid or wrong format */
+#define DKIM_NO_SIGNATURES                  -13 /* process error, no sigs */
+#define DKIM_NO_VALID_SIGNATURES            -14 /* process error, no valid sigs */
+#define DKIM_BODY_HASH_MISMATCH             -15 /* sigature verify error: message body does not hash to bh value */
+#define DKIM_SELECTOR_ALGORITHM_MISMATCH    -16 /* signature error: selector h= doesn't match signature a= */
+#define DKIM_STAT_INCOMPAT                  -17 /* signature error: incompatible v= */
+#define DKIM_UNSIGNED_FROM                  -18 /* signature error: not all message's From headers in signature */
+#define DKIM_OUT_OF_MEMORY                  -19 /* memory allocation failed */
+#define DKIM_INVALID_CONTEXT                -20 /* DKIMContext structure invalid for this operation */
+#define DKIM_NO_SENDER                      -21 /* signing error: Could not find From: or Sender: header in message */
+#define DKIM_BAD_PRIVATE_KEY                -22 /* signing error: Could not parse private key */
+#define DKIM_BUFFER_TOO_SMALL               -23 /* signing error: Buffer passed in is not large enough */
+#define DKIM_MAX_ERROR                      -24 /* set this to 1 greater than the highest error code (but negative) */
 
-#define DKIM_SSP_UNKNOWN			 1 /*- some messages may be signed */
-#define DKIM_SSP_ALL				 2 /*- all messages are signed, 3rd party allowed */
-#define DKIM_SSP_STRICT				 3 /*- all messages are signed, no 3rd party allowed */
-#define DKIM_SSP_SCOPE				 4 /*- the domain should be considered invalid */
-#define DKIM_SSP_TEMPFAIL			 5 /*- Temporary Error */
+#define DKIM_SSP_UNKNOWN                      1 /*- some messages may be signed */
+#define DKIM_SSP_ALL                          2 /*- all messages are signed, 3rd party allowed */
+#define DKIM_SSP_STRICT                       3 /*- all messages are signed, no 3rd party allowed */
+#define DKIM_SSP_SCOPE                        4 /*- the domain should be considered invalid */
+#define DKIM_SSP_TEMPFAIL                     5 /*- Temporary Error */
 
-#define DKIM_ADSP_UNKNOWN			 1 /*- some messages may be signed */
-#define DKIM_ADSP_ALL				 2 /*- All message are signed with author signature */
-#define DKIM_ADSP_DISCARDABLE		 3 /*- messages which fail verification are Discardable */
-#define DKIM_ADSP_SCOPE				 4 /*- domain is out of scope */
-#define DKIM_ADSP_TEMPFAIL			 5 /*- Temporary Error */
+#define DKIM_ADSP_UNKNOWN                     1 /*- some messages may be signed */
+#define DKIM_ADSP_ALL                         2 /*- All message are signed with author signature */
+#define DKIM_ADSP_DISCARDABLE                 3 /*- messages which fail verification are Discardable */
+#define DKIM_ADSP_SCOPE                       4 /*- domain is out of scope */
+#define DKIM_ADSP_TEMPFAIL                    5 /*- Temporary Error */
 
 
-// This function is called once for each header in the message
-// return 1 to include this header in the signature and 0 to exclude.
+/* This function is called once for each header in the message */
+/* return 1 to include this header in the signature and 0 to exclude. */
 typedef int     (DKIM_CALL *DKIMHEADERCALLBACK) (const char *szHeader);
 
-// This function is called to retrieve a TXT record from DNS
+/* This function is called to retrieve a TXT record from DNS */
 typedef int     (DKIM_CALL *DKIMDNSCALLBACK) (const char *szFQDN, char *szBuffer, int nBufLen);
 
 typedef struct DKIMContext_t {
@@ -139,31 +141,30 @@ typedef struct DKIMContext_t {
 } DKIMContext;
 
 typedef struct DKIMSignOptions_t {
-	int             nCanon;	// canonization 
-	int             nIncludeBodyLengthTag;	// 0 = don't include l= tag, 1 = include l= tag
-	int             nIncludeTimeStamp;	// 0 = don't include t= tag, 1 = include t= tag
-	int             nIncludeQueryMethod;	// 0 = don't include q= tag, 1 = include q= tag
-	char            szSelector[80];	// selector - required
-	char            szDomain[256];	// domain - optional - if empty, domain is computed from sender
-	char            szIdentity[256];	// for i= tag, if empty tag will not be included in sig
-	time_t          expireTime;	// for x= tag, if 0 tag will not be included in sig
-	DKIMHEADERCALLBACK pfnHeaderCallback;	// header callback
-	char            szRequiredHeaders[256];	// colon-separated list of headers that must be signed
-	int             nHash;	// use one of the DKIM_HASH_xx constants here
-	// even if not present in the message
-	int             nIncludeCopiedHeaders;	// 0 = don't include z= tag, 1 = include z= tag
-	int             nIncludeBodyHash;	// use one of the DKIM_BODYHASH_xx constants here
+	int             nCanon;                 /* canonization */
+	int             nIncludeBodyLengthTag;  /* 0 = don't include l= tag, 1 = include l= tag */
+	int             nIncludeTimeStamp;      /* 0 = don't include t= tag, 1 = include t= tag */
+	int             nIncludeQueryMethod;    /* 0 = don't include q= tag, 1 = include q= tag */
+	char            szSelector[80];         /* selector - required */
+	char            szDomain[256];          /* domain - optional - if empty, domain is computed from sender */
+	char            szIdentity[256];        /* for i= tag, if empty tag will not be included in sig */
+	time_t          expireTime;             /* for x= tag, if 0 tag will not be included in sig */
+	DKIMHEADERCALLBACK pfnHeaderCallback;   /* header callback */
+	char            szRequiredHeaders[256]; /* colon-separated list of headers that must be signed */
+	int             nHash;                  /* use one of the DKIM_HASH_xx constants here, even if not present in the message */
+	int             nIncludeCopiedHeaders;  /* 0 = don't include z= tag, 1 = include z= tag */
+	int             nIncludeBodyHash;       /* use one of the DKIM_BODYHASH_xx constants here */
 } DKIMSignOptions;
 
 typedef struct DKIMVerifyOptions_t {
-	DKIMDNSCALLBACK pfnSelectorCallback;	// selector record callback
-	DKIMDNSCALLBACK pfnPracticesCallback;	// SSP record callback
-	int             nHonorBodyLengthTag;	// 0 = ignore l= tag, 1 = use l= tag to limit the amount of body verified
-	int             nCheckPractices;		// 0 = use default (unknown) practices, 1 = request and use sender's signing practices
-	int             nSubjectRequired;		// 0 = subject is required to be signed, 1 = not required
-	int             nSaveCanonicalizedData;	// 0 = canonicalized data is not saved, 1 = canonicalized data is saved
-	int             nAllowUnsignedFromHeaders;	// 0 = From headers not included in the signature are not allowed, 1 = allowed
-	int             nAccept3ps;				// 0 = don't check 3rd party signature(s), 1 = check 3rd party signature(s)
+	DKIMDNSCALLBACK pfnSelectorCallback;       /* selector record callback */
+	DKIMDNSCALLBACK pfnPracticesCallback;      /* SSP record callback */
+	int             nHonorBodyLengthTag;       /* 0 = ignore l= tag, 1 = use l= tag to limit the amount of body verified */
+	int             nCheckPractices;           /* 0 = use default (unknown) practices, 1 = request and use sender's signing practices */
+	int             nSubjectRequired;          /* 0 = subject is required to be signed, 1 = not required */
+	int             nSaveCanonicalizedData;    /* 0 = canonicalized data is not saved, 1 = canonicalized data is saved */
+	int             nAllowUnsignedFromHeaders; /* 0 = From headers not included in the signature are not allowed, 1 = allowed */
+	int             nAccept3ps;                /* 0 = don't check 3rd party signature(s), 1 = check 3rd party signature(s) */
 } DKIMVerifyOptions;
 
 typedef struct DKIMVerifyDetails_t {

--- a/libdkim-x/dkimsign.cpp
+++ b/libdkim-x/dkimsign.cpp
@@ -1,5 +1,8 @@
 /*
  * $Log: dkimsign.cpp,v $
+ * Revision 1.20  2023-01-26 22:51:21+05:30  Cprogrammer
+ * added ed25519 encryption for DKIM signatues
+ *
  * Revision 1.19  2021-08-28 21:42:23+05:30  Cprogrammer
  * added ReplaceSelector to replace selector
  *
@@ -95,25 +98,25 @@ CDKIMSign::CDKIMSign()
 	m_EmptyLineCount = 0;
 	m_pfnHdrCallback = NULL;
 #if OPENSSL_VERSION_NUMBER >= 0x10100000L
-	if (!m_allman_sha1ctx)
-		m_allman_sha1ctx = EVP_MD_CTX_new();
-	EVP_SignInit(m_allman_sha1ctx, EVP_sha1());
 	if (!m_Hdr_ietf_sha1ctx)
 		m_Hdr_ietf_sha1ctx = EVP_MD_CTX_new();
 	EVP_SignInit(m_Hdr_ietf_sha1ctx, EVP_sha1());
+
 	if (!m_Bdy_ietf_sha1ctx)
 		m_Bdy_ietf_sha1ctx = EVP_MD_CTX_new();
 	EVP_DigestInit(m_Bdy_ietf_sha1ctx, EVP_sha1());
-#ifdef HAVE_EVP_SHA256
+
 	if (!m_Hdr_ietf_sha256ctx)
 		m_Hdr_ietf_sha256ctx = EVP_MD_CTX_new();
 	EVP_SignInit(m_Hdr_ietf_sha256ctx, EVP_sha256());
+
 	if (!m_Bdy_ietf_sha256ctx)
 		m_Bdy_ietf_sha256ctx = EVP_MD_CTX_new();
 	EVP_DigestInit(m_Bdy_ietf_sha256ctx, EVP_sha256());
-#endif
+
+	if (!m_Hdr_ed25519ctx)
+		m_Hdr_ed25519ctx = EVP_MD_CTX_new();
 #else
-	EVP_SignInit(&m_allman_sha1ctx, EVP_sha1());
 	EVP_SignInit(&m_Hdr_ietf_sha1ctx, EVP_sha1());
 	EVP_DigestInit(&m_Bdy_ietf_sha1ctx, EVP_sha1());
 #ifdef HAVE_EVP_SHA256
@@ -126,15 +129,12 @@ CDKIMSign::CDKIMSign()
 CDKIMSign::~CDKIMSign()
 {
 #if OPENSSL_VERSION_NUMBER >= 0x10100000L
-	EVP_MD_CTX_reset(m_allman_sha1ctx);
 	EVP_MD_CTX_reset(m_Hdr_ietf_sha1ctx);
 	EVP_MD_CTX_reset(m_Bdy_ietf_sha1ctx);
-#ifdef HAVE_EVP_SHA256
 	EVP_MD_CTX_reset(m_Hdr_ietf_sha256ctx);
 	EVP_MD_CTX_reset(m_Bdy_ietf_sha256ctx);
-#endif
+	EVP_MD_CTX_free(m_Hdr_ed25519ctx);
 #else
-	EVP_MD_CTX_cleanup(&m_allman_sha1ctx);
 	EVP_MD_CTX_cleanup(&m_Hdr_ietf_sha1ctx);
 	EVP_MD_CTX_cleanup(&m_Bdy_ietf_sha1ctx);
 #ifdef HAVE_EVP_SHA256
@@ -145,11 +145,9 @@ CDKIMSign::~CDKIMSign()
 }
 
 
-////////////////////////////////////////////////////////////////////////////////
-// 
-// Init - save the options
-//
-////////////////////////////////////////////////////////////////////////////////
+/* 
+ * Init - save the options
+ */
 int
 CDKIMSign::Init(DKIMSignOptions *pOptions)
 {
@@ -170,7 +168,6 @@ CDKIMSign::Init(DKIMSignOptions *pOptions)
 	m_nIncludeTimeStamp = pOptions->nIncludeTimeStamp;
 	m_nIncludeQueryMethod = pOptions->nIncludeQueryMethod;
 	m_nIncludeCopiedHeaders = pOptions->nIncludeCopiedHeaders;
-	m_nIncludeBodyHash = pOptions->nIncludeBodyHash;
 
 	/*-
 	 * NOTE: the following line is not backwards compatible with MD 8.0.3
@@ -184,6 +181,10 @@ CDKIMSign::Init(DKIMSignOptions *pOptions)
 	m_nHash = pOptions->nHash;
 	m_bReturnedSigAssembled = false;
 	m_sCopiedHeaders.erase();
+#if ((OPENSSL_VERSION_NUMBER > 0x10101000L))
+	SigHdrs.assign("");
+	m_SigHdrs = 0;
+#endif
 	return nRet;
 }
 
@@ -193,63 +194,52 @@ CDKIMSign::ReplaceSelector(DKIMSignOptions *pOptions)
 	sSelector.assign(pOptions->szSelector);
 }
 
-// Hash - update the hash
+/* Hash - update the hash */
 void
-CDKIMSign::Hash(const char *szBuffer, int nBufLength, bool bHdr, bool bAllmanOnly)
+CDKIMSign::Hash(const char *szBuffer, int nBufLength, bool bHdr)
 {
-	EVP_MD_CTX     *p1, *p2, *p3, *p4, *p5;
+	EVP_MD_CTX     *p1, *p2, *p3, *p4;
 #if OPENSSL_VERSION_NUMBER >= 0x10100000L
-	p1 = m_allman_sha1ctx;
-	p2 = m_Hdr_ietf_sha1ctx;
-	p3 = m_Hdr_ietf_sha256ctx;
-	p4 = m_Bdy_ietf_sha1ctx;
-	p5 = m_Bdy_ietf_sha256ctx;
+	p1 = m_Hdr_ietf_sha1ctx;
+	p2 = m_Hdr_ietf_sha256ctx;
+	p3 = m_Bdy_ietf_sha1ctx;
+	p4 = m_Bdy_ietf_sha256ctx;
 #else
-	p1 = &m_allman_sha1ctx;
-	p2 = &m_Hdr_ietf_sha1ctx;
-	p3 = &m_Hdr_ietf_sha256ctx;
-	p4 = &m_Bdy_ietf_sha1ctx;
-	p5 = &m_Bdy_ietf_sha256ctx;
-#endif
-	if (bAllmanOnly) {
-		if (m_nIncludeBodyHash & DKIM_BODYHASH_ALLMAN_1)
-			EVP_SignUpdate(p1, szBuffer, nBufLength);
-	} else {
-		if (m_nIncludeBodyHash < DKIM_BODYHASH_IETF_1)
-			EVP_SignUpdate(p1, szBuffer, nBufLength);
-		else
-		if (m_nIncludeBodyHash & DKIM_BODYHASH_IETF_1) {
-			if (m_nIncludeBodyHash & DKIM_BODYHASH_ALLMAN_1)
-				EVP_SignUpdate(p1, szBuffer, nBufLength);
+	p1 = &m_Hdr_ietf_sha1ctx;
 #ifdef HAVE_EVP_SHA256
-			if (m_nHash & DKIM_HASH_SHA256) {
-				if (bHdr)
-					EVP_SignUpdate(p3, szBuffer, nBufLength);
-				else
-					EVP_DigestUpdate(p5, szBuffer, nBufLength);
-			}
-			if (m_nHash != DKIM_HASH_SHA256) {
-				if (bHdr)
-					EVP_SignUpdate(p2, szBuffer, nBufLength);
-				else
-					EVP_DigestUpdate(p4, szBuffer, nBufLength);
-			}
-#else
-			if (bHdr)
-				EVP_SignUpdate(p2, szBuffer, nBufLength);
-			else
-				EVP_DigestUpdate(p4, szBuffer, nBufLength);
+	p2 = &m_Hdr_ietf_sha256ctx;
 #endif
+	p3 = &m_Bdy_ietf_sha1ctx;
+#ifdef HAVE_EVP_SHA256
+	p4 = &m_Bdy_ietf_sha256ctx;
+#endif
+#endif
+
+	if (bHdr) { /* Generate signature: b=... */
+		if (m_nHash == DKIM_HASH_SHA1 || m_nHash == DKIM_HASH_SHA1_AND_SHA256)
+			EVP_SignUpdate(p1, szBuffer, nBufLength);
+#ifdef HAVE_EVP_SHA256
+		EVP_SignUpdate(p2, szBuffer, nBufLength);
+#endif
+#if OPENSSL_VERSION_NUMBER >= 0x10101000L
+		if (m_nHash == DKIM_HASH_ED25519) {
+			SigHdrs.append(szBuffer, nBufLength);
+			m_SigHdrs += nBufLength;
 		}
+#endif
+	} else { /* lets go for body hash values: bh=... */
+		if (m_nHash == DKIM_HASH_SHA1 || m_nHash == DKIM_HASH_SHA1_AND_SHA256)
+			EVP_DigestUpdate(p3, szBuffer, nBufLength);
+#ifdef HAVE_EVP_SHA256
+		EVP_DigestUpdate(p4, szBuffer, nBufLength);
+#endif
 	}
 }
 
 
-////////////////////////////////////////////////////////////////////////////////
-// 
-// SignThisTag - return boolean whether or not to sign this tag
-//
-////////////////////////////////////////////////////////////////////////////////
+/* 
+ * SignThisTag - return boolean whether or not to sign this tag
+ */
 bool CDKIMSign::SignThisTag(const string &sTag)
 {
 	bool            bRet = true;
@@ -270,7 +260,7 @@ ConvertHeaderToQuotedPrintable(const char *source, char *dest)
 {
 	bool            bConvert = false;
 
-// do quoted printable
+	/* do quoted printable */
 	static unsigned char hexchars[16] = { '0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'A', 'B', 'C', 'D', 'E', 'F' };
 	unsigned char  *d = (unsigned char *) dest;
 	for (const unsigned char *s = (const unsigned char *)source; *s != '\0'; s++) {
@@ -288,11 +278,9 @@ ConvertHeaderToQuotedPrintable(const char *source, char *dest)
 }
 
 
-////////////////////////////////////////////////////////////////////////////////
-// 
-// GetHeaderParams - Extract any needed header parameters
-//
-////////////////////////////////////////////////////////////////////////////////
+/* 
+ * GetHeaderParams - Extract any needed header parameters
+ */
 void
 CDKIMSign::GetHeaderParams(const string & sHdr)
 {
@@ -350,7 +338,7 @@ CDKIMSign::ProcessHeaders(void)
 			if (_stricmp(sTag.c_str(), "From:") == 0) {
 				bFromHeaderFound = true;
 				nSignThisTag = 1;
-				IsRequiredHeader(sTag);	// remove from required header list
+				IsRequiredHeader(sTag);	/* remove from required header list */
 			}
 			/* is this in the list of headers that must be signed? */
 			else
@@ -362,18 +350,18 @@ CDKIMSign::ProcessHeaders(void)
 				else
 					nSignThisTag = SignThisTag(sTag) ? 1 : 0;
 			}
-			// save header parameters
+			/* save header parameters */
 			GetHeaderParams(*iter);
 			if (nSignThisTag > 0) {
-				// add this tag to h=
+				/* add this tag to h= */
 				hParam.append(sTag);
 				IterMapIter = IterMap.find(sTag);
 				riter = (IterMapIter == IterMap.end())? HeaderList.rbegin() : IterMapIter->second;
-				// walk the list in reverse looking for the last instance of this header
+				/* walk the list in reverse looking for the last instance of this header */
 				while (riter != HeaderList.rend()) {
 					if (_strnicmp(riter->c_str(), sTag.c_str(), sTag.size()) == 0) {
 						ProcessHeader(*riter);
-						// save the reverse iterator position for this tag
+						/* save the reverse iterator position for this tag */
 						riter++;
 						IterMap[sTag] = riter;
 						break;
@@ -383,11 +371,10 @@ CDKIMSign::ProcessHeaders(void)
 			}
 		}
 	}
-	Hash("\r\n", 2, true, true);	// only for Allman sig
 	if (!bFromHeaderFound) {
 		string sFrom("From:");
 		hParam.append(sFrom);
-		IsRequiredHeader(sFrom);	// remove from required header list
+		IsRequiredHeader(sFrom);	/* remove from required header list */
 	}
 	hParam.append(sRequiredHeaders);
 	if (hParam.at(hParam.size() - 1) == ':')
@@ -404,9 +391,10 @@ CDKIMSign::GetDomain(void)
 }
 
 void
-CDKIMSign::ProcessHeader(const string & sHdr)
+CDKIMSign::ProcessHeader(const string &sHdr)
 {
-	switch (HIWORD(m_Canon)) {
+	switch (HIWORD(m_Canon))
+	{
 	case DKIM_CANON_SIMPLE:
 		Hash(sHdr.c_str(), sHdr.size(), true);
 		Hash("\r\n", 2, true);
@@ -436,7 +424,8 @@ CDKIMSign::ProcessHeader(const string & sHdr)
 
 int CDKIMSign::ProcessBody(char *szBuffer, int nBufLength, bool bEOF)
 {
-	switch (LOWORD(m_Canon)) {
+	switch (LOWORD(m_Canon))
+	{
 	case DKIM_CANON_SIMPLE:
 		if (nBufLength > 0) {
 			while (m_EmptyLineCount > 0) {
@@ -537,11 +526,9 @@ bool CDKIMSign::ParseFromAddress(void)
 }
 
 
-////////////////////////////////////////////////////////////////////////////////
-// 
-// InitSig - initialize signature folding algorithm
-//
-////////////////////////////////////////////////////////////////////////////////
+/* 
+ * InitSig - initialize signature folding algorithm
+ */
 void
 CDKIMSign::InitSig(void)
 {
@@ -550,12 +537,10 @@ CDKIMSign::InitSig(void)
 	m_nSigPos = m_sSig.size();
 }
 
-////////////////////////////////////////////////////////////////////////////////
-// 
-// AddTagToSig - add tag and value to signature folding if necessary
-//               if bFold, fold at cbrk char
-//
-////////////////////////////////////////////////////////////////////////////////
+/* 
+ * AddTagToSig - add tag and value to signature folding if necessary
+ *               if bFold, fold at cbrk char
+ */
 void CDKIMSign::AddTagToSig(char *Tag, const string & sValue, char cbrk, bool bFold)
 {
 	int             nTagLen = strlen(Tag);
@@ -574,11 +559,9 @@ void CDKIMSign::AddTagToSig(char *Tag, const string & sValue, char cbrk, bool bF
 }
 
 
-////////////////////////////////////////////////////////////////////////////////
-// 
-// AddTagToSig - add tag and numeric value to signature folding if necessary
-//
-////////////////////////////////////////////////////////////////////////////////
+/* 
+ * AddTagToSig - add tag and numeric value to signature folding if necessary
+ */
 void CDKIMSign::AddTagToSig(char *Tag, unsigned long nValue)
 {
 	char            szValue[64];
@@ -586,11 +569,9 @@ void CDKIMSign::AddTagToSig(char *Tag, unsigned long nValue)
 	AddTagToSig(Tag, szValue, 0, false);
 }
 
-////////////////////////////////////////////////////////////////////////////////
-// 
-// AddInterTagSpace - add space or fold here
-//
-////////////////////////////////////////////////////////////////////////////////
+/* 
+ * AddInterTagSpace - add space or fold here
+ */
 void CDKIMSign::AddInterTagSpace(int nSizeOfNextTag)
 {
 	if (m_nSigPos + nSizeOfNextTag + 1 > OptimalHeaderLineLength) {
@@ -603,12 +584,10 @@ void CDKIMSign::AddInterTagSpace(int nSizeOfNextTag)
 }
 
 
-////////////////////////////////////////////////////////////////////////////////
-// 
-// AddTagToSig - add value to signature folding if necessary
-//               if cbrk == 0 fold anywhere, otherwise fold only at cbrk
-//
-////////////////////////////////////////////////////////////////////////////////
+/* 
+ * AddTagToSig - add value to signature folding if necessary
+ *               if cbrk == 0 fold anywhere, otherwise fold only at cbrk
+ */
 void CDKIMSign::AddFoldedValueToSig(const string & sValue, char cbrk)
 {
 	string::size_type pos = 0;
@@ -654,11 +633,9 @@ void CDKIMSign::AddFoldedValueToSig(const string & sValue, char cbrk)
 }
 
 
-////////////////////////////////////////////////////////////////////////////////
-// 
-// GetSig - compute hash and return signature header in szSignature
-//
-////////////////////////////////////////////////////////////////////////////////
+/* 
+ * GetSig - compute hash and return signature header in szSignature
+ */
 int CDKIMSign::GetSig(char *szPrivKey, char *szSignature, unsigned int nSigLength)
 {
 	if (szPrivKey == NULL)
@@ -676,11 +653,9 @@ int CDKIMSign::GetSig(char *szPrivKey, char *szSignature, unsigned int nSigLengt
 }
 
 
-////////////////////////////////////////////////////////////////////////////////
-// 
-// GetSig - compute hash and return signature header in szSignature
-//
-////////////////////////////////////////////////////////////////////////////////
+/* 
+ * GetSig - compute hash and return signature header in szSignature
+ */
 int CDKIMSign::GetSig2(char *szPrivKey, char **pszSignature)
 {
 	if (szPrivKey == NULL)
@@ -695,12 +670,10 @@ int CDKIMSign::GetSig2(char *szPrivKey, char **pszSignature)
 }
 
 
-////////////////////////////////////////////////////////////////////////////////
-// 
-// IsRequiredHeader - Check if header in required list. If so, delete
-//                    header from list.
-//
-////////////////////////////////////////////////////////////////////////////////
+/* 
+ * IsRequiredHeader - Check if header in required list. If so, delete
+ *                    header from list.
+ */
 bool CDKIMSign::IsRequiredHeader(const string & sTag)
 {
 	string::size_type start = 0;
@@ -721,7 +694,8 @@ bool CDKIMSign::IsRequiredHeader(const string & sTag)
 	return false;
 }
 
-int CDKIMSign::ConstructSignature(char *szPrivKey, bool bUseIetfBodyHash, bool bUseSha256)
+int
+CDKIMSign::ConstructSignature(char *szPrivKey, int nSigAlg)
 {
 	string          sSignedSig;
 	unsigned char  *sig;
@@ -731,31 +705,46 @@ int CDKIMSign::ConstructSignature(char *szPrivKey, bool bUseIetfBodyHash, bool b
 	int             size, len;
 	char           *buf, *cptr; 
 	const char     *ptr, *dptr, *sptr;
+	unsigned char   Hash[EVP_MAX_MD_SIZE];
+	unsigned int   nHashLen = 0;
 	EVP_MD_CTX     *p1, *p2, *p3, *p4, *p5;
 #if OPENSSL_VERSION_NUMBER >= 0x10100000L
-	p1 = m_allman_sha1ctx;
-	p2 = m_Hdr_ietf_sha1ctx;
-	p3 = m_Hdr_ietf_sha256ctx;
-	p4 = m_Bdy_ietf_sha1ctx;
-	p5 = m_Bdy_ietf_sha256ctx;
+	p1 = m_Hdr_ietf_sha1ctx;
+	p2 = m_Hdr_ietf_sha256ctx;
+	p3 = m_Bdy_ietf_sha1ctx;
+	p4 = m_Bdy_ietf_sha256ctx;
+	p5 = m_Hdr_ed25519ctx;
 #else
-	p1 = &m_allman_sha1ctx;
-	p2 = &m_Hdr_ietf_sha1ctx;
-	p3 = &m_Hdr_ietf_sha256ctx;
-	p4 = &m_Bdy_ietf_sha1ctx;
-	p5 = &m_Bdy_ietf_sha256ctx;
+	p1 = &m_Hdr_ietf_sha1ctx;
+#ifdef HAVE_EVP_SHA256
+	p2 = &m_Hdr_ietf_sha256ctx;
 #endif
+	p3 = &m_Bdy_ietf_sha1ctx;
+#ifdef HAVE_EVP_SHA256
+	p4 = &m_Bdy_ietf_sha256ctx;
+#endif
+#endif
+	int             nSignRet = 0;
 
 	/*- construct the DKIM-Signature: header and add to hash */
 	InitSig();
-	if (bUseIetfBodyHash)
-		AddTagToSig((char *) "v", "1", 0, false);
+	AddTagToSig((char *) "v", "1", 0, false);
+	switch (nSigAlg)
+	{
+	case DKIM_HASH_SHA1:
+		AddTagToSig((char *) "a", "rsa-sha1", 0, false);
+		break;
 #ifdef HAVE_EVP_SHA256
-	AddTagToSig((char *) "a", bUseSha256 ? "rsa-sha256" : "rsa-sha1", 0, false);
-#else
-	AddTagToSig((char *) "a", "rsa-sha1", 0, false);
+	case DKIM_HASH_SHA256:
+		AddTagToSig((char *) "a", "rsa-sha256", 0, false);
+		break;
 #endif
-	switch (m_Canon) {
+	case DKIM_HASH_ED25519:
+		AddTagToSig((char *) "a", "ed25519", 0, false);
+		break;
+	}
+	switch (m_Canon)
+	{
 	case DKIM_SIGN_SIMPLE:
 		AddTagToSig((char *) "c", "simple", 0, false);
 		break;
@@ -806,23 +795,31 @@ int CDKIMSign::ConstructSignature(char *szPrivKey, bool bUseIetfBodyHash, bool b
 	if (!sIdentity.empty())
 		AddTagToSig((char *) "i", sIdentity, 0, false);
 	if (m_nIncludeQueryMethod)
-		AddTagToSig((char *) "q", bUseIetfBodyHash ? "dns/txt" : "dns", 0, false);
+		AddTagToSig((char *) "q", "dns/txt", 0, false);
 	AddTagToSig((char *) "h", hParam, ':', true);
 	if (m_nIncludeCopiedHeaders)
 		AddTagToSig((char *) "z", m_sCopiedHeaders, 0, true);
-	if (bUseIetfBodyHash) {
-		unsigned char Hash[EVP_MAX_MD_SIZE];
-		unsigned int nHashLen = 0;
+	{
+		switch (nSigAlg)
+		{
+		case DKIM_HASH_SHA1:
+			EVP_DigestFinal(p3, Hash, &nHashLen);
+			break;
 #ifdef HAVE_EVP_SHA256
-		EVP_DigestFinal(bUseSha256 ? p5 : p4, Hash, &nHashLen);
-#else
-		EVP_DigestFinal(p4, Hash, &nHashLen);
+		case DKIM_HASH_SHA256:
+			EVP_DigestFinal(p4, Hash, &nHashLen);
+			break;
 #endif
-		bio = BIO_new(BIO_s_mem());
-		if (!bio)
+#if OPENSSL_VERSION_NUMBER >= 0x10101000L
+		case DKIM_HASH_ED25519:
+			EVP_DigestFinal(p4, Hash, &nHashLen);
+			break;
+#endif
+		}
+		if (nHashLen) {
+		if (!(bio = BIO_new(BIO_s_mem())))
 			return DKIM_OUT_OF_MEMORY;
-		b64 = BIO_new(BIO_f_base64());
-		if (!b64) {
+		if (!(b64 = BIO_new(BIO_f_base64()))) {
 			BIO_free(bio);
 			return DKIM_OUT_OF_MEMORY;
 		}
@@ -834,8 +831,7 @@ int CDKIMSign::ConstructSignature(char *szPrivKey, bool bUseIetfBodyHash, bool b
 		}
 		BIO_flush(b64);
 		len = nHashLen * 2;
-		buf = new char[len];
-		if (buf == NULL) {
+		if (!(buf = new char[len])) {
 			BIO_free_all(b64);
 			return DKIM_OUT_OF_MEMORY;
 		}
@@ -846,9 +842,10 @@ int CDKIMSign::ConstructSignature(char *szPrivKey, bool bUseIetfBodyHash, bool b
 			delete[]buf;
 			return DKIM_OUT_OF_MEMORY;
 		}
-		buf[size] = '\0';
+		buf[size] = 0;
 		AddTagToSig((char *) "bh", buf, 0, true);
 		delete[]buf;
+		}
 	}
 	AddInterTagSpace(3);
 	m_sSig.append("b=");
@@ -864,14 +861,24 @@ int CDKIMSign::ConstructSignature(char *szPrivKey, bool bUseIetfBodyHash, bool b
 		sTemp = RelaxHeader(sSignedSig);
 	else
 		sTemp = sSignedSig.c_str();
-	if (bUseIetfBodyHash) {
-#ifdef HAVE_EVP_SHA256
-		EVP_SignUpdate(bUseSha256 ? p3 : p2, sTemp.c_str(), sTemp.size());
-#else
-		EVP_SignUpdate(p2, sTemp.c_str(), sTemp.size());
-#endif
-	} else
+	switch (nSigAlg)
+	{
+	case DKIM_HASH_SHA1:
 		EVP_SignUpdate(p1, sTemp.c_str(), sTemp.size());
+		break;
+#ifdef HAVE_EVP_SHA256
+	case DKIM_HASH_SHA256:
+		EVP_SignUpdate(p2, sTemp.c_str(), sTemp.size());
+		break;
+#endif
+#if OPENSSL_VERSION_NUMBER >= 0x10101000L
+	case DKIM_HASH_ED25519:
+		SigHdrs.append(sTemp.c_str(), sTemp.size());
+		m_SigHdrs += sTemp.size();
+		break;
+#endif
+	}
+
 	if (!(bio = BIO_new_mem_buf(szPrivKey, -1)))
 		return DKIM_OUT_OF_MEMORY;
 	pkey = PEM_read_bio_PrivateKey(bio, NULL, NULL, NULL);
@@ -879,24 +886,40 @@ int CDKIMSign::ConstructSignature(char *szPrivKey, bool bUseIetfBodyHash, bool b
 	if (!pkey)
 		return DKIM_BAD_PRIVATE_KEY;
 	siglen = EVP_PKEY_size(pkey);
-	int             nSignRet;
 	sig = (unsigned char *) OPENSSL_malloc(siglen);
 	if (sig == NULL) {
 		EVP_PKEY_free(pkey);
 		return DKIM_OUT_OF_MEMORY;
 	}
-	if (bUseIetfBodyHash) {
-#ifdef HAVE_EVP_SHA256
-		nSignRet = EVP_SignFinal(bUseSha256 ? p3 : p2, sig, &siglen, pkey);
-#else
-		nSignRet = EVP_SignFinal(p2, sig, &siglen, pkey);
-#endif
-	} else
+
+	/*- Finish streaming signature and potentially go for Ed25519 signatures */
+	switch (nSigAlg)
+	{
+	case DKIM_HASH_SHA1:
 		nSignRet = EVP_SignFinal(p1, sig, &siglen, pkey);
+		break;
+#ifdef HAVE_EVP_SHA256
+	case DKIM_HASH_SHA256:
+		nSignRet = EVP_SignFinal(p2, sig, &siglen, pkey);
+		break;
+#endif
+#if OPENSSL_VERSION_NUMBER >= 0x10101000L
+	case DKIM_HASH_ED25519:
+		size_t          sig_len;
+		unsigned char  *SignMsg;
+		EVP_DigestSignInit(p5, NULL, NULL, NULL, pkey);
+		SignMsg = (unsigned char *) SigHdrs.c_str();
+		EVP_DigestSign(p5, NULL, &sig_len, SignMsg, m_SigHdrs);
+		sig = (unsigned char *) OPENSSL_malloc(sig_len);
+		nSignRet = EVP_DigestSign(p5, sig, &sig_len, SignMsg, m_SigHdrs);
+		siglen = (unsigned int) sig_len;
+		break;
+#endif
+	}
 	EVP_PKEY_free(pkey);
 	if (!nSignRet) {
 		OPENSSL_free(sig);
-		return DKIM_BAD_PRIVATE_KEY;	// key too small
+		return DKIM_BAD_PRIVATE_KEY; /* key too small */
 	}
 	if (!(bio = BIO_new(BIO_s_mem())))
 		return DKIM_OUT_OF_MEMORY;
@@ -931,7 +954,8 @@ int CDKIMSign::ConstructSignature(char *szPrivKey, bool bUseIetfBodyHash, bool b
 	return DKIM_SUCCESS;
 }
 
-int CDKIMSign::AssembleReturnedSig(char *szPrivKey)
+int
+CDKIMSign::AssembleReturnedSig(char *szPrivKey)
 {
 	int             nRet;
 
@@ -939,61 +963,49 @@ int CDKIMSign::AssembleReturnedSig(char *szPrivKey)
 		return DKIM_SUCCESS;
 	ProcessFinal();
 	if (ParseFromAddress() == false) {
-		//return DKIM_NO_SENDER;
+		/* return DKIM_NO_SENDER; */
 	}
-	Hash("\r\n", 2, true, true); /* only for Allman sig */
-	string allmansha1sig,
+	string          ed25519Sig,
 #ifdef HAVE_EVP_SHA256
 		ietfsha256Sig,
 #endif
 		ietfsha1Sig;
-	if (m_nIncludeBodyHash < DKIM_BODYHASH_IETF_1) {
-		nRet = ConstructSignature(szPrivKey, false, false);
+	if (m_nHash == DKIM_HASH_SHA256 || m_nHash == DKIM_HASH_SHA1_AND_SHA256) {
+		nRet = ConstructSignature(szPrivKey, DKIM_HASH_SHA256);
 		if (nRet == DKIM_SUCCESS)
-			allmansha1sig.assign(m_sSig);
+			ietfsha256Sig.assign(m_sSig);
 		else
 			return nRet;
-	} else
-	if (m_nIncludeBodyHash & DKIM_BODYHASH_IETF_1) {
-		if (m_nIncludeBodyHash & DKIM_BODYHASH_ALLMAN_1) {
-			if ((nRet = ConstructSignature(szPrivKey, false, false)) == DKIM_SUCCESS)
-				allmansha1sig.assign(m_sSig);
-			else
-				return nRet;
-		}
-#ifdef HAVE_EVP_SHA256
-		if (m_nHash & DKIM_HASH_SHA256) {
-			if ((nRet = ConstructSignature(szPrivKey, true, true)) == DKIM_SUCCESS)
-				ietfsha256Sig.assign(m_sSig);
-			else
-				return nRet;
-		}
-		if (m_nHash != DKIM_HASH_SHA256) {
-			if ((nRet = ConstructSignature(szPrivKey, true, false)) == DKIM_SUCCESS)
-				ietfsha1Sig.assign(m_sSig);
-			else
-				return nRet;
-		}
-#else
-		if ((nRet = ConstructSignature(szPrivKey, true, false)) == DKIM_SUCCESS)
+	}
+	if (m_nHash == DKIM_HASH_SHA1 || m_nHash == DKIM_HASH_SHA1_AND_SHA256) {
+		nRet = ConstructSignature(szPrivKey, DKIM_HASH_SHA1);
+		if (nRet == DKIM_SUCCESS)
 			ietfsha1Sig.assign(m_sSig);
 		else
 			return nRet;
-#endif
 	}
-	m_sReturnedSig.assign(allmansha1sig);
+	if (m_nHash == DKIM_HASH_ED25519) {
+		nRet = ConstructSignature(szPrivKey, DKIM_HASH_ED25519);
+		if (nRet == DKIM_SUCCESS)
+			ed25519Sig.assign(m_sSig);
+		else
+			return nRet;
+	}
+	if (!ed25519Sig.empty()) {
+		if (!m_sReturnedSig.empty())
+			m_sReturnedSig.append("\n");
+		m_sReturnedSig.assign(ed25519Sig);
+	}
 	if (!ietfsha1Sig.empty()) {
 		if (!m_sReturnedSig.empty())
 			m_sReturnedSig.append("\n");
 		m_sReturnedSig.append(ietfsha1Sig);
 	}
-#ifdef HAVE_EVP_SHA256
 	if (!ietfsha256Sig.empty()) {
 		if (!m_sReturnedSig.empty())
 			m_sReturnedSig.append("\n");
 		m_sReturnedSig.append(ietfsha256Sig);
 	}
-#endif
 	m_bReturnedSigAssembled = true;
 	return DKIM_SUCCESS;
 }
@@ -1001,7 +1013,7 @@ int CDKIMSign::AssembleReturnedSig(char *szPrivKey)
 void
 getversion_dkimsign_cpp()
 {
-	static char    *x = (char *) "$Id: dkimsign.cpp,v 1.19 2021-08-28 21:42:23+05:30 Cprogrammer Exp mbhangui $";
+	static char    *x = (char *) "$Id: dkimsign.cpp,v 1.20 2023-01-26 22:51:21+05:30 Cprogrammer Exp mbhangui $";
 
 	x++;
 }

--- a/libdkim-x/dkimsign.h
+++ b/libdkim-x/dkimsign.h
@@ -1,5 +1,9 @@
 /*
  * $Log: dkimsign.h,v $
+ * Revision 1.7  2023-01-26 22:46:01+05:30  Cprogrammer
+ * removed allman code
+ * updated for ed25519 DKIM signatures
+ *
  * Revision 1.6  2021-08-28 21:42:40+05:30  Cprogrammer
  * added ReplaceSelector to replace selector
  *
@@ -58,7 +62,7 @@ public:
 	char           *DKIM_CALL GetDomain(void);
 
 protected:
-	void            Hash(const char *szBuffer, int nBufLength, bool bHdr, bool bAllmanOnly = false);
+	void            Hash(const char* szBuffer,int nBufLength,bool bHdr);
 	bool            SignThisTag(const string & sTag);
 	void            GetHeaderParams(const string & sHdr);
 	void            ProcessHeader(const string & sHdr);
@@ -69,7 +73,7 @@ protected:
 	void            AddInterTagSpace(int nSizeOfNextTag);
 	void            AddFoldedValueToSig(const string & sValue, char cbrk);
 	bool            IsRequiredHeader(const string & sTag);
-	int             ConstructSignature(char *szPrivKey, bool bUseIetfBodyHash, bool bUseSha256);
+	int             ConstructSignature(char *szPrivKey, int nSigAlg);
 	int             AssembleReturnedSig(char *szPrivKey);
 #if OPENSSL_VERSION_NUMBER >= 0x10100000L
 	EVP_MD_CTX     *m_Hdr_ietf_sha1ctx = NULL;	/* the header hash for ietf sha1  */
@@ -78,7 +82,7 @@ protected:
 	EVP_MD_CTX     *m_Hdr_ietf_sha256ctx = NULL;	/* the header hash for ietf sha256 */
 	EVP_MD_CTX     *m_Bdy_ietf_sha256ctx = NULL;	/* the body hash for ietf sha256 */
 #endif
-	EVP_MD_CTX     *m_allman_sha1ctx = NULL;	/* the hash for allman sha1  */
+	EVP_MD_CTX     *m_Hdr_ed25519ctx = NULL; /* the PureEd25519 signature */
 #else
 	EVP_MD_CTX      m_Hdr_ietf_sha1ctx;	/* the header hash for ietf sha1  */
 	EVP_MD_CTX      m_Bdy_ietf_sha1ctx;	/* the body hash for ietf sha1  */
@@ -86,9 +90,8 @@ protected:
 	EVP_MD_CTX      m_Hdr_ietf_sha256ctx;	/* the header hash for ietf sha256 */
 	EVP_MD_CTX      m_Bdy_ietf_sha256ctx;	/* the body hash for ietf sha256 */
 #endif
-	EVP_MD_CTX      m_allman_sha1ctx;	/* the hash for allman sha1  */
 #endif
-	int             m_Canon;	// canonization method
+	int             m_Canon;	/* canonization method */
 	int             m_EmptyLineCount;
 	string          hParam;
 	string          sFrom;
@@ -97,23 +100,23 @@ protected:
 	string          sReturnPath;
 	string          sBouncedAddr; /*- used for bounces */
 	string          sDomain;
-	string          sIdentity;	// for i= tag, if empty tag will not be included in sig
+	string          sIdentity;	/* for i= tag, if empty tag will not be included in sig */
 	string          sRequiredHeaders;
 	bool            m_IncludeBodyLengthTag;
 	int             m_nBodyLength;
 	time_t          m_ExpireTime;
-	int             m_nIncludeTimeStamp;	// 0 = don't include t= tag, 1 = include t= tag
-	int             m_nIncludeQueryMethod;	// 0 = don't include q= tag, 1 = include q= tag
-	int             m_nHash;	// use one of the DKIM_HASH_xx constants here
-	int             m_nIncludeCopiedHeaders;	// 0 = don't include z= tag, 1 = include z= tag
-	int             m_nIncludeBodyHash;	// 0 = calculate sig using draft 0, 1 = include bh= tag and 
-	// use new signature computation algorithm
-	DKIMHEADERCALLBACK m_pfnHdrCallback;
+	int             m_nIncludeTimeStamp;		/* 0 = don't include t= tag, 1 = include t= tag */
+	int             m_nIncludeQueryMethod;		/* 0 = don't include q= tag, 1 = include q= tag */
+	int             m_nHash;					/* use one of the DKIM_HASH_xx constants here */
+	int             m_nIncludeCopiedHeaders;	/* 0 = don't include z= tag, 1 = include z= tag */
+	DKIMHEADERCALLBACK m_pfnHdrCallback;		/* use new signature computation algorithm */
 	string          m_sSig;
 	int             m_nSigPos;
 	string          m_sReturnedSig;
 	bool            m_bReturnedSigAssembled;
 	string          m_sCopiedHeaders;
+    string          SigHdrs;
+    size_t          m_SigHdrs;
 };
 
 #endif	/*- DKIMSIGN_H */

--- a/libdkim-x/dkimverify.h
+++ b/libdkim-x/dkimverify.h
@@ -1,5 +1,8 @@
 /*
  * $Log: dkimverify.h,v $
+ * Revision 1.10  2023-01-26 22:46:59+05:30  Cprogrammer
+ * added ed25519 signatures
+ *
  * Revision 1.9  2019-06-14 21:25:11+05:30  Cprogrammer
  * BUG - honor body length tag in verification. Changed data type for BodyLength
  *
@@ -104,13 +107,14 @@ public:
 #if OPENSSL_VERSION_NUMBER >= 0x10100000L
 	EVP_MD_CTX     *m_Hdr_ctx = NULL;
 	EVP_MD_CTX     *m_Bdy_ctx = NULL;
+	EVP_MD_CTX     *m_Msg_ctx = NULL;
 #else
 	EVP_MD_CTX      m_Hdr_ctx;
 	EVP_MD_CTX      m_Bdy_ctx;
 #endif
 	SelectorInfo   *m_pSelector;
 	int             Status;
-	int             m_nHash;	// use one of the DKIM_HASH_xxx constants here
+	int             m_nHash;	/* use one of the DKIM_HASH_xxx constants here */
 	unsigned        EmptyLineCount;
 	bool            m_SaveCanonicalizedData;
 };
@@ -136,11 +140,11 @@ protected:
 	int             GetSSP(const string &sDomain, int &iSSP, bool & bTesting);
 	list <SignatureInfo> Signatures;
 	list <SelectorInfo> Selectors;
-	DKIMDNSCALLBACK m_pfnSelectorCallback;	// selector record callback
-	DKIMDNSCALLBACK m_pfnPracticesCallback;	// SSP record callback
+	DKIMDNSCALLBACK m_pfnSelectorCallback;	/* selector record callback */
+	DKIMDNSCALLBACK m_pfnPracticesCallback;	/* SSP record callback */
 	bool            m_HonorBodyLengthTag;
 	bool            m_CheckPractices;
-	bool            m_Accept3ps;		//TBS(Luc) : accept 3rd party signature(s)
+	bool            m_Accept3ps;		/* TBS(Luc) : accept 3rd party signature(s) */
 	bool            m_SubjectIsRequired;
 	bool            m_SaveCanonicalizedData;
 	bool            m_AllowUnsignedFromHeaders;

--- a/libdkim-x/doc/ChangeLog
+++ b/libdkim-x/doc/ChangeLog
@@ -79,6 +79,12 @@ Release 1.5 Start 19/03/2009 End 08/09/2022
 - 08/09/2022 - indimail-mta-3.0.1
 - 27/11/2022
 39. dkim.c: updated help message for -h option
+- 26/01/2023
+40. dkim.cpp: removed -b option. Option kept for backward compatibility
+41. dkim.cpp: added -z 4 for setting Ed25519 DKIM signature
+42. dkim.h: added definition for DKIM_HASH_ED25519
+43. dkimsign.cpp: added creation of Ed25519 DKIM signatures
+44. dkimverify.cpp: added verification of Ed25519 DKIM signatures
 
 *
 ----------------------


### PR DESCRIPTION
Special thanks to Erwin Hoffman. Ed25519 has been made possible because of Erwin's work on the same
1. dkim.cpp: removed -b option. Option kept for backward compatibility
2. dkim.cpp: added -z 4 for setting Ed25519 DKIM signature
3. dkim.h: added definition for DKIM_HASH_ED25519
4. dkimsign.cpp: added creation of Ed25519 DKIM signatures
5. dkimverify.cpp: added verification of Ed25519 DKIM signatures
6. dknewkey.sh: added option to generate ed25519 DKIM keys
7. qmail-dkim.c, dk-filter.sh: removed setting redundant -b option
8. qmail-dkim.c: update verification message to include ED25519 failure