### PR TITLE
Add privilege qcert for accessing certificates by qmaild, qmailr

### DIFF
--- a/indimail-mta-x/DIRS.in
+++ b/indimail-mta-x/DIRS.in
@@ -33,11 +33,11 @@ d:::0755:@prefix@/lib/indimail/plugins::
 d:root:qmail:02755:@qsysconfdir@::
 d:root:qmail:02775:@qsysconfdir@/control::
 d:indimail:qmail:02775:@qsysconfdir@/control/cache::
-d:root:qmail:02755:@qsysconfdir@/control/domainkeys::
+d:root:qcerts:02755:@qsysconfdir@/control/domainkeys::
 d:qmailr:qmail:02775:@qsysconfdir@/control/ratelimit::
 d:root:qmail:0755:@qsysconfdir@/control/defaultqueue::
 d:root:qmail:02775:@qsysconfdir@/users::
-d:root:qmail:02775:@qsysconfdir@/certs::
+d:root:qcerts:02775:@qsysconfdir@/certs::
 d:root:qmail:02775:@qsysconfdir@/tcp::
 d:root:root:0755:@qsysconfdir@/perms.d::
 d:root:root:0755:@qsysconfdir@/perms.d/indimail-mta::

--- a/indimail-mta-x/Makefile
+++ b/indimail-mta-x/Makefile
@@ -223,36 +223,38 @@ auto_uids.h: conf-users conf-groups
 	echo ""; \
 	echo "#include <sys/types.h>"; \
 	echo ""; \
-	echo "#define ALIASU    \"`head -1 conf-users  | tail -1`\""; \
-	echo "#define QMAILD    \"`head -2 conf-users  | tail -1`\""; \
-	echo "#define QMAILL    \"`head -3 conf-users  | tail -1`\""; \
-	echo "#define ROOTUSER  \"`head -4 conf-users  | tail -1`\""; \
-	echo "#define QMAILP    \"`head -5 conf-users  | tail -1`\""; \
-	echo "#define QMAILQ    \"`head -6 conf-users  | tail -1`\""; \
-	echo "#define QMAILR    \"`head -7 conf-users  | tail -1`\""; \
-	echo "#define QMAILS    \"`head -8 conf-users  | tail -1`\""; \
-	echo "#define INDIUSER  \"`head -9 conf-users  | tail -1`\""; \
+	echo "#define ALIASU    \"`head -1  conf-users | tail -1`\""; \
+	echo "#define QMAILD    \"`head -2  conf-users | tail -1`\""; \
+	echo "#define QMAILL    \"`head -3  conf-users | tail -1`\""; \
+	echo "#define ROOTUSER  \"`head -4  conf-users | tail -1`\""; \
+	echo "#define QMAILP    \"`head -5  conf-users | tail -1`\""; \
+	echo "#define QMAILQ    \"`head -6  conf-users | tail -1`\""; \
+	echo "#define QMAILR    \"`head -7  conf-users | tail -1`\""; \
+	echo "#define QMAILS    \"`head -8  conf-users | tail -1`\""; \
+	echo "#define INDIUSER  \"`head -9  conf-users | tail -1`\""; \
 	echo "#define QSCANDU   \"`head -10 conf-users | tail -1`\""; \
 	echo "#define QMAILG    \"`head -1 conf-groups | tail -1`\""; \
 	echo "#define NOFILESG  \"`head -2 conf-groups | tail -1`\""; \
 	echo "#define INDIGROUP \"`head -3 conf-groups | tail -1`\""; \
 	echo "#define QSCANDG   \"`head -4 conf-groups | tail -1`\""; \
+	echo "#define QCERTSG   \"`head -5 conf-groups | tail -1`\""; \
 	echo ""; \
-	echo "extern int auto_uida;" ;\
-	echo "extern int auto_uidd;" ;\
-	echo "extern int auto_uidl;" ;\
-	echo "extern int auto_uido;" ;\
-	echo "extern int auto_uidp;" ;\
-	echo "extern int auto_uidq;" ;\
-	echo "extern int auto_uidr;" ;\
-	echo "extern int auto_uids;" ;\
-	echo "extern int auto_uidv;" ;\
-	echo "extern int auto_uidc;" ;\
+	echo "extern int auto_uida; /* alias user */" ;\
+	echo "extern int auto_uidd; /* qmail daemon user */" ;\
+	echo "extern int auto_uidl; /* qmail log user */" ;\
+	echo "extern int auto_uido; /* root user */" ;\
+	echo "extern int auto_uidp; /* password access user */" ;\
+	echo "extern int auto_uidq; /* qmail queue user */" ;\
+	echo "extern int auto_uidr; /* qmail remote user */" ;\
+	echo "extern int auto_uids; /* qmail send user */" ;\
+	echo "extern int auto_uidi; /* indimail user */" ;\
+	echo "extern int auto_uidv; /* virus scan user */" ;\
 	echo ""; \
-	echo "extern int auto_gidq;" ;\
-	echo "extern int auto_gidn;" ;\
-	echo "extern int auto_gidv;" ;\
-	echo "extern int auto_gidc;" ;\
+	echo "extern int auto_gidq; /* qmail group */" ;\
+	echo "extern int auto_gidn; /* nofiles gorup */" ;\
+	echo "extern int auto_gidi; /* indimail user */" ;\
+	echo "extern int auto_gidv; /* virus scan group */" ;\
+	echo "extern int auto_gidc; /* certs access user */" ;\
 	echo ""; \
 	echo "int             uidinit(int, int);"; \
 	echo "char           *get_user(uid_t);"; \
@@ -262,20 +264,21 @@ auto_uids.h: conf-users conf-groups
 	) > auto_uids.h
 
 auto_uids.c: auto-uid auto-gid conf-users conf-groups
-	(./auto-uid auto_uidv `head -9  conf-users | tail -1` \
-	&& ./auto-uid auto_uida `head -1  conf-users` \
+	( ./auto-uid auto_uida `head -1  conf-users` \
 	&&./auto-uid auto_uidd `head -2  conf-users | tail -1` \
 	&&./auto-uid auto_uidl `head -3  conf-users | tail -1` \
+	&&./auto-uid auto_uido `head -4  conf-users | tail -1` \
 	&&./auto-uid auto_uidp `head -5  conf-users | tail -1` \
 	&&./auto-uid auto_uidq `head -6  conf-users | tail -1` \
 	&&./auto-uid auto_uidr `head -7  conf-users | tail -1` \
 	&&./auto-uid auto_uids `head -8  conf-users | tail -1` \
-	&&./auto-uid auto_uidc `head -10 conf-users | tail -1` \
-	&&./auto-uid auto_uido `head -4  conf-users | tail -1` \
-	&&./auto-gid auto_gidv `head -3  conf-groups | tail -1` \
+	&&./auto-uid auto_uidi `head -9  conf-users | tail -1` \
+	&&./auto-uid auto_uidv `head -10 conf-users | tail -1` \
 	&&./auto-gid auto_gidq `head -1  conf-groups` \
 	&&./auto-gid auto_gidn `head -2  conf-groups | tail -1` \
-	&&./auto-gid auto_gidc `head -4  conf-groups | tail -1` \
+	&&./auto-gid auto_gidi `head -3  conf-groups | tail -1` \
+	&&./auto-gid auto_gidv `head -4  conf-groups | tail -1` \
+	&&./auto-gid auto_gidc `head -5  conf-groups | tail -1` \
 	) > auto_uids.c.tmp && mv auto_uids.c.tmp auto_uids.c
 
 auto_uids.o: compile auto_uids.c

--- a/indimail-mta-x/cleanq.c
+++ b/indimail-mta-x/cleanq.c
@@ -1,5 +1,8 @@
 /*
  * $Log: cleanq.c,v $
+ * Revision 1.13  2023-02-14 07:45:58+05:30  Cprogrammer
+ * renamed auto_uidc, auto_gidc to auto_uidv, auto_gidv
+ *
  * Revision 1.12  2021-08-29 23:27:08+05:30  Cprogrammer
  * define functions as noreturn
  *
@@ -231,7 +234,7 @@ main(int argc, char **argv)
 	if (optind + 1 == argc && chdir(argv[optind++]) == -1)
 		strerr_die3sys(111, FATAL, "chdir: ", argv[optind]);
 	uid = getuid();
-	if (uid != auto_uidc && setreuid(auto_uidc, auto_uidc))
+	if (uid != auto_uidv && setreuid(auto_uidv, auto_uidv))
 		strerr_die2sys(111, FATAL, "setreuid failed: ");
 	if ((fdsourcedir = open(".", O_RDONLY | O_NDELAY)) == -1)
 		strerr_die2sys(111, FATAL, "unable to open current directory: ");
@@ -246,7 +249,7 @@ main(int argc, char **argv)
 			_exit(111);
 		if (stat(".", &st) == -1)
 			strerr_die2sys(111, FATAL, "unable to stat '.'");
-		if (st.st_uid != auto_uidc) {
+		if (st.st_uid != auto_uidv) {
 			strerr_warn2(FATAL, "current directory not owned by qscand", 0);
 			_exit(111);
 		}
@@ -274,7 +277,7 @@ main(int argc, char **argv)
 void
 getversion_cleanq_c()
 {
-	static char    *x = "$Id: cleanq.c,v 1.12 2021-08-29 23:27:08+05:30 Cprogrammer Exp mbhangui $";
+	static char    *x = "$Id: cleanq.c,v 1.13 2023-02-14 07:45:58+05:30 Cprogrammer Exp mbhangui $";
 
 	x++;
 }

--- a/indimail-mta-x/conf-groups
+++ b/indimail-mta-x/conf-groups
@@ -2,7 +2,9 @@ qmail
 nofiles
 indimail
 qscand
+qcerts
 
-These are the qmail groups. The second group should not have access to
-any files, but it must be usable for processes; this requirement
-excludes the ``nogroup'' and ``nobody'' groups on many systems.
+These are the qmail,indimail groups. The second group should not
+have access to any files, but it must be usable for processes;
+this requirements excludes the ``nogroup'' and ``nobody''
+groups on many systems.

--- a/indimail-mta-x/conf-users
+++ b/indimail-mta-x/conf-users
@@ -12,7 +12,7 @@ qscand
 The qmail system is heavily partitioned for security; it does almost
 nothing as root.
 
-The first nine lines of this file are the alias user, the daemon user,
+The first ten lines of this file are the alias user, the daemon user,
 the log user, the owner of miscellaneous files such as binaries, the
 passwd user, the queue user, the remote user, the send user, the
 indimail user and the virus scan user.

--- a/indimail-mta-x/create_services.in
+++ b/indimail-mta-x/create_services.in
@@ -21,7 +21,7 @@ cp=$(which cp)
 # End USER Configuration OPTIONS
 #
 
-# $Id: create_services.in,v 2.118 2023-02-14 12:12:27+05:30 Cprogrammer Exp mbhangui $
+# $Id: create_services.in,v 2.118 2023-02-14 17:58:06+05:30 Cprogrammer Exp mbhangui $
 
 usage()
 {
@@ -498,7 +498,7 @@ eval $svctool --slowq --servicedir=$servicedir --qbase=$qbase \
   --dmemory=$send_soft_mem --min-free=52428800 --dkverify=$ver_opt \
   --dksign=$sign_opt --private_key=$controldir/domainkeys/%/$dkimkeyfn \
   --remote-authsmtp=plain --localfilter --remotefilter \
-  --deliverylimit-count="-1" --deliverylimit-size="-1" --utf8
+  --deliverylimit-count="-1" --deliverylimit-size="-1" --setgroups --utf8
 #
 # Greylist
 #
@@ -758,7 +758,7 @@ fi
 
 #
 # $Log: create_services.in,v $
-# Revision 2.118  2023-02-14 12:12:27+05:30  Cprogrammer
+# Revision 2.118  2023-02-14 17:58:06+05:30  Cprogrammer
 # added --setgroups to set USE_SETGROUPS env variable for qmail-start
 #
 # Revision 2.117  2022-11-07 20:45:29+05:30  Cprogrammer

--- a/indimail-mta-x/create_services.in
+++ b/indimail-mta-x/create_services.in
@@ -21,7 +21,7 @@ cp=$(which cp)
 # End USER Configuration OPTIONS
 #
 
-# $Id: create_services.in,v 2.117 2022-11-07 20:45:29+05:30 Cprogrammer Exp mbhangui $
+# $Id: create_services.in,v 2.118 2023-02-14 12:12:27+05:30 Cprogrammer Exp mbhangui $
 
 usage()
 {
@@ -453,7 +453,7 @@ do
     e_opt="--remote-authsmtp=plain --localfilter --remotefilter"
     e_opt="$e_opt --deliverylimit-count=-1 --deliverylimit-size=-1"
     e_opt="$e_opt --rbl=-rzen.spamhaus.org --rbl=-rdnsbl-1.uceprotect.net"
-    e_opt="$e_opt --dmemory=$send_soft_mem --utf8"
+    e_opt="$e_opt --dmemory=$send_soft_mem --setgroups --utf8"
   fi
   if [ $tcpserver_plugin -eq 1 ] ; then
     e_opt="$e_opt --shared-objects=1 --use-dlmopen=1"
@@ -758,6 +758,9 @@ fi
 
 #
 # $Log: create_services.in,v $
+# Revision 2.118  2023-02-14 12:12:27+05:30  Cprogrammer
+# added --setgroups to set USE_SETGROUPS env variable for qmail-start
+#
 # Revision 2.117  2022-11-07 20:45:29+05:30  Cprogrammer
 # removed domainkeys for new installs
 #

--- a/indimail-mta-x/debian/indimail-mta.postinst.in
+++ b/indimail-mta-x/debian/indimail-mta.postinst.in
@@ -350,7 +350,7 @@ eval ${prefix}/sbin/svctool --slowq --servicedir=${servicedir} --qbase=${qbase} 
     --dmemory=${send_soft_mem} --min-free=52428800 --dkverify=${ver_opt} \
 	--dksign=${sign_opt} --private_key=${qsysconfdir}/control/domainkeys/%/${dkimkeyfn} \
 	--remote-authsmtp=login --localfilter --remotefilter \
-	--deliverylimit-count="-1" --deliverylimit-size="-1" --utf8
+	--deliverylimit-count="-1" --deliverylimit-size="-1" --setgroups --utf8
 
 #odmr
 ${prefix}/sbin/svctool --smtp=366 --odmr --servicedir=${servicedir} \

--- a/indimail-mta-x/debian/indimail-mta.postinst.in
+++ b/indimail-mta-x/debian/indimail-mta.postinst.in
@@ -311,7 +311,7 @@ do
 		extra_opt="--remote-authsmtp=login --localfilter --remotefilter"
 		extra_opt="$extra_opt --deliverylimit-count=-1 --deliverylimit-size=-1"
 		extra_opt="$extra_opt --rbl=-rzen.spamhaus.org --rbl=-rdnsbl-1.uceprotect.net"
-		extra_opt="$extra_opt --dmemory=$send_soft_mem --utf8"
+		extra_opt="$extra_opt --dmemory=$send_soft_mem --setgroups --utf8"
 	fi
 	if [ $tcpserver_plugin -eq 1 ] ; then
 		extra_opt="$extra_opt --shared-objects=1 --use-dlmopen=1"

--- a/indimail-mta-x/debian/indimail-mta.preinst.in
+++ b/indimail-mta-x/debian/indimail-mta.preinst.in
@@ -90,6 +90,7 @@ case "$1" in
 	/usr/bin/getent group nofiles   > /dev/null || /usr/sbin/groupadd nofiles  || true
 	/usr/bin/getent group qmail     > /dev/null || /usr/sbin/groupadd qmail    || true
 	/usr/bin/getent group qscand    > /dev/null || /usr/sbin/groupadd qscand   || true
+	/usr/bin/getent group qcerts    > /dev/null || /usr/sbin/groupadd qcerts   || true
 	
 	for i in indimail alias qmaild qmaill qmailp qmailq qmailr qmails qscand
 	do
@@ -100,11 +101,11 @@ case "$1" in
 		/usr/sbin/useradd -r -g indimail -u 555 -d ${qmaildir} indimail || \
 		test $? = 4 && /usr/sbin/useradd -r -g indimail -d ${qmaildir} indimail || true
 	/usr/bin/getent passwd alias    > /dev/null || /usr/sbin/useradd -M -g nofiles  -d ${qmaildir}/alias  -s /sbin/nologin  alias || true
-	/usr/bin/getent passwd qmaild   > /dev/null || /usr/sbin/useradd -M -g nofiles  -d ${qmaildir}        -s /sbin/nologin qmaild || true
+	/usr/bin/getent passwd qmaild   > /dev/null || /usr/sbin/useradd -M -g nofiles  -d ${qmaildir}        -s /sbin/nologin qmaild -G qcerts || true
 	/usr/bin/getent passwd qmaill   > /dev/null || /usr/sbin/useradd -M -g nofiles  -d ${logdir}          -s /sbin/nologin qmaill || true
 	/usr/bin/getent passwd qmailp   > /dev/null || /usr/sbin/useradd -M -g nofiles  -d ${qmaildir}        -s /sbin/nologin qmailp || true
 	/usr/bin/getent passwd qmailq   > /dev/null || /usr/sbin/useradd -M -g qmail    -d ${qmaildir}        -s /sbin/nologin qmailq || true
-	/usr/bin/getent passwd qmailr   > /dev/null || /usr/sbin/useradd -M -g qmail    -d ${qmaildir}        -s /sbin/nologin qmailr || true
+	/usr/bin/getent passwd qmailr   > /dev/null || /usr/sbin/useradd -M -g qmail    -d ${qmaildir}        -s /sbin/nologin qmailr -G qcerts || true
 	/usr/bin/getent passwd qmails   > /dev/null || /usr/sbin/useradd -M -g qmail    -d ${qmaildir}        -s /sbin/nologin qmails || true
 	/usr/bin/getent passwd qscand   > /dev/null || /usr/sbin/useradd -M -g qscand   -d ${qmaildir}/qscanq -G qmail,qscand -s /sbin/nologin qscand || true
 	if [ $nscd_up -ge 1 ] ; then

--- a/indimail-mta-x/dknewkey.sh
+++ b/indimail-mta-x/dknewkey.sh
@@ -1,5 +1,5 @@
 #
-# $Id: dknewkey.sh,v 1.17 2023-02-11 23:01:57+05:30 Cprogrammer Exp mbhangui $
+# $Id: dknewkey.sh,v 1.18 2023-02-14 07:48:10+05:30 Cprogrammer Exp mbhangui $
 #
 
 usage()
@@ -125,6 +125,8 @@ force=0
 bits=2048
 ktype="rsa"
 domain=""
+cert_user="root"
+cert_group="qcerts"
 eval set -- "$options"
 while :; do
 	case "$1" in
@@ -218,7 +220,7 @@ else
 		selector=$(basename $selector)
 	fi
 	if [ ! -d $dir ] ; then
-		if (! mkdir -p $dir || ! chown root:qmail $dir || ! chmod 755 $dir) ; then
+		if (! mkdir -p $dir || ! chown $cert_user:$cert_group $dir || ! chmod 755 $dir) ; then
 			exit 1
 		fi
 	fi
@@ -272,7 +274,7 @@ else
 	fi
 
 	exec 2>&3 # restore stderr
-	if ( ! chown root:qmail $selector $selector.pub || ! chmod 640 $selector || ! chmod 644 $selector.pub) ; then
+	if ( ! chown $cert_user:$cert_group $selector $selector.pub || ! chmod 640 $selector || ! chmod 644 $selector.pub) ; then
 		exit 1
 	fi
 	print_key "$domain" "$selector"
@@ -281,6 +283,9 @@ exit 0
 
 #
 # $Log: dknewkey.sh,v $
+# Revision 1.18  2023-02-14 07:48:10+05:30  Cprogrammer
+# use qcerts group for certificate group permission
+#
 # Revision 1.17  2023-02-11 23:01:57+05:30  Cprogrammer
 # generate ed25519 public key without ASN.1 structure (skip first 12 bytes)
 #

--- a/indimail-mta-x/doc/ChangeLog
+++ b/indimail-mta-x/doc/ChangeLog
@@ -39,6 +39,36 @@ multi-signature generation
     signature verification status on fd 2
 - 13/02/2022
 21. removed yahoo domainkeys
+- 14/02/2022
+22. cleanq.c, qhpsi.c, qscanq.c: renamed auto_uidc, auto_gidc to auto_uidv, auto_gidv
+23. dknewkey.sh: use qcerts group for certificate group permission
+24. get_uid.c: added qcerts group ID for certificate group permissionA
+25. get_uid.c: renamed auto_uidv, auto_gidv to auto_uidi, auto_gidi
+26. get_uid.c: added auto_gidc for qcerts group ID
+27. indimail-mta.spec: added group ID qcerts for certificate group permissions.
+28. perm_list.in: updated group ownership of certs, domainkeys directory to
+    qcerts
+29. qlocal_upgrade.in: add group ID qcerts
+30. qlocal_upgrade.in: updated group id of certs to qcerts
+31. qlocal_upgrade.in: added qcerts as supplementary group for qmaild, qmailr
+    and apache
+32. qmail-poppass.c, sql-database.c: renamed auto_uidv to auto_uidi, auto_gidv
+    to auto_gidi
+33. qmail-showctl.c: renamed auto_uidv to auto_uidi, auto_uidc to auto_uidv,
+    auto_gidv to auto_gidi
+34. qmail-showctl.c: added auto_uidc for qcerts group ID
+35. qmail-sql.c: renamed auto_uidv, auto_gidv to auto_uidi, auto_gidi
+36. smtpd.c: fix dossl function - return on error
+37. svctool.in: use tcpserver -u qmaild for running qmail-smtpd for qcerts
+    supplememtary group
+38. svctool.in: create qcerts group ID and added qcerts as supplementary group
+    for qmailr, qmaild, apache
+39. svctool.in: create certs with root:qcerts owner:group
+40. update_tmprsadh: create rsa/dh parameter files with root:qcerts
+    owner:group
+41. create_services.in, svctool.in, indimail-mta.spec.in,
+    debian/indimail-mta.postinst.in: added --setgroups to set USE_SETGROUPS
+    env variable for qmail-start
 
 * Mon Jan 30 2023 13:14:56 +0000 Manvendra Bhangui <indimail-mta@indimail.org> 3.0.2-1.1%{?dist}
 Release 3.0.2-1.1 Start 08/09/2022 End 30/11/2023

--- a/indimail-mta-x/get_uid.c
+++ b/indimail-mta-x/get_uid.c
@@ -1,5 +1,11 @@
 /*
  * $Log: get_uid.c,v $
+ * Revision 1.5  2023-02-14 07:49:06+05:30  Cprogrammer
+ * added qcerts group ID for certificate group permission
+ * renamed auto_uidc, auto_gidc to auto_uidv, auto_gidv
+ * renamed auto_uidv, auto_gidv to auto_uidi, auto_gidi
+ * added auto_gidc for qcerts group ID
+ *
  * Revision 1.4  2022-03-09 13:03:12+05:30  Cprogrammer
  * use qendpwent(), qendgrent() when using functions from qgetpwgr.c
  *
@@ -57,7 +63,7 @@ UIDARRAY        uid_a[] = {{ALIASU,-1,-1}, {QMAILD,-1,-1}, {QMAILL,-1,-1},
 					{QMAILR,-1,-1}, {QMAILS,-1,-1}, {INDIUSER,-1,-1},
 					{QSCANDU,-1,-1}, {0}};
 GIDARRAY        gid_a[] = {{QMAILG,-1,-1}, {NOFILESG,-1,-1},
-					{INDIGROUP,-1,-1}, {QSCANDG,-1,-1}, {0}};
+					{INDIGROUP,-1,-1}, {QSCANDG,-1,-1}, {QCERTSG, -1, -1}, {0}};
 
 static int
 get_uid(char *user, int exit_on_error)
@@ -160,12 +166,13 @@ uidinit(int closeflag, int exit_on_error)
 	DO_UID(auto_uidq, u, QMAILQ, exit_on_error, not_found);
 	DO_UID(auto_uidr, u, QMAILR, exit_on_error, not_found);
 	DO_UID(auto_uids, u, QMAILS, exit_on_error, not_found);
-	DO_UID(auto_uidv, u, INDIUSER, exit_on_error, not_found);
-	DO_UID(auto_uidc, u, QSCANDU, exit_on_error, not_found);
+	DO_UID(auto_uidi, u, INDIUSER, exit_on_error, not_found);
+	DO_UID(auto_uidv, u, QSCANDU, exit_on_error, not_found);
 	DO_GID(auto_gidq, g, QMAILG, exit_on_error, not_found);
 	DO_GID(auto_gidn, g, NOFILESG, exit_on_error, not_found);
-	DO_GID(auto_gidv, g, INDIGROUP, exit_on_error, not_found);
-	DO_GID(auto_gidc, g, QSCANDG, exit_on_error, not_found);
+	DO_GID(auto_gidi, g, INDIGROUP, exit_on_error, not_found);
+	DO_GID(auto_gidv, g, QSCANDG, exit_on_error, not_found);
+	DO_GID(auto_gidc, g, QCERTSG, exit_on_error, not_found);
 	if (closeflag) {
 		use_pwgr ? qendpwent() : endpwent();
 		use_pwgr ? qendgrent() : endgrent();
@@ -201,8 +208,8 @@ get_user(uid_t uid)
 	GET_USER(uid, auto_uidq, QMAILQ);
 	GET_USER(uid, auto_uidr, QMAILR);
 	GET_USER(uid, auto_uids, QMAILS);
-	GET_USER(uid, auto_uidv, INDIUSER);
-	GET_USER(uid, auto_uidc, QSCANDU);
+	GET_USER(uid, auto_uidi, INDIUSER);
+	GET_USER(uid, auto_uidv, QSCANDU);
 	if (!(pw = (use_pwgr ? qgetpwuid : getpwuid) (uid))) {
 		strnum[fmt_ulong(strnum, uid)] = 0;
 		strerr_die3sys(111, "get_user: unable to get uid for uid ", strnum, ": ");
@@ -219,8 +226,9 @@ get_group(gid_t gid)
 		return ((char *) 0);
 	GET_GROUP(gid, auto_gidq, QMAILG);
 	GET_GROUP(gid, auto_gidn, NOFILESG);
-	GET_GROUP(gid, auto_gidv, INDIGROUP);
-	GET_GROUP(gid, auto_gidc, QSCANDG);
+	GET_GROUP(gid, auto_gidi, INDIGROUP);
+	GET_GROUP(gid, auto_gidv, QSCANDG);
+	GET_GROUP(gid, auto_gidc, QCERTSG);
 	GET_GROUP(gid, 0, "root");
 	if (!(gr = (use_pwgr ? qgetgrgid : getgrgid) (gid))) {
 		strnum[fmt_ulong(strnum, gid)] = 0;
@@ -232,7 +240,7 @@ get_group(gid_t gid)
 void
 getversion_get_uid_c()
 {
-	static char    *x = "$Id: get_uid.c,v 1.4 2022-03-09 13:03:12+05:30 Cprogrammer Exp mbhangui $";
+	static char    *x = "$Id: get_uid.c,v 1.5 2023-02-14 07:49:06+05:30 Cprogrammer Exp mbhangui $";
 
 	x++;
 }

--- a/indimail-mta-x/indimail-mta.spec.in
+++ b/indimail-mta-x/indimail-mta.spec.in
@@ -1,6 +1,6 @@
 #
 #
-# $Id: indimail-mta.spec.in,v 1.371 2023-02-13 09:59:43+05:30 Cprogrammer Exp mbhangui $
+# $Id: indimail-mta.spec.in,v 1.373 2023-02-14 12:14:00+05:30 Cprogrammer Exp mbhangui $
 %undefine _missing_build_ids_terminate_build
 %global _unpackaged_files_terminate_build 1
 
@@ -74,6 +74,7 @@ Provides: user(qscand)      > 999
 Provides: group(%groupname) = %gid
 Provides: group(qmail)      > 999
 Provides: group(qscand)     > 999
+Provides: group(qcerts)     > 999
 %if %build_on_obs == 0
 Requires(pre): shadow-utils
 Requires(postun): shadow-utils
@@ -299,7 +300,7 @@ echo
 echo "The qmail system is heavily partitioned for security; it does almost"
 echo "nothing as root."
 echo
-echo "The first nine lines of this file are the alias user, the daemon user,"
+echo "The first ten lines of this file are the alias user, the daemon user,"
 echo "the log user, the owner of miscellaneous files such as binaries, the"
 echo "passwd user, the queue user, the remote user, the send user, the"
 echo "indimail user and the virus scan user."
@@ -316,10 +317,12 @@ echo "qmail"
 echo "nofiles"
 echo %groupname
 echo "qscand"
+echo "qcerts"
 echo
-echo "These are the qmail groups. The second group should not have access to"
-echo "any files, but it must be usable for processes; this requirement"
-echo "excludes the \`\`nogroup'' and \`\`nobody'' groups on many systems."
+echo "These are the qmail,indimail groups. The second group should not"
+echo "have access to any files, but it must be usable for processes;"
+echo "this requirements excludes the \`\`nogroup'' and \`\`nobody''"
+echo "groups on many systems."
 ) > /tmp/conf-groups
 diff /tmp/conf-groups conf-groups > /dev/null 2>&1
 if [ $? -ne 0 ] ; then
@@ -422,10 +425,18 @@ do
   touch %{buildroot}%{qsysconfdir}/control/$i
 done
 
-for i in rsa2048.pem rsa1024.pem servercert.cnf servercert.pem dh1024.pem \
-dh2048.pem dh512.pem rsa512.pem servercert.rand
+for i in rsa dh
 do
-  echo "%ghost %attr(0640,indimail,qmail) %config(noreplace,missingok) %{qsysconfdir}/certs/$i"
+  for j in 512 1024 2048 4096
+  do
+    echo "%ghost %attr(0640,indimail,qcerts) %config(noreplace,missingok) %{qsysconfdir}/certs/"$i""$j".pem"
+    echo ../certs/"$i""$j".pem 1>&3
+    touch %{buildroot}%{qsysconfdir}/certs/"$i""$j".pem
+  done
+done
+for i in servercert.cnf servercert.pem servercert.rand
+do
+  echo "%ghost %attr(0640,indimail,qcerts) %config(noreplace,missingok) %{qsysconfdir}/certs/$i"
   echo ../certs/$i 1>&3
   touch %{buildroot}%{qsysconfdir}/certs/$i
 done
@@ -480,10 +491,10 @@ echo ../resolv.conf 1>&3
 %dir %attr(2775,alias,qmail)                       %{qmaildir}/alias
 %dir %attr(2775,indimail,qmail)                    %{qmaildir}/autoturn
 %dir %attr(2755,root,qmail)                        %{qsysconfdir}
-%dir %attr(2775,root,qmail)                        %{qsysconfdir}/certs
+%dir %attr(2775,root,qcerts)                       %{qsysconfdir}/certs
 %dir %attr(2775,root,qmail)                        %{qsysconfdir}/control
 %dir %attr(2775,indimail,qmail)                    %{qsysconfdir}/control/cache
-%dir %attr(2755,root,qmail)                        %{qsysconfdir}/control/domainkeys
+%dir %attr(2755,root,qcerts)                       %{qsysconfdir}/control/domainkeys
 %dir %attr(0755,root,qmail)                        %{qsysconfdir}/control/defaultqueue
 %dir %attr(0755,root,qmail)                        %{qsysconfdir}/control/global_vars
 %dir %attr(0755,root,root)                         %{qsysconfdir}/perms.d
@@ -1163,19 +1174,20 @@ fi
 /usr/bin/getent group nofiles   > /dev/null || /usr/sbin/groupadd nofiles  || true
 /usr/bin/getent group qmail     > /dev/null || /usr/sbin/groupadd qmail    || true
 /usr/bin/getent group qscand    > /dev/null || /usr/sbin/groupadd qscand   || true
+/usr/bin/getent group qcerts    > /dev/null || /usr/sbin/groupadd qcerts   || true
 
 /usr/bin/getent passwd %username > /dev/null || /usr/sbin/useradd -r -g %groupname -u %uid -d %{qmaildir} %username || true
 if [ $? = 4 ] ; then
   /usr/sbin/useradd -r -g %groupname -d %{qmaildir} %username
 fi
 /usr/bin/getent passwd alias    > /dev/null || /usr/sbin/useradd -M -g nofiles  -d %{qmaildir}/alias  -s /sbin/nologin alias  || true
-/usr/bin/getent passwd qmaild   > /dev/null || /usr/sbin/useradd -M -g nofiles  -d %{qmaildir}        -s /sbin/nologin qmaild || true
+/usr/bin/getent passwd qmaild   > /dev/null || /usr/sbin/useradd -M -g nofiles  -d %{qmaildir}        -s /sbin/nologin qmaild -G qcerts || true
 /usr/bin/getent passwd qmaill   > /dev/null || /usr/sbin/useradd -M -g nofiles  -d %{logdir}          -s /sbin/nologin qmaill || true
 /usr/bin/getent passwd qmailp   > /dev/null || /usr/sbin/useradd -M -g nofiles  -d %{qmaildir}        -s /sbin/nologin qmailp || true
 /usr/bin/getent passwd qmailq   > /dev/null || /usr/sbin/useradd -M -g qmail    -d %{qmaildir}        -s /sbin/nologin qmailq || true
-/usr/bin/getent passwd qmailr   > /dev/null || /usr/sbin/useradd -M -g qmail    -d %{qmaildir}        -s /sbin/nologin qmailr || true
+/usr/bin/getent passwd qmailr   > /dev/null || /usr/sbin/useradd -M -g qmail    -d %{qmaildir}        -s /sbin/nologin qmailr -G qcerts || true
 /usr/bin/getent passwd qmails   > /dev/null || /usr/sbin/useradd -M -g qmail    -d %{qmaildir}        -s /sbin/nologin qmails || true
-/usr/bin/getent passwd qscand   > /dev/null || /usr/sbin/useradd -M -g qscand   -d %{qmaildir}/qscanq -G qmail,qscand -s /sbin/nologin qscand || true
+/usr/bin/getent passwd qscand   > /dev/null || /usr/sbin/useradd -M -g qscand   -d %{qmaildir}/qscanq -s /sbin/nologin qscand -G qmail,qscand || true
 
 for i in %username alias qmaild qmaill qmailp qmailq qmailr qmails qscand
 do
@@ -1379,7 +1391,7 @@ do
     extra_opt="--remote-authsmtp=login --localfilter --remotefilter"
     extra_opt="$extra_opt --deliverylimit-count=-1 --deliverylimit-size=-1"
     extra_opt="$extra_opt --rbl=-rzen.spamhaus.org --rbl=-rdnsbl-1.uceprotect.net"
-    extra_opt="$extra_opt --dmemory=%{send_soft_mem} --utf8"
+    extra_opt="$extra_opt --dmemory=%{send_soft_mem} --setgroups --utf8"
   fi
 %if %{tcpserver_plugin} == 1
     extra_opt="$extra_opt --shared-objects=1 --use-dlmopen=1"

--- a/indimail-mta-x/indimail-mta.spec.in
+++ b/indimail-mta-x/indimail-mta.spec.in
@@ -1,6 +1,6 @@
 #
 #
-# $Id: indimail-mta.spec.in,v 1.373 2023-02-14 12:14:00+05:30 Cprogrammer Exp mbhangui $
+# $Id: indimail-mta.spec.in,v 1.373 2023-02-14 18:02:01+05:30 Cprogrammer Exp mbhangui $
 %undefine _missing_build_ids_terminate_build
 %global _unpackaged_files_terminate_build 1
 
@@ -1430,7 +1430,7 @@ eval %{_prefix}/sbin/svctool --queueParam=defaultqueue \
   --dmemory=%{send_soft_mem} --min-free=52428800 --dkverify=${ver_opt} \
   --dksign=${sign_opt} --private_key=%{qsysconfdir}/control/domainkeys/%/%{dkimkeyfn} \
   --remote-authsmtp=login --localfilter --remotefilter \
-  --deliverylimit-count="-1" --deliverylimit-size="-1" --utf8
+  --deliverylimit-count="-1" --deliverylimit-size="-1" --setgroups --utf8
 
 # ODMR service
 %{_prefix}/sbin/svctool --smtp=366 --odmr --servicedir=%{servicedir} \

--- a/indimail-mta-x/perm_list.in
+++ b/indimail-mta-x/perm_list.in
@@ -22,10 +22,10 @@
 %dir %attr(0755,root,root)         @mandir@/man8
 %dir %attr(0755,root,qmail)        @prefix@/lib/indimail/plugins
 %dir %attr(2755,root,qmail)        @qsysconfdir@ #indimail-mini #qmta
-%dir %attr(2775,root,qmail)        @qsysconfdir@/certs
+%dir %attr(2775,root,qcerts)       @qsysconfdir@/certs
 %dir %attr(2775,root,qmail)        @qsysconfdir@/control #indimail-mini #qmta
 %dir %attr(2775,indimail,qmail)    @qsysconfdir@/control/cache
-%dir %attr(2755,root,qmail)        @qsysconfdir@/control/domainkeys
+%dir %attr(2755,root,qcerts)       @qsysconfdir@/control/domainkeys
 %dir %attr(2775,qmailr,qmail)      @qsysconfdir@/control/ratelimit
 %dir %attr(0755,root,qmail)        @qsysconfdir@/control/defaultqueue #indimail-mini #qmta
 %dir %attr(0755,root,qmail)        @qsysconfdir@/control/global_vars #indimail-mini #qmta

--- a/indimail-mta-x/qhpsi.c
+++ b/indimail-mta-x/qhpsi.c
@@ -1,5 +1,8 @@
 /*
  * $Log: qhpsi.c,v $
+ * Revision 1.11  2023-02-14 08:39:26+05:30  Cprogrammer
+ * renamed auto_uidc to auto_uidv
+ *
  * Revision 1.10  2021-08-29 23:27:08+05:30  Cprogrammer
  * define functions as noreturn
  *
@@ -68,7 +71,7 @@ main(int argc, char **argv)
 	 * Set the real and effective user id to qscand to
 	 * prevent rogue programs from creating mischief
 	 */
-	if (setreuid(auto_uidc, auto_uidc)) {
+	if (setreuid(auto_uidv, auto_uidv)) {
 		if (flaglog)
 			strerr_die2sys(50, FATAL, "setreuid failed: ");
 		_exit(50);
@@ -140,6 +143,6 @@ main(int argc, char **argv)
 void
 getversion_qmail_qhpsi_c()
 {
-	static char    *x = "$Id: qhpsi.c,v 1.10 2021-08-29 23:27:08+05:30 Cprogrammer Exp mbhangui $";
+	static char    *x = "$Id: qhpsi.c,v 1.11 2023-02-14 08:39:26+05:30 Cprogrammer Exp mbhangui $";
 	x++;
 }

--- a/indimail-mta-x/qlocal_upgrade.in
+++ b/indimail-mta-x/qlocal_upgrade.in
@@ -1,5 +1,5 @@
 #
-# $Id: qlocal_upgrade.in,v 1.51 2022-12-02 10:45:09+05:30 Cprogrammer Exp mbhangui $
+# $Id: qlocal_upgrade.in,v 1.52 2023-02-14 08:40:32+05:30 Cprogrammer Exp mbhangui $
 #
 PATH=/bin:/usr/bin:/usr/sbin:/sbin
 chown=$(which chown)
@@ -27,7 +27,7 @@ check_update_if_diff()
 do_install()
 {
 date
-echo "Running $1 $Id: qlocal_upgrade.in,v 1.51 2022-12-02 10:45:09+05:30 Cprogrammer Exp mbhangui $"
+echo "Running $1 $Id: qlocal_upgrade.in,v 1.52 2023-02-14 08:40:32+05:30 Cprogrammer Exp mbhangui $"
 # upgrade libindimail (VIRTUAL_PKG_LIB) for dynamic loading of libindimail
 # upgrade libmysqlclient path in /etc/indimail/control/libmysql
 /usr/sbin/svctool --fixsharedlibs
@@ -36,7 +36,7 @@ echo "Running $1 $Id: qlocal_upgrade.in,v 1.51 2022-12-02 10:45:09+05:30 Cprogra
 do_post_upgrade()
 {
 date
-echo "Running $1 $Id: qlocal_upgrade.in,v 1.51 2022-12-02 10:45:09+05:30 Cprogrammer Exp mbhangui $"
+echo "Running $1 $Id: qlocal_upgrade.in,v 1.52 2023-02-14 08:40:32+05:30 Cprogrammer Exp mbhangui $"
 if [ -x /bin/systemctl -o -x /usr/bin/systemctl ] ; then
 	systemctl is-enabled svscan >/dev/null 2>&1
 	if [ $? -ne 0 ] ; then
@@ -156,16 +156,55 @@ if [ ! -f $sysconfdir/certs/clientcert.pem -a ! -L $sysconfdir/certs/clientcert.
 	$ln -s servercert.pem clientcert.pem
 fi
 
-getent group apache > /dev/null
-if [ $? -ne 2 ] ; then
-	for i in servercert.pem dh2048.pem rsa2048.pem dh1024.pem rsa1024.pem dh512.pem rsa512.pem
+t=$(getent group qcerts)
+if [ $? -eq 2 ] ; then
+	groupadd qcerts
+	usermod -aG qcerts qmaild
+	usermod -aG qcerts qmailr
+	/usr/bin/getent group apache > /dev/null && /usr/sbin/usermod -aG qcerts apache
+	chgrp -R qcerts $sysconfdir/certs
+	chgrp -R qcerts $sysconfdir/control/domainkeys
+else
+	t1=0
+	t2=0
+	t3=0
+	for t in $(echo $t | cut -d: -f4 | sed -e 's{,{ {g')
 	do
-		# roundcube (php) will require read access to certs
-		if [ -f $sysconfdir/certs/$i ] ; then
-			$chgrp qmail $sysconfdir/certs/$i
+		if [ "$t" = "qmailr" ] ; then
+			t1=1
+		elif [ "$t" = "qmaild" ] ; then
+			t2=1
+		elif [ "$t" = "apache" ] ; then
+			t3=1
 		fi
 	done
+	if [ $t1 -eq 0 ] ; then
+		echo usermod -aG qcerts qmailr
+	fi
+	if [ $t2 -eq 0 ] ; then
+		echo usermod -aG qcerts qmaild
+	fi
+	if [ $t3 -eq 0 ] ; then
+		/usr/bin/getent group apache > /dev/null && usermod -aG qcerts apache
+	fi
 fi
+
+for i in rsa dh
+do
+	for j in 512 1024 2048 4096
+	do
+	if [ -f $sysconfdir/certs/$i"$j".pem ] ; then
+		$chgrp qcerts $sysconfdir/certs/$i"$j".pem
+	fi
+	done
+done
+for i in servercert.cnf servercert.pem servercert.rand
+do
+	if [ -f $sysconfdir/certs/$i ] ; then
+		$chgrp qcerts $sysconfdir/certs/$i
+	fi
+done
+
 cd $sysconfdir/control
 if [ $? -eq 0 ] ; then
 	if [ ! -f servercert.pem ] ; then
@@ -326,6 +365,11 @@ case $1 in
 esac
 #
 # $Log: qlocal_upgrade.in,v $
+# Revision 1.52  2023-02-14 08:40:32+05:30  Cprogrammer
+# added group ID qcerts
+# fix permissions of existing certificates to group permissions qcerts
+# added qcerts as supplementary group for qmaild, qmailr and apache
+#
 # Revision 1.51  2022-12-02 10:45:09+05:30  Cprogrammer
 # add AUTOSCAN env variable for svscan
 #

--- a/indimail-mta-x/qmail-poppass.c
+++ b/indimail-mta-x/qmail-poppass.c
@@ -1,5 +1,8 @@
 /*
  * $Log: qmail-poppass.c,v $
+ * Revision 1.7  2023-02-14 09:13:01+05:30  Cprogrammer
+ * renamed auto_uidv to auto_uidi
+ *
  * Revision 1.6  2022-01-30 08:40:59+05:30  Cprogrammer
  * replaced execvp with execv
  *
@@ -240,10 +243,10 @@ main(int argc, char **argv)
 	host = argv[1];
 	authargs = argv + 2;
 	uid = getuid();
-	if (uid != auto_uidv && uid != 0)
+	if (uid != auto_uidi && uid != 0)
 	{
 		out("500 you should run this program with uid 0 or uid ");
-		strnum[fmt_ulong(strnum, auto_uidv)] = 0;
+		strnum[fmt_ulong(strnum, auto_uidi)] = 0;
 		out(strnum);
 		out("\r\n");
 		flush();
@@ -359,7 +362,7 @@ main(int argc, char **argv)
 void
 getversion_qmail_poppass_c()
 {
-	static char    *x = "$Id: qmail-poppass.c,v 1.6 2022-01-30 08:40:59+05:30 Cprogrammer Exp mbhangui $";
+	static char    *x = "$Id: qmail-poppass.c,v 1.7 2023-02-14 09:13:01+05:30 Cprogrammer Exp mbhangui $";
 
 	x = sccsidmakeargsh;
 	x++;

--- a/indimail-mta-x/qmail-showctl.c
+++ b/indimail-mta-x/qmail-showctl.c
@@ -1,5 +1,9 @@
 /*
  * $Log: qmail-showctl.c,v $
+ * Revision 1.12  2023-02-14 09:15:23+05:30  Cprogrammer
+ * renamed auto_uidv to auto_uidi, auto_uidc to auto_uidv, auto_gidv to auto_gidi
+ * added auto_uidc for qcerts id
+ *
  * Revision 1.11  2023-01-22 13:17:57+05:30  Cprogrammer
  * fixed do_int
  *
@@ -585,10 +589,10 @@ show_internals(char *home)
 	substdio_put(subfdout, num, fmt_ulong(num, (unsigned long) auto_uids));
 	substdio_put(subfdout, "\n", 1);
 	substdio_put(subfdout, " indimail: ", 11);
-	substdio_put(subfdout, num, fmt_ulong(num, (unsigned long) auto_uidv));
+	substdio_put(subfdout, num, fmt_ulong(num, (unsigned long) auto_uidi));
 	substdio_put(subfdout, "\n", 1);
 	substdio_put(subfdout, " qscand  : ", 11);
-	substdio_put(subfdout, num, fmt_ulong(num, (unsigned long) auto_uidc));
+	substdio_put(subfdout, num, fmt_ulong(num, (unsigned long) auto_uidv));
 	substdio_put(subfdout, "\n\n", 2);
 	substdio_put(subfdout, "group ids\n", 10);
 	substdio_put(subfdout, " nofiles : ", 11);
@@ -598,9 +602,12 @@ show_internals(char *home)
 	substdio_put(subfdout, num, fmt_ulong(num, (unsigned long) auto_gidq));
 	substdio_put(subfdout, "\n", 1);
 	substdio_put(subfdout, " indimail: ", 11);
-	substdio_put(subfdout, num, fmt_ulong(num, (unsigned long) auto_gidv));
+	substdio_put(subfdout, num, fmt_ulong(num, (unsigned long) auto_gidi));
 	substdio_put(subfdout, "\n", 1);
 	substdio_put(subfdout, " qscand  : ", 11);
+	substdio_put(subfdout, num, fmt_ulong(num, (unsigned long) auto_gidv));
+	substdio_put(subfdout, "\n", 1);
+	substdio_put(subfdout, " qcerts  : ", 11);
 	substdio_put(subfdout, num, fmt_ulong(num, (unsigned long) auto_gidc));
 	substdio_put(subfdout, "\n", 1);
 }
@@ -875,7 +882,7 @@ main(int argc, char **argv)
 void
 getversion_qmail_showctl_c()
 {
-	static char    *x = "$Id: qmail-showctl.c,v 1.11 2023-01-22 13:17:57+05:30 Cprogrammer Exp mbhangui $";
+	static char    *x = "$Id: qmail-showctl.c,v 1.12 2023-02-14 09:15:23+05:30 Cprogrammer Exp mbhangui $";
 
 	if (x)
 		x++;

--- a/indimail-mta-x/qmail-sql.c
+++ b/indimail-mta-x/qmail-sql.c
@@ -1,5 +1,8 @@
 /*
  * $Log: qmail-sql.c,v $
+ * Revision 1.11  2023-02-14 09:16:35+05:30  Cprogrammer
+ * renamed auto_uidv, auto_gidv to auto_uidi, auto_gidi
+ *
  * Revision 1.10  2021-06-13 17:19:57+05:30  Cprogrammer
  * do chdir(controldir) instead of chdir(auto_sysconfdir)
  *
@@ -213,7 +216,7 @@ main(int argc, char **argv)
 			strerr_die2x(111, FATAL, "out of memory");
 		if (write(fd, str.s, str.len) == -1)
 			strerr_die4sys(111, FATAL, "write: ", fn.s, ": ");
-		if (fchown(fd, auto_uidv, auto_gidv))
+		if (fchown(fd, auto_uidi, auto_gidi))
 			strerr_die4sys(111, FATAL, "fchown: ", fn.s, ": ");
 		if (close(fd))
 			strerr_die4sys(111, FATAL, "close: ", fn.s, ": ");
@@ -272,7 +275,7 @@ main(int argc, char **argv)
 void
 getversion_qmail_sql_c()
 {
-	static char    *x = "$Id: qmail-sql.c,v 1.10 2021-06-13 17:19:57+05:30 Cprogrammer Exp mbhangui $";
+	static char    *x = "$Id: qmail-sql.c,v 1.11 2023-02-14 09:16:35+05:30 Cprogrammer Exp mbhangui $";
 
 	x++;
 }

--- a/indimail-mta-x/qscanq.c
+++ b/indimail-mta-x/qscanq.c
@@ -1,5 +1,8 @@
 /*
  * $Log: qscanq.c,v $
+ * Revision 1.12  2023-02-14 09:17:24+05:30  Cprogrammer
+ * renamed auto_uidc to auto_uidv
+ *
  * Revision 1.11  2022-10-03 12:25:19+05:30  Cprogrammer
  * fixed return exit codes
  *
@@ -110,7 +113,7 @@ main(int argc, char *argv[])
 	umask(0);
 
 	uid = getuid();
-	if (uid != auto_uidc && setreuid(auto_uidc, auto_uidc)) {
+	if (uid != auto_uidv && setreuid(auto_uidv, auto_uidv)) {
 		if (flaglog)
 			strerr_die2sys(QQ_XTEMP, FATAL, "setreuid failed: ");
 		_exit(QQ_XTEMP);
@@ -196,7 +199,7 @@ main(int argc, char *argv[])
 void
 getversion_qscanq_c()
 {
-	static char    *x = "$Id: qscanq.c,v 1.11 2022-10-03 12:25:19+05:30 Cprogrammer Exp mbhangui $";
+	static char    *x = "$Id: qscanq.c,v 1.12 2023-02-14 09:17:24+05:30 Cprogrammer Exp mbhangui $";
 
 	x++;
 }

--- a/indimail-mta-x/sql-database.c
+++ b/indimail-mta-x/sql-database.c
@@ -1,5 +1,8 @@
 /*
  * $Log: sql-database.c,v $
+ * Revision 1.4  2023-02-14 09:19:46+05:30  Cprogrammer
+ * renamed auto_uidv to auto_uidi, auto_gidv to auto_gidi
+ *
  * Revision 1.3  2021-06-13 17:23:25+05:30  Cprogrammer
  * do chdir(controldir) instead of chdir(auto_sysconfdir)
  *
@@ -259,7 +262,7 @@ main(int argc, char **argv)
 	if (dbserver && user && pass && dbname && table_name) {
 		if ((fd = open(fn.s, O_CREAT|O_TRUNC|O_WRONLY, 0644)) == -1)
 			strerr_die4sys(111, FATAL, "open: ", fn.s, ": ");
-		if (fchown(fd, auto_uidv, auto_gidv))
+		if (fchown(fd, auto_uidi, auto_gidi))
 			strerr_die4sys(111, FATAL, "fchown: ", fn.s, ": ");
 		if (!stralloc_copys(&str, dbserver) || !stralloc_catb(&str, ":", 1) ||
 				!stralloc_cats(&str, user) || !stralloc_catb(&str, ":", 1) ||
@@ -327,7 +330,7 @@ main(int argc, char **argv)
 void
 getversion_sql_database_c()
 {
-	static char    *x = "$Id: sql-database.c,v 1.3 2021-06-13 17:23:25+05:30 Cprogrammer Exp mbhangui $";
+	static char    *x = "$Id: sql-database.c,v 1.4 2023-02-14 09:19:46+05:30 Cprogrammer Exp mbhangui $";
 
 	x++;
 }

--- a/indimail-mta-x/svctool.9
+++ b/indimail-mta-x/svctool.9
@@ -163,6 +163,7 @@ Known values for OPTION are:
   [--dksign=dk|dkim|both|none --private_key=private_key]
   [--password-cache] [--query-cache]
   [--smtp-plugin]
+  [--setgroups]
   [--utf8]
   --default-domain=domain
 
@@ -263,6 +264,7 @@ Known values for OPTION are:
   shared-objects - Enabled tcpserver plugins, 0 - disabled, 1 - enabled
   use-dlmopen    - Use dlmopen() instead of dlopen() to load shared objects
   smtp-plugin    - Enable SMTP Plugin support
+  setgroups      - Add addition supplementary groups
   utf8           - Enable Email Address Internationalization Support (SMTPUTF8)
 
 --delivery=ident --qbase=queue_path --qcount=N --qstart=I
@@ -288,6 +290,7 @@ Known values for OPTION are:
   [--dksign=dk|dkim|both|none --private_key=private_key]
   [--remote-authsmtp=b]
   [--ssl]
+  [--setgroups]
   [--utf8]
   --default-domain=domain
 
@@ -341,6 +344,7 @@ Known values for OPTION are:
                    delivery times.
   b              - Authenticated SMTP method to use by qmail-remote (plain, login, cram-md5)
   ssl            - Use SSL encrypted communication in qmail-remote
+  setgroups      - Add addition supplementary groups
   utf8           - Enable Email Address Internationalization Support (SMTPUTF8)
 
 --slowq --qbase=queue_path
@@ -361,6 +365,7 @@ Known values for OPTION are:
   [--dksign=dk|dkim|both|none --private_key=private_key]
   [--remote-authsmtp=b]
   [--ssl]
+  [--setgroups]
   [--utf8]
   --default-domain=domain
 
@@ -399,6 +404,7 @@ Known values for OPTION are:
                    delivery times.
   b              - Authenticated SMTP method to use by qmail-remote (plain, login, cram-md5)
   ssl            - Use SSL encrypted communication in qmail-remote
+  setgroups      - Add addition supplementary groups
   utf8           - Enable Email Address Internationalization Support (SMTPUTF8)
 
 --queueParam=dir --qbase=queue_path --qcount=N --qstart=I

--- a/indimail-mta-x/svctool.in
+++ b/indimail-mta-x/svctool.in
@@ -1,5 +1,5 @@
 #
-# $Id: svctool.in,v 2.654 2023-02-13 10:00:02+05:30 Cprogrammer Exp mbhangui $
+# $Id: svctool.in,v 2.656 2023-02-14 12:20:03+05:30 Cprogrammer Exp mbhangui $
 #
 
 #
@@ -25,7 +25,7 @@ host=@HOST@
 shared_objects=0
 use_dlmopen=0
 skip_sendmail_check=0
-RCSID="# \$Id: svctool.in,v 2.654 2023-02-13 10:00:02+05:30 Cprogrammer Exp mbhangui $"
+RCSID="# \$Id: svctool.in,v 2.656 2023-02-14 12:20:03+05:30 Cprogrammer Exp mbhangui $"
 
 #
 # End of User Configuration
@@ -88,6 +88,7 @@ Known values for OPTION are:
   [--dksign=dkim|none --private_key=private_key]
   [--password-cache] [--query-cache]
   [--smtp-plugin]
+  [--setgroups]
   [--utf8]
   --default-domain=domain
 
@@ -188,6 +189,7 @@ Known values for OPTION are:
   shared-objects - Enabled tcpserver plugins, 0 - disabled, 1 - enabled
   use-dlmopen    - Use dlmopen() instead of dlopen() to load shared objects
   smtp-plugin    - Enable SMTP Plugin support
+  setgroups      - Add addition supplementary groups
   utf8           - Enable Email Address Internationalization Support (SMTPUTF8)
 
 --delivery=ident --qbase=queue_path --qcount=N --qstart=I
@@ -213,6 +215,7 @@ Known values for OPTION are:
   [--dksign=dkim|none --private_key=private_key]
   [--remote-authsmtp=b]
   [--ssl]
+  [--setgroups]
   [--utf8]
   --default-domain=domain
 
@@ -266,6 +269,7 @@ Known values for OPTION are:
                    delivery times.
   b              - Authenticated SMTP method to use by qmail-remote (plain, login, cram-md5)
   ssl            - Use SSL encrypted communication in qmail-remote
+  setgroups      - Add addition supplementary groups
   utf8           - Enable Email Address Internationalization Support (SMTPUTF8)
 
 --slowq --qbase=queue_path
@@ -286,6 +290,7 @@ Known values for OPTION are:
   [--dksign=dkim|none --private_key=private_key]
   [--remote-authsmtp=b]
   [--ssl]
+  [--setgroups]
   [--utf8]
   --default-domain=domain
 
@@ -324,6 +329,7 @@ Known values for OPTION are:
                    delivery times.
   b              - Authenticated SMTP method to use by qmail-remote (plain, login, cram-md5)
   ssl            - Use SSL encrypted communication in qmail-remote
+  setgroups      - Add addition supplementary groups
   utf8           - Enable Email Address Internationalization Support (SMTPUTF8)
 
 --queueParam=dir --qbase=queue_path --qcount=N --qstart=I
@@ -2816,7 +2822,7 @@ else
 fi
 echo "-x $sysconfdir/tcp/tcp.smtp.cdb \\"
 echo "-c variables/MAXDAEMONS -o -b \\\$MAXDAEMONS \\"
-echo "-u \$MYUID -g \$MYGID \\\$LOCALIP \\\$PORT \\\$RBLCOMMAND \\"
+echo "-u qmaild \\\$LOCALIP \\\$PORT \\\$RBLCOMMAND \\"
 if [ -f /bin/false ] ; then
 	false="/bin/false"
 else
@@ -3578,7 +3584,7 @@ if [ $run_file_only -ne 1 ] ; then
 		# this will have all variables of "$cdb_f"_config_ssl also
 		create_"$cdb_f"_config $COURIER_PORT $infifo > $conf_dir/.courier_variables
 	fi
-	echo "/tmp/inquery" > $conf_dir/TMPDIR
+	echo "/tmp/inquery" > $conf_dir/FIFOTMPDIR
 	echo "0660" > $conf_dir/FIFO_MODE
 	if [ ! " $memory" = " " ] ; then
 		echo $memory > $conf_dir/SOFT_MEM
@@ -6384,6 +6390,11 @@ fi
 if [ $qmr_ssl -eq 1 ] ; then
 echo $sysconfdir/certs > $conf_dir/CERTDIR #for qmail-remote
 fi
+if [ $setgroups -eq 1 ] ; then
+	echo 1 > $conf_dir/USE_SETGROUPS
+else
+	> $conf_dir/USE_SETGROUPS
+fi
 if [ $utf8 -eq 1 ] ; then
 	echo $utf8 > $conf_dir/UTF8
 else
@@ -6629,6 +6640,11 @@ else
 fi
 if [ $qmr_ssl -eq 1 ] ; then
 echo $sysconfdir/certs > $conf_dir/CERTDIR #for qmail-remote
+fi
+if [ $setgroups -eq 1 ] ; then
+	echo 1 > $conf_dir/USE_SETGROUPS
+else
+	> $conf_dir/USE_SETGROUPS
 fi
 if [ $utf8 -eq 1 ] ; then
 	echo $utf8 > $conf_dir/UTF8
@@ -7580,8 +7596,8 @@ create_users()
 		;;
 	esac
 
-	# qmail, nofiles, qscand group
-	for i in qmail nofiles qscand; do
+	# qmail, nofiles, qscand, qcerts group
+	for i in qmail nofiles qscand qcerts; do
 		case "$host" in
 		*-*-darwin*)
 		groupid=`dscl . -list /Groups PrimaryGroupID | awk '{print $2}' | sort -n | tail -1`
@@ -7590,10 +7606,20 @@ create_users()
 		if [ $? -ne 0 ]; then
 			echo "creating group $i"
 			macOSgroupadd -g $groupid $i
+			if [ "$i" = "qcerts" ] ; then
+				/usr/bin/dscl . -list Users/apache >/dev/null 2>&1
+				if [ $? -eq 0 ] ; then
+					echo "added supplementary group qcerts to apache"
+					/usr/bin/dscl . append /Groups/qcerts GroupMembership apache
+				fi
+			fi
 		fi
 		;;
 		*)
 		linuxgroupadd $i
+		if [ "$i" = "qcerts" ] ; then
+			/usr/bin/getent group apache > /dev/null && /usr/sbin/usermod -aG qcerts apache
+		fi
 		;;
 		esac
 	done
@@ -7643,11 +7669,19 @@ create_users()
 			/usr/bin/dscl . -list Users/$i >/dev/null 2>&1
 			if [ $? -ne 0 ]; then
 				echo "Creating $t"
-				macOSuseradd -M -u $userid -g nofiles -d $QmailHOME -s $safe_shell $i
+				if [ "$i" = "qmaild" ] ; then
+					macOSuseradd -M -u $userid -g nofiles -d $QmailHOME -s $safe_shell -G qcerts $i
+				else
+					macOSuseradd -M -u $userid -g nofiles -d $QmailHOME -s $safe_shell $i
+				fi
 			fi
 			;;
 			*)
-			linuxuseradd -c "$t" -M -g nofiles -d $QmailHOME -s $safe_shell $i
+			if [ "$i" = "qmaild" ] ; then
+				linuxuseradd -c "$t" -M -g nofiles -d $QmailHOME -s $safe_shell -G qcerts $i
+			else
+				linuxuseradd -c "$t" -M -g nofiles -d $QmailHOME -s $safe_shell $i
+			fi
 			;;
 		esac
 	done
@@ -7671,11 +7705,19 @@ create_users()
 			/usr/bin/dscl . -list Users/$i >/dev/null 2>&1
 			if [ $? -ne 0 ]; then
 				echo "Creating $t"
-				macOSuseradd -M -u $userid -g qmail -d $QmailHOME -s $safe_shell $i
+				if [ "$i" = "qmailr" ] ; then
+					macOSuseradd -M -u $userid -g qmail -d $QmailHOME -s $safe_shell -G qcerts $i
+				else
+					macOSuseradd -M -u $userid -g qmail -d $QmailHOME -s $safe_shell $i
+				fi
 			fi
 			;;
 			*)
-			linuxuseradd -c "$t" -M -g qmail -d $QmailHOME -s $safe_shell $i
+			if [ "$i" = "qmailr" ] ; then
+				linuxuseradd -c "$t" -M -g qmail -d $QmailHOME -s $safe_shell -G qcerts $i
+			else
+				linuxuseradd -c "$t" -M -g qmail -d $QmailHOME -s $safe_shell $i
+			fi
 			;;
 		esac
 	done
@@ -9149,7 +9191,7 @@ create_cert()
 		/bin/mkdir -p "$DESTDIR"$sysconfdir/certs
 		change_config $conf_file $TMPDIR/config.cnf.$$
 		/bin/chmod 640 $conf_file
-		$chown indimail:qmail $conf_file
+		$chown root:qcerts $conf_file
 	fi
 	if [ -f "$DESTDIR"$sysconfdir/certs/servercert.pem -a $force -ne 1 ] ; then
 		echo ""$DESTDIR"$sysconfdir/certs/servercert.pem exists. Remove to create new" 1>&2
@@ -9163,7 +9205,7 @@ create_cert()
 		exit 1
 	fi
 	/bin/chmod 640 "$DESTDIR"$sysconfdir/certs/servercert.pem
-	$chown indimail:qmail "$DESTDIR"$sysconfdir/certs/servercert.pem
+	$chown root:qcerts "$DESTDIR"$sysconfdir/certs/servercert.pem
 	if [ -f "$DESTDIR"$sysconfdir/certs/clientcert.pem ] ; then
 		t=$(readlink "$DESTDIR"$sysconfdir/certs/clientcert.pem)
 		t=$(basename $t)
@@ -9362,6 +9404,7 @@ use_starttls=0
 forcetls=0
 nooverwrite=0
 run_file_only=0
+setgroups=0
 utf8=0
 usefsync=0
 usefdatasync=0
@@ -9656,6 +9699,9 @@ while test $# -gt 0; do
 	;;
 	--utf8)
 	utf8=1
+	;;
+	--setgroups)
+	setgroups=1
 	;;
 	--cname-lookup)
 	enable_cname_lookup="yes"

--- a/indimail-mta-x/update_tmprsadh.sh
+++ b/indimail-mta-x/update_tmprsadh.sh
@@ -4,6 +4,9 @@
 # Frederik Vermeulen 2004-04-19 GPL
 #
 # $Log: update_tmprsadh.sh,v $
+# Revision 1.13  2023-02-14 09:27:09+05:30  Cprogrammer
+# create rsa/dh parameter files with root:qcerts owner:group
+#
 # Revision 1.12  2022-05-18 13:30:52+05:30  Cprogrammer
 # added --maxbits argument to specify maximum bits
 #
@@ -85,13 +88,13 @@ while true
 do
 	/usr/bin/openssl genrsa -out $CERTDIR/rsa"$i".new $i &&
 	$chmod 640 $CERTDIR/rsa"$i".new &&
-	$chown indimail:qmail $CERTDIR/rsa"$i".new &&
+	$chown root:qcerts $CERTDIR/rsa"$i".new &&
 	$mv -f $CERTDIR/rsa"$i".new $CERTDIR/rsa"$i".pem
 	echo rsa"$i".pem
 
 	/usr/bin/openssl dhparam -2 -out $CERTDIR/dh"$i".new $i &&
 	$chmod 640 $CERTDIR/dh"$i".new &&
-	$chown indimail:qmail $CERTDIR/dh"$i".new &&
+	$chown root:qcerts $CERTDIR/dh"$i".new &&
 	$mv -f $CERTDIR/dh"$i".new $CERTDIR/dh"$i".pem
 	echo dh"$i".pem
 	i=$(expr $i / 2)


### PR DESCRIPTION
1. cleanq.c, qhpsi.c, qscanq.c: renamed auto_uidc, auto_gidc to auto_uidv, auto_gidv
2. dknewkey.sh: use qcerts group for certificate group permission 
3. get_uid.c: added qcerts group ID for certificate group permissions
4. get_uid.c: renamed auto_uidv, auto_gidv to auto_uidi, auto_gidi
5. get_uid.c: added auto_gidc for qcerts group ID
6. indimail-mta.spec: added group ID qcerts for certificate group permissions.
7. perm_list.in: updated group ownership of certs, domainkeys directory to qcerts
8. qlocal_upgrade.in: add group ID qcerts
9. qlocal_upgrade.in: updated group id of certs to qcerts
10. qlocal_upgrade.in: added qcerts as supplementary group for qmaild, qmailr and apache
11. qmail-poppass.c, sql-database.c: renamed auto_uidv to auto_uidi, auto_gidv to auto_gidi
12. qmail-showctl.c: renamed auto_uidv to auto_uidi, auto_uidc to auto_uidv, auto_gidv to auto_gidi
13. qmail-showctl.c: added auto_uidc for qcerts group ID
14. qmail-sql.c: renamed auto_uidv, auto_gidv to auto_uidi, auto_gidi
15. smtpd.c: fix dossl function - return on error
16. svctool.in: use tcpserver -u qmaild for running qmail-smtpd for qcerts supplememtary group
17. svctool.in: create qcerts group ID and added qcerts as supplementary group for qmailr, qmaild, apache
18. svctool.in: create certs with root:qcerts owner:group
19. update_tmprsadh: create rsa/dh parameter files with root:qcerts owner:group
20. debian/indimail-mta.postinst.in: added --setgroups to set USE_SETGROUPS env variable for qmail-start