### PR TITLE
clear env variables for dot-qmail commands

### DIFF
--- a/indimail-mta-x/doc/ChangeLog
+++ b/indimail-mta-x/doc/ChangeLog
@@ -35,6 +35,8 @@ Release @version@-@release@ Start 11/09/2023 End --/--/----
 20. indimail-mta.spec, qlocal_upgrade: pass --setuser-priv to svctool for qmail-send service
 31. qmail-local.c: added X-Forwarded-To, X-Forwarded-For headers when
     forwarding
+32. qmail-local, svctool: added SANITIZE_ENV to clear environment variables
+    for dot-qmail commands
 
 * Fri Sep 08 2023 11:58:03 +0000 Manvendra Bhangui <indimail-mta@indimail.org> 3.0.4-1.1%{?dist}
 Release 3.0.4-1.1 Start 24/04/2023 End 08/09/2023

--- a/indimail-mta-x/doc/ChangeLog
+++ b/indimail-mta-x/doc/ChangeLog
@@ -37,6 +37,7 @@ Release @version@-@release@ Start 11/09/2023 End --/--/----
     forwarding
 32. qmail-local, svctool: added SANITIZE_ENV to clear environment variables
     for dot-qmail commands
+33. added '%' option in dot-qmail to add env variables from a directory
 
 * Fri Sep 08 2023 11:58:03 +0000 Manvendra Bhangui <indimail-mta@indimail.org> 3.0.4-1.1%{?dist}
 Release 3.0.4-1.1 Start 24/04/2023 End 08/09/2023

--- a/indimail-mta-x/dot-qmail.9
+++ b/indimail-mta-x/dot-qmail.9
@@ -32,8 +32,7 @@ A comment line begins with a number sign:
   # this is a comment
 .EE
 
-.B qmail-local
-ignores the line.
+\fBqmail-local\fR ignores the line.
 
 .TP 5
 (2)
@@ -177,6 +176,28 @@ is a little ugly, but it gets the job done. The same functionality is
 already available with |command lines, but then you need multiple
 \fB.qmail\fR files, which exposes extra addresses to outside senders, so it
 gets a little more complicated.
+
+.TP 5
+(7)
+A envdir line begins with a percent sign:
+
+.EX
+     % envdir_path
+.EE
+
+\fBqmail-local\fR takes the rest of the line as a directory with
+environment variables and sets/unsets environment variables like the
+\fBenvdir\fR(8) command. An command executed using a command line in
+\fBdot-qmail\fR(5) will inherit these environment variables. You can also
+ensure that the commands run just with the environment variables from
+\fIenvdir_path\fR by setting \fBSANITIZE_ENV\fR environment variable for
+\fBqmail-local\fR. If \fBSANITIZE_ENV\fR is enabled \fBqmail-local\fR
+will first clear all environment variables other than USE_FSYNC,
+USE_FDATASYNC, USE_SYNCDIR. You can set additional environment variables to
+preserve by setting SANITIZE_ENV as a colon ':' separated list of
+environment variables to preserve. The purpose of \fBSANITIZE_ENV\fR is to
+ensure programs run using \fBdot-qmail\fR(5) will run without any
+environment variable inherited from the startup scripts.
 
 .PP
 If \fB.qmail\fR has the execute bit set, it must not contain any program

--- a/indimail-mta-x/indimail-env.9
+++ b/indimail-mta-x/indimail-env.9
@@ -886,6 +886,13 @@ Used by condtomaildir, \fBdot-forward\fR(1), maildirdeliver, preline,
 \fBserialcmd\fR(1), \fBvacation\fR(8)
 
 .TP
+\fISANITIZE_ENV\R
+Used by \fBqmail-local\fR(8) to clear all environment variables other than
+USE_FSYNC, USE_FDATASYNC, USE_SYNCDIR. You can set additional environment
+variables to preserve by setting SANITIZE_ENV as a colon ':' separated list
+of environment variables to preserve.
+
+.TP
 \fISCANCMD\fR \fISCANDIR\fR
 Used by \fBqscanq-stdin\fR(8), \fBqhpsi\fR(8)
 

--- a/indimail-mta-x/qmail-local.9
+++ b/indimail-mta-x/qmail-local.9
@@ -85,6 +85,14 @@ The environment variable \fBUSE_FSYNC\fR, \fBUSE_FDATASYNC\fR,
 \fBUSE_SYNCDIR\fR is controlled by \fBqmail-send\fR(8) /
 \fBtodo-proc\fR(8).
 
+If the environment variable \fBSANITIZE_ENV\fR is enabled \fBqmail-local\fR
+will first clear all environment variables other than USE_FSYNC,
+USE_FDATASYNC, USE_SYNCDIR. You can set additional environment variables to
+preserve by setting SANITIZE_ENV as a colon ':' separated list of
+environment variables to preserve. The purpose of \fBSANITIZE_ENV\fR is to
+ensure programs run using \fBdot-qmail\fR(5) will run without any
+environment variable inherited from the startup scripts.
+
 .SH "OPTIONS"
 .TP
 .B \-n

--- a/indimail-mta-x/qmail-local.c
+++ b/indimail-mta-x/qmail-local.c
@@ -1,6 +1,7 @@
 /*
  * $Id: qmail-local.c,v 1.47 2023-09-20 08:23:28+05:30 Cprogrammer Exp mbhangui $
  */
+#include <stdio.h>
 #include <sys/types.h>
 #include <sys/time.h>
 #include <sys/stat.h>
@@ -27,6 +28,8 @@
 #include <case.h>
 #include <qtime.h>
 #include <constmap.h>
+#include <envdir.h>
+#include <pathexec.h>
 #include "hassrs.h"
 #ifdef HAVESRS
 #include "srs.h"
@@ -278,7 +281,7 @@ mailprogram(char *prog)
 		args[2] = prog;
 		args[3] = 0;
 		sig_pipedefault();
-		execv(*args, args);
+		pathexec(args);
 		strerr_die3x(111, "Unable to run /bin/sh: ", error_str(errno), ". (#4.3.0)");
 	}
 
@@ -574,12 +577,66 @@ sayit(char *type, char *cmd, unsigned int len)
 	substdio_putsflush(subfdoutsmall, "\n");
 }
 
+void
+sanitize_env(char *x)
+{
+	char           *e;
+	int             i, j;
+	struct env_tab {
+		char           *env_name;
+		char           *env_val;
+	} etable[] = {
+		{ "USE_FSYNC", 0 },
+		{ "USE_FDATASYNC", 0 },
+		{ "USE_SYNCDIR", 0 },
+		{ 0, 0 }
+	};
+	struct env_tab *p, *q;
+
+	if (*x) {
+		if (!stralloc_copys(&cmds, x) ||
+				!stralloc_0(&cmds))
+			temp_nomem();
+		for (i = 0; *x;)
+			if (*x++ == ':')
+				i++;
+	} else
+		i = 0;
+	if (!(p = (struct env_tab *) alloc(sizeof(struct env_tab) * (i + 4))))
+		temp_nomem();
+	for (j = 0, q = etable; q->env_name; q++, j++) {
+		p[j].env_name = q->env_name;
+		p[j].env_val = env_get(q->env_name);
+	}
+	if (i) {
+		x = cmds.s;
+		for (e = x; *x; x++) {
+			if (*x == ':') {
+				*x = 0;
+				p[j].env_name = e;
+				p[j++].env_val = env_get(e);
+				e = x + 1;
+			}
+		}
+		p[j].env_name = e;
+		p[j++].env_val = env_get(e);
+	}
+	p[j].env_name = (char *) NULL;
+	env_clear();
+	for (q = p; q->env_name; q++) {
+		if (q->env_val && !env_put2(q->env_name, q->env_val))
+			temp_nomem();
+	}
+	execl("/bin/sh", "sh", (char *) NULL);
+	return;
+}
+
 int
 main(int argc, char **argv)
 {
-	char           *x;
+	char           *x, *e;
 	char          **recips;
-	int             opt, fd, flagforwardonly;
+	int             opt, fd, flagforwardonly, r;
 	unsigned int    i, j, numforward;
 	datetime_sec    starttime;
 
@@ -587,6 +644,10 @@ main(int argc, char **argv)
 	sig_pipeignore();
 	if (!env_init())
 		temp_nomem();
+	if (!stralloc_ready(&cmds, 0))
+		temp_nomem();
+	if ((x = env_get("SANITIZE_ENV")))
+		sanitize_env(x);
 	flagdoit = 1;
 	while ((opt = getopt(argc, argv, "nN")) != opteof) {
 		switch (opt)
@@ -750,7 +811,7 @@ main(int argc, char **argv)
 	}
 	if (!stralloc_0(&ueo))
 		temp_nomem();
-	if (!env_put2("NEWSENDER", ueo.s) || !stralloc_ready(&cmds, 0))
+	if (!env_put2("NEWSENDER", ueo.s))
 		temp_nomem();
 	cmds.len = 0;
 	if (fd != -1)
@@ -770,6 +831,7 @@ main(int argc, char **argv)
 		if (cmds.s[j] == '\n') {
 			switch (cmds.s[i])
 			{
+			case '%':
 			case '#':
 			case '.':
 			case '/':
@@ -806,6 +868,12 @@ main(int argc, char **argv)
 				if (i)
 					break;
 				strerr_die1x(111, "Uh-oh: first line of .qmail file is blank. (#4.2.1)");
+			case '%': /*- envdir */
+				x = cmds.s + i + 1;
+				for (;*x && (*x == ' ' || *x == '\t'); x++);
+				if ((r = envdir(x, &e, 1, 0)))
+					strerr_die5sys(111, "Uh-oh: ", envdir_str(i), ": ", e, ": ");
+				break;
 			case '#': /*- comment */
 			case ':': /*- end branch */
 				break;
@@ -900,7 +968,7 @@ main(int argc, char **argv)
 			if (flag99)
 				break;
 		}
-	}
+	} /* for (j = 0; j < cmds.len; ++j) */
 	if (numforward) {
 		if (flagdoit) {
 			recips[numforward] = 0;

--- a/indimail-mta-x/qmail-local.c
+++ b/indimail-mta-x/qmail-local.c
@@ -1,7 +1,6 @@
 /*
- * $Id: qmail-local.c,v 1.47 2023-09-20 08:23:28+05:30 Cprogrammer Exp mbhangui $
+ * $Id: qmail-local.c,v 1.48 2023-09-20 21:26:31+05:30 Cprogrammer Exp mbhangui $
  */
-#include <stdio.h>
 #include <sys/types.h>
 #include <sys/time.h>
 #include <sys/stat.h>
@@ -984,7 +983,7 @@ main(int argc, char **argv)
 void
 getversion_qmail_local_c()
 {
-	static char    *x = "$Id: qmail-local.c,v 1.47 2023-09-20 08:23:28+05:30 Cprogrammer Exp mbhangui $";
+	static char    *x = "$Id: qmail-local.c,v 1.48 2023-09-20 21:26:31+05:30 Cprogrammer Exp mbhangui $";
 
 	x = sccsidmyctimeh;
 	x++;
@@ -992,6 +991,9 @@ getversion_qmail_local_c()
 
 /*
  * $Log: qmail-local.c,v $
+ * Revision 1.48  2023-09-20 21:26:31+05:30  Cprogrammer
+ * added '%' option in dot-qmail to add env variables from a directory
+ *
  * Revision 1.47  2023-09-20 08:23:28+05:30  Cprogrammer
  * added X-Forwarded-To, X-Forwarded-For headers when forwarding
  *

--- a/indimail-mta-x/svctool.9
+++ b/indimail-mta-x/svctool.9
@@ -146,6 +146,7 @@ Known values for OPTION are:
   [--routes=smtp|qmtp|static]
   [--cname-lookup]
   [--setuser-priv]
+  [--sanitize-env=env_list]
   [--min-free=M --skipsend --deliverylimit-count=D --deliverylimit-size=S]
   [--rbl=list]
   [--content-filter=c]
@@ -237,6 +238,8 @@ Known values for OPTION are:
   routes         - Perform SMTPROUTE / QMTPROUTE / static routing
   cname-lookup   - Perform CNAME lookup for recipient host in qmail-remote
   setuser-priv   - Set supplementary groups when run qmail-local
+  env_list       - List of env variables to preserve when --sanitize-env
+                   is given
   masquerade     - Allow user to change Mail From when using authenticated smtp
   rbl            - Deploy RBL lookups
   skipsend       - Skip creation of send script
@@ -288,7 +291,7 @@ Known values for OPTION are:
   [--routes=smtp|qmtp|static]
   [--cname-lookup]
   [--setuser-priv]
-  [--setuser-priv]
+  [--sanitize-env=env_list]
   [--min-free=M --deliverylimit-count=D --deliverylimit-size=S]
   [--logfilter=logfifo]
   [--localfilter --remotefilter]
@@ -336,6 +339,8 @@ Known values for OPTION are:
   routes         - Perform SMTPROUTE / QMTPROUTE / static routing
   cname-lookup   - Perform CNAME lookup for recipient host in qmail-remote
   setuser-priv   - Set supplementary groups when run qmail-local
+  env_list       - List of env variables to preserve when --sanitize-env
+                   is given
   fsync          - Sync files and directories when writing files
   syncdir        - Use BSD style sync semantics for flushing directories
   paranoid       - Paranoid hostaccess check
@@ -367,6 +372,7 @@ Known values for OPTION are:
   [--routes=smtp|qmtp|static]
   [--cname-lookup]
   [--setuser-priv]
+  [--sanitize-env=env_list]
   [--min-free=M --deliverylimit-count=D --deliverylimit-size=S]
   [--localfilter --remotefilter]
   [--dkverify=dkim|none]
@@ -398,6 +404,8 @@ Known values for OPTION are:
   routes         - Perform SMTPROUTE / QMTPROUTE / static routing
   cname-lookup   - Perform CNAME lookup for recipient host in qmail-remote
   setuser-priv   - Set supplementary groups when run qmail-local
+  env_list       - List of env variables to preserve when --sanitize-env
+                   is given
   fsync          - Sync files and directories when writing files
   syncdir        - Use BSD style sync semantics for flushing directories
   paranoid       - Paranoid hostaccess check

--- a/indimail-mta-x/svctool.in
+++ b/indimail-mta-x/svctool.in
@@ -1,5 +1,5 @@
 #
-# $Id: svctool.in,v 2.702 2023-09-20 00:33:12+05:30 Cprogrammer Exp mbhangui $
+# $Id: svctool.in,v 2.703 2023-09-20 21:25:28+05:30 Cprogrammer Exp mbhangui $
 #
 
 #
@@ -26,7 +26,7 @@ host=@HOST@
 shared_objects=0
 use_dlmopen=0
 skip_sendmail_check=0
-RCSID="# \$Id: svctool.in,v 2.702 2023-09-20 00:33:12+05:30 Cprogrammer Exp mbhangui $"
+RCSID="# \$Id: svctool.in,v 2.703 2023-09-20 21:25:28+05:30 Cprogrammer Exp mbhangui $"
 
 #
 # End of User Configuration

--- a/indimail-mta-x/svctool.in
+++ b/indimail-mta-x/svctool.in
@@ -70,6 +70,7 @@ Known values for OPTION are:
   [--routes=smtp|qmtp|static]
   [--cname-lookup]
   [--setuser-priv]
+  [--sanitize-env=env_list]
   [--min-free=M --skipsend --deliverylimit-count=D --deliverylimit-size=S]
   [--rbl=list]
   [--content-filter=c]
@@ -161,6 +162,8 @@ Known values for OPTION are:
   routes         - Perform SMTPROUTE / QMTPROUTE / static routing
   cname-lookup   - Perform CNAME lookup for recipient host in qmail-remote
   setuser-priv   - Set supplementary groups when run qmail-local
+  env_list       - List of env variables to preserve when --sanitize-env
+                   is given
   masquerade     - Allow user to change Mail From when using authenticated smtp
   rbl            - Deploy RBL lookups
   skipsend       - Skip creation of send script
@@ -212,6 +215,7 @@ Known values for OPTION are:
   [--routes=smtp|qmtp|static]
   [--cname-lookup]
   [--setuser-priv]
+  [--sanitize-env=env_list]
   [--min-free=M --deliverylimit-count=D --deliverylimit-size=S]
   [--logfilter=logfifo]
   [--localfilter --remotefilter]
@@ -259,6 +263,8 @@ Known values for OPTION are:
   routes         - Perform SMTPROUTE / QMTPROUTE / static routing
   cname-lookup   - Perform CNAME lookup for recipient host in qmail-remote
   setuser-priv   - Set supplementary groups when run qmail-local
+  env_list       - List of env variables to preserve when --sanitize-env
+                   is given
   fsync          - Sync files and directories when writing files
   syncdir        - Use BSD style sync semantics for flushing directories
   paranoid       - Paranoid hostaccess check
@@ -290,6 +296,7 @@ Known values for OPTION are:
   [--routes=smtp|qmtp|static]
   [--cname-lookup]
   [--setuser-priv]
+  [--sanitize-env=env_list]
   [--min-free=M --deliverylimit-count=D --deliverylimit-size=S]
   [--localfilter --remotefilter]
   [--dkverify=dkim|none]
@@ -321,6 +328,8 @@ Known values for OPTION are:
   routes         - Perform SMTPROUTE / QMTPROUTE / static routing
   cname-lookup   - Perform CNAME lookup for recipient host in qmail-remote
   setuser-priv   - Set supplementary groups when run qmail-local
+  env_list       - List of env variables to preserve when --sanitize-env
+                   is given
   fsync          - Sync files and directories when writing files
   syncdir        - Use BSD style sync semantics for flushing directories
   paranoid       - Paranoid hostaccess check
@@ -6795,6 +6804,11 @@ if [ $setuser_privilege -eq 1 ] ; then
 else
 	> $conf_dir/SETUSER_PRIVILEGES
 fi
+if [ -n "$sanitized_env" ] ; then
+	echo $sanitized_env > $conf_dir/SANITIZE_ENV
+else
+	> $conf_dir/SANITIZE_ENV
+fi
 if [ ! " $CONTROLDIR" = " " ] ; then
 	echo "$CONTROLDIR" > $conf_dir/CONTROLDIR
 else
@@ -7044,6 +7058,16 @@ if [ " $enable_cname_lookup" = " " ] ; then
 	echo 1 > $conf_dir/DISABLE_CNAME_LOOKUP
 else
 	> $conf_dir/DISABLE_CNAME_LOOKUP
+fi
+if [ $setuser_privilege -eq 1 ] ; then
+	echo 1 > $conf_dir/SETUSER_PRIVILEGES
+else
+	> $conf_dir/SETUSER_PRIVILEGES
+fi
+if [ -n "$sanitized_env" ] ; then
+	echo $sanitized_env > $conf_dir/SANITIZE_ENV
+else
+	> $conf_dir/SANITIZE_ENV
 fi
 if [ ! " $CONTROLDIR" = " " ] ; then
 	echo "$CONTROLDIR" > $conf_dir/CONTROLDIR
@@ -10280,6 +10304,7 @@ qmailsmtpd=$QmailBinPrefix"/sbin/qmail-smtpd"
 envdir_opts="-c"
 updatecerts=0
 setuser_privilege=0
+sanitized_env=""
 if [ " $CONTROLDIR" = " " ] ; then
 	cntrldir=$sysconfdir/control
 else
@@ -10576,6 +10601,9 @@ while test $# -gt 0; do
 	;;
 	--setuser-priv)
 	setuser_privilege=1
+	;;
+	--sanitize-env=*)
+	sanitized_env=$optarg
 	;;
 	--odmr)
 	odmr=1


### PR DESCRIPTION
1. Use SANITIZE_ENV environment variable to clear all environment variables in qmail-local execpt USE_FSYNC, USE_FDATASYNC, USE_SYNCDIR and env variables in SANITIZE_ENV
2. update qmail-local.c to use SANITIZE_ENV
3. update svctool to create SANITIZE_ENV
4. update man pages for qmail-local, dot-qmail, svctool