### PR TITLE
refactor qmulti.c

### DIFF
--- a/indimail-mta-x/Makefile
+++ b/indimail-mta-x/Makefile
@@ -778,7 +778,7 @@ load qhpsi.o auto_qmail.o get_uid.o auto_uids.o
 	./load qhpsi auto_qmail.o get_uid.o auto_uids.o \
 	-ldl $(QMAILLIB)
 
-qhpsi.o: compile qhpsi.c auto_qmail.h auto_uids.h
+qhpsi.o: compile qhpsi.c auto_qmail.h auto_uids.h qmail.h
 	./compile qhpsi.c
 
 qscanq: load qscanq.o auto_uids.o get_uid.o \
@@ -871,7 +871,8 @@ conf-servicedir
 custom_error.o: compile custom_error.c qmail.h
 	./compile custom_error.c
 getqueue.o: \
-compile getqueue.c getqueue.h haslibrt.h custom_error.h conf-queue
+compile getqueue.c getqueue.h haslibrt.h custom_error.h \
+qmail.h conf-queue
 	./compile `grep -h -v "^#" conf-queue` getqueue.c
 
 qscanq-stdin: load qscanq-stdin.o auto_qmail.o \
@@ -894,7 +895,7 @@ do_ripmime.o: compile do_ripmime.c exitcodes.h
 	./compile do_ripmime.c
 
 do_scan.o: compile do_scan.c exitcodes.h qregex.h control.h \
-variables.h auto_control.h
+variables.h auto_control.h qmail.h
 	./compile do_scan.c
 
 auto_ripmime_cmd.c: auto-strarr conf-ripmime-cmd
@@ -1073,9 +1074,10 @@ variables.o set_environment.o auto_qmail.o auto_prefix.o srs.lib
 	set_environment.o $(static_option) $(QMAILLIB) \
 	-L../libsrs2-x/libsrs2/.libs `cat srs.lib` $(dynamic_option)
 
-qmail-inject.8: qmail-inject.9 conf-prefix conf-sysconfdir
+qmail-inject.8: qmail-inject.9 conf-prefix conf-qmail conf-sysconfdir
 	cat qmail-inject.9 \
 	| sed s}PREFIX}"`head -1 conf-prefix`"}g \
+	| sed s}HOME}"`head -1 conf-qmail`"}g \
 	| sed s}@controldir\@}"`head -1 conf-sysconfdir`/control"}g \
 	> qmail-inject.8
 
@@ -1257,8 +1259,8 @@ auto_control.o socket.lib
 
 qmail-qmqpc.o: \
 compile qmail-qmqpc.c auto_control.h slurpclose.h ip.h \
-timeoutconn.h control.h variables.h \
-haveip6.h socket.h conf-ip
+timeoutconn.h control.h variables.h qmail.h socket.h \
+haveip6.h conf-ip
 	./compile `grep -h -v "^#" conf-ip` qmail-qmqpc.c
 
 qmail-qmqpd: \
@@ -1326,10 +1328,7 @@ compile qmail-multi.c qmulti.h qmail.h mailfilter.h conf-queue
 
 qmail-multi.8: \
 qmail-multi.9 conf-prefix conf-qmail
-	cat qmail-multi.9 \
-	| sed s}QMAILHOME}"`head -1 conf-qmail`"}g \
-	| sed s}PREFIX}"`head -1 conf-prefix`"}g \
-	> qmail-multi.8
+	$(edit) qmail-multi.9 > qmail-multi.8
 
 qmail-spamfilter: load qmail-spamfilter.o qmulti.o \
 auto_prefix.o auto_qmail.o auto_control.o control.o \
@@ -3286,7 +3285,7 @@ sortedtest: load sortedtest.o sorted.o
 sortedtest.o: compile sortedtest.c sorted.h
 	./compile sortedtest.c
 
-generic.o: compile generic.c
+generic.o: compile generic.c qmail.h
 	./compile generic.c
 
 relaytest.o: compile relaytest.c

--- a/indimail-mta-x/do_scan.c
+++ b/indimail-mta-x/do_scan.c
@@ -1,63 +1,5 @@
 /*
- * $Log: do_scan.c,v $
- * Revision 1.19  2021-08-29 23:27:08+05:30  Cprogrammer
- * define functions as noreturn
- *
- * Revision 1.18  2021-06-15 11:32:24+05:30  Cprogrammer
- * remove creation of link for /etc/indimail/control in scanq directory
- *
- * Revision 1.17  2021-06-09 19:34:19+05:30  Cprogrammer
- * added makeargs.h
- *
- * Revision 1.16  2020-04-01 16:13:35+05:30  Cprogrammer
- * added header for makeargs() function
- *
- * Revision 1.15  2018-05-18 17:39:05+05:30  Cprogrammer
- * BUG - break out of loop if file extension matches a line in badext
- *
- * Revision 1.14  2018-05-11 14:37:51+05:30  Cprogrammer
- * BUG - fixed prohibited extensions scanning
- *
- * Revision 1.13  2016-05-17 19:44:58+05:30  Cprogrammer
- * use auto_control, set by conf-control to set control directory
- *
- * Revision 1.12  2009-05-01 10:38:48+05:30  Cprogrammer
- * change for errstr argument to address_match()
- *
- * Revision 1.11  2009-04-29 21:03:17+05:30  Cprogrammer
- * check address_match() for failure
- *
- * Revision 1.10  2009-04-29 08:59:07+05:30  Cprogrammer
- * change for cdb argument to address_match()
- *
- * Revision 1.9  2009-04-29 08:24:03+05:30  Cprogrammer
- * change for address_match() function
- *
- * Revision 1.8  2008-08-03 18:25:33+05:30  Cprogrammer
- * use proper proto
- *
- * Revision 1.7  2007-12-20 13:54:42+05:30  Cprogrammer
- * removed compilation warning
- *
- * Revision 1.6  2005-02-18 17:54:30+05:30  Cprogrammer
- * Facility to specify name of scanned file by %s in SCANCMD env variable
- *
- * Revision 1.5  2004-10-22 20:24:40+05:30  Cprogrammer
- * added RCS id
- *
- * Revision 1.4  2004-09-27 15:30:26+05:30  Cprogrammer
- * moved env_unset("VIRUSCHECK") to qmail-multi.c
- *
- * Revision 1.3  2004-09-23 22:54:44+05:30  Cprogrammer
- * corrected problem with permissions
- *
- * Revision 1.2  2004-09-22 22:24:55+05:30  Cprogrammer
- * added SCANCMD to select virus scanner
- * add code to reject bad attachments
- *
- * Revision 1.1  2004-09-20 11:08:52+05:30  Cprogrammer
- * Initial revision
- *
+ * $Id: do_scan.c,v 1.20 2023-10-27 16:10:57+05:30 Cprogrammer Exp mbhangui $
  */
 #include <sys/types.h>
 #include <unistd.h>
@@ -71,6 +13,7 @@
 #include <str.h>
 #include <makeargs.h>
 #include <noreturn.h>
+#include "qmail.h"
 #include "control.h"
 #include "qregex.h"
 #include "exitcodes.h"
@@ -90,13 +33,13 @@ static stralloc brp = { 0 };
 no_return void
 die_nomem()
 {
-	_exit(51);
+	_exit(QQ_OUT_OF_MEMORY);
 }
 
 no_return void
 die_control()
 {
-	_exit(55);
+	_exit(QQ_CONFIG_ERR);
 }
 
 no_return void
@@ -117,7 +60,7 @@ scan_badattachments(char *dir_name)
 	if (!dir_name || !*dir_name)
 		return (0);
 	if (!(dir = opendir(dir_name)))
-		die(61);
+		die(QQ_CHDIR);
 	if ((extok = control_readfile(&ext, (x = env_get("BADEXT")) && *x ? x : "badext", 0)) == -1)
 		die_control();
 	if (extok && !constmap_init(&mapext, ext.s, ext.len, 0))
@@ -200,7 +143,7 @@ do_scan()
 			close(1); /*- Don't let it fiddle with envelope */
 			if ((ptr = env_get("SCANCMD"))) {
 				if (!(scancmd = makeargs(ptr)))
-					_exit(51);
+					_exit(QQ_OUT_OF_MEMORY);
 				for (i = 1;scancmd[i];i++) {
 					if (!str_diffn(scancmd[i], "%s", 2))
 						scancmd[i] = ".";
@@ -236,9 +179,74 @@ do_scan()
 void
 getversion_do_scan_c()
 {
-	static char    *x = "$Id: do_scan.c,v 1.19 2021-08-29 23:27:08+05:30 Cprogrammer Exp mbhangui $";
+	static char    *x = "$Id: do_scan.c,v 1.20 2023-10-27 16:10:57+05:30 Cprogrammer Exp mbhangui $";
 
 	x = sccsidmakeargsh;
 	x++;
 }
 #endif
+
+/*
+ * $Log: do_scan.c,v $
+ * Revision 1.20  2023-10-27 16:10:57+05:30  Cprogrammer
+ * replace hard-coded exit values with constants from qmail.h
+ *
+ * Revision 1.19  2021-08-29 23:27:08+05:30  Cprogrammer
+ * define functions as noreturn
+ *
+ * Revision 1.18  2021-06-15 11:32:24+05:30  Cprogrammer
+ * remove creation of link for /etc/indimail/control in scanq directory
+ *
+ * Revision 1.17  2021-06-09 19:34:19+05:30  Cprogrammer
+ * added makeargs.h
+ *
+ * Revision 1.16  2020-04-01 16:13:35+05:30  Cprogrammer
+ * added header for makeargs() function
+ *
+ * Revision 1.15  2018-05-18 17:39:05+05:30  Cprogrammer
+ * BUG - break out of loop if file extension matches a line in badext
+ *
+ * Revision 1.14  2018-05-11 14:37:51+05:30  Cprogrammer
+ * BUG - fixed prohibited extensions scanning
+ *
+ * Revision 1.13  2016-05-17 19:44:58+05:30  Cprogrammer
+ * use auto_control, set by conf-control to set control directory
+ *
+ * Revision 1.12  2009-05-01 10:38:48+05:30  Cprogrammer
+ * change for errstr argument to address_match()
+ *
+ * Revision 1.11  2009-04-29 21:03:17+05:30  Cprogrammer
+ * check address_match() for failure
+ *
+ * Revision 1.10  2009-04-29 08:59:07+05:30  Cprogrammer
+ * change for cdb argument to address_match()
+ *
+ * Revision 1.9  2009-04-29 08:24:03+05:30  Cprogrammer
+ * change for address_match() function
+ *
+ * Revision 1.8  2008-08-03 18:25:33+05:30  Cprogrammer
+ * use proper proto
+ *
+ * Revision 1.7  2007-12-20 13:54:42+05:30  Cprogrammer
+ * removed compilation warning
+ *
+ * Revision 1.6  2005-02-18 17:54:30+05:30  Cprogrammer
+ * Facility to specify name of scanned file by %s in SCANCMD env variable
+ *
+ * Revision 1.5  2004-10-22 20:24:40+05:30  Cprogrammer
+ * added RCS id
+ *
+ * Revision 1.4  2004-09-27 15:30:26+05:30  Cprogrammer
+ * moved env_unset("VIRUSCHECK") to qmail-multi.c
+ *
+ * Revision 1.3  2004-09-23 22:54:44+05:30  Cprogrammer
+ * corrected problem with permissions
+ *
+ * Revision 1.2  2004-09-22 22:24:55+05:30  Cprogrammer
+ * added SCANCMD to select virus scanner
+ * add code to reject bad attachments
+ *
+ * Revision 1.1  2004-09-20 11:08:52+05:30  Cprogrammer
+ * Initial revision
+ *
+ */

--- a/indimail-mta-x/doc/ChangeLog
+++ b/indimail-mta-x/doc/ChangeLog
@@ -13,9 +13,14 @@ Release 3.0.6-1.1 Start 25/10/2023 End XX/XX/XXXX
 08. create_services.in: added --setuser-priv option for slowq service
 09. autoresponder.c, indimail-spamfilter.c: rewind descriptor 0 regardless of
     MAKE_SEEKABLE setting
-- 25/10/2023
+- 26/10/2023
 10. qmail-spamfilter.c: added HAMEXITCODE, UNSUREEXITCODE
 11. qmail-spamfilter.c: Fixed working of globalspamredirect + REJECTSPAM
+- 27/10/2023
+12. do_scan.c, generic.c, getqueue.c, mailfilter.c, qhpsi.c,
+    qmail-qmqpc.c: replace hard-coded exit values with constants from qmail.h
+13. qmulti.c: unset env variables queue_env, QUEUEPROG to prevent recursion 
+14. qmulti.c: refactored code to handle qmail-queue consistently
 
 * Tue Oct 17 2023 18:34:04 +0000 Manvendra Bhangui <indimail-mta@indimail.org> 3.0.5-1.1%{?dist}
 Release 3.0.5-1.1 Start 11/09/2023 End 17/10/2023

--- a/indimail-mta-x/generic.c
+++ b/indimail-mta-x/generic.c
@@ -1,5 +1,73 @@
 /*
+ * $Id: generic.c,v 1.7 2023-10-27 16:11:04+05:30 Cprogrammer Exp mbhangui $
+ */
+#include <unistd.h>
+#include <str.h>
+#include <env.h>
+#include <wait.h>
+#include <makeargs.h>
+#include <noreturn.h>
+#include "qmail.h"
+
+extern char    *auto_scancmd[];
+
+no_return int
+virusscan(char *messfn)
+{
+	int             wstat, child;
+	unsigned long   u;
+	char          **argv;
+	char           *scancmd[3] = { 0, 0, 0 };
+	char           *ptr;
+
+	switch (child = fork())
+	{
+	case -1:
+		_exit(QQ_FORK_ERR);
+	case 0:
+		if ((ptr = env_get("SCANCMD"))) {
+			if (!(argv = makeargs(ptr)))
+				_exit(QQ_OUT_OF_MEMORY);
+		} else
+			argv = auto_scancmd;
+		if (!argv[1]) {
+			scancmd[0] = argv[0];
+			scancmd[1] = messfn;
+			argv = scancmd;
+		} else
+		for (u = 1; argv[u]; u++) {
+			if (!str_diffn(argv[u], "%s", 2))
+				argv[u] = messfn;
+		}
+		if (*argv[0] != '/' && *argv[0] != '.')
+			execvp(*argv, argv);
+		else
+			execv(*argv, argv);
+		_exit(QQ_EXEC_FAILED);
+	}
+	if (wait_pid(&wstat, child) == -1)
+		_exit(QQ_WAITPID_SURPRISE);
+	if (wait_crashed(wstat))
+		_exit(QQ_CRASHED);
+	_exit(wait_exitcode(wstat));
+}
+
+#ifndef lint
+void
+getversion_generic_c()
+{
+	static char    *x = "$Id: generic.c,v 1.7 2023-10-27 16:11:04+05:30 Cprogrammer Exp mbhangui $";
+
+	x = sccsidmakeargsh;
+	x++;
+}
+#endif
+
+/*
  * $Log: generic.c,v $
+ * Revision 1.7  2023-10-27 16:11:04+05:30  Cprogrammer
+ * replace hard-coded exit values with constants from qmail.h
+ *
  * Revision 1.6  2021-08-29 23:27:08+05:30  Cprogrammer
  * define functions as noreturn
  *
@@ -19,63 +87,3 @@
  * Initial revision
  *
  */
-#include <unistd.h>
-#include <str.h>
-#include <env.h>
-#include <wait.h>
-#include <makeargs.h>
-#include <noreturn.h>
-
-extern char    *auto_scancmd[];
-
-no_return int
-virusscan(char *messfn)
-{
-	int             wstat, child;
-	unsigned long   u;
-	char          **argv;
-	char           *scancmd[3] = { 0, 0, 0 };
-	char           *ptr;
-
-	switch (child = fork())
-	{
-	case -1:
-		_exit(121);
-	case 0:
-		if ((ptr = env_get("SCANCMD"))) {
-			if (!(argv = makeargs(ptr)))
-				_exit(51);
-		} else
-			argv = auto_scancmd;
-		if (!argv[1]) {
-			scancmd[0] = argv[0];
-			scancmd[1] = messfn;
-			argv = scancmd;
-		} else
-		for (u = 1; argv[u]; u++) {
-			if (!str_diffn(argv[u], "%s", 2))
-				argv[u] = messfn;
-		}
-		if (*argv[0] != '/' && *argv[0] != '.')
-			execvp(*argv, argv);
-		else
-			execv(*argv, argv);
-		_exit(75);
-	}
-	if (wait_pid(&wstat, child) == -1)
-		_exit(122);
-	if (wait_crashed(wstat))
-		_exit(123);
-	_exit(wait_exitcode(wstat));
-}
-
-#ifndef lint
-void
-getversion_generic_c()
-{
-	static char    *x = "$Id: generic.c,v 1.6 2021-08-29 23:27:08+05:30 Cprogrammer Exp mbhangui $";
-
-	x = sccsidmakeargsh;
-	x++;
-}
-#endif

--- a/indimail-mta-x/getqueue.c
+++ b/indimail-mta-x/getqueue.c
@@ -1,18 +1,5 @@
 /*
- * $Log: getqueue.c,v $
- * Revision 1.4  2023-02-08 11:18:07+05:30  Cprogrammer
- * include stdint.h for uint32_t definition
- *
- * Revision 1.3  2022-04-14 08:17:55+05:30  Cprogrammer
- * added feature to disable a queue and skip disabled queues
- * refactored code and added comments
- *
- * Revision 1.2  2022-03-30 21:08:38+05:30  Cprogrammer
- * use arc4random() to randomly select queue
- *
- * Revision 1.1  2022-03-26 10:23:34+05:30  Cprogrammer
- * Initial revision
- *
+ * $Id: getqueue.c,v 1.5 2023-10-27 16:22:13+05:30 Cprogrammer Exp mbhangui $
  */
 #include <unistd.h>
 #include <fmt.h>
@@ -21,6 +8,7 @@
 #include <error.h>
 #include <arc4random.h>
 #include <stdint.h>
+#include "qmail.h"
 #include "haslibrt.h"
 #ifdef HASLIBRT
 #include <sys/mman.h>
@@ -52,7 +40,7 @@ queueNo_from_shm(char *ident)
 		custom_error(ident, "Z", "unable to read POSIX shared memory segment /qscheduler", 0, "X.3.0");
 	close(shm);
 	if (!(queue = (int *) alloc(qcount * sizeof(int))))
-		_exit(51);
+		_exit(QQ_OUT_OF_MEMORY);
 	/*- get queue with lowest concurrency */
 	for (j = n = 0, min = -1; j < qcount; j++) {
 		s = shm_name;
@@ -139,8 +127,28 @@ queueNo_from_env()
 void
 getversion_getqueue_c()
 {
-	static char    *x = "$Id: getqueue.c,v 1.4 2023-02-08 11:18:07+05:30 Cprogrammer Exp mbhangui $";
+	static char    *x = "$Id: getqueue.c,v 1.5 2023-10-27 16:22:13+05:30 Cprogrammer Exp mbhangui $";
 
 	x++;
 }
 #endif
+
+/*
+ * $Log: getqueue.c,v $
+ * Revision 1.5  2023-10-27 16:22:13+05:30  Cprogrammer
+ * replace hard-coded exit values with constants from qmail.h
+ *
+ * Revision 1.4  2023-02-08 11:18:07+05:30  Cprogrammer
+ * include stdint.h for uint32_t definition
+ *
+ * Revision 1.3  2022-04-14 08:17:55+05:30  Cprogrammer
+ * added feature to disable a queue and skip disabled queues
+ * refactored code and added comments
+ *
+ * Revision 1.2  2022-03-30 21:08:38+05:30  Cprogrammer
+ * use arc4random() to randomly select queue
+ *
+ * Revision 1.1  2022-03-26 10:23:34+05:30  Cprogrammer
+ * Initial revision
+ *
+ */

--- a/indimail-mta-x/mailfilter.c
+++ b/indimail-mta-x/mailfilter.c
@@ -1,11 +1,5 @@
 /*
- * $Log: mailfilter.c,v $
- * Revision 1.2  2022-10-17 19:43:40+05:30  Cprogrammer
- * use exit codes defines from qmail.h
- *
- * Revision 1.1  2021-06-09 19:32:41+05:30  Cprogrammer
- * Initial revision
- *
+ * $Id: mailfilter.c,v 1.3 2023-10-27 16:11:14+05:30 Cprogrammer Exp mbhangui $
  */
 #include <unistd.h>
 #include <env.h>
@@ -25,11 +19,11 @@ mailfilter(int argc, char **argv, char *filterargs)
 	int             wstat, filt_exitcode;
 
 	if (pipe(pipefd) == -1)
-		_exit(60);
+		_exit(QQ_PIPE_SOCKET);
 	switch ((filt_pid = fork()))
 	{
 	case -1:
-		_exit(121);
+		_exit(QQ_FORK_ERR);
 	case 0: /*- Filter Program */
 		/*- Mail content read from fd 0 */
 		if (mktempfile(0))
@@ -40,7 +34,7 @@ mailfilter(int argc, char **argv, char *filterargs)
 			close(pipefd[1]);
 		/*- Avoid loop if program(s) defined by FILTERARGS call qmail-inject, etc */
 		if (!env_unset("FILTERARGS") || !env_unset("SPAMFILTER"))
-			_exit(51);
+			_exit(QQ_OUT_OF_MEMORY);
 		execl("/bin/sh", "qmailfilter", "-c", filterargs, (char *) 0);
 		_exit(QQ_EXEC_FAILED);
 	default:
@@ -86,7 +80,7 @@ mailfilter(int argc, char **argv, char *filterargs)
 void
 getversion_mailfilter_c()
 {
-	static char    *x = "$Id: mailfilter.c,v 1.2 2022-10-17 19:43:40+05:30 Cprogrammer Exp mbhangui $";
+	static char    *x = "$Id: mailfilter.c,v 1.3 2023-10-27 16:11:14+05:30 Cprogrammer Exp mbhangui $";
 
 	x = sccsidmailfilterh;
 	x = sccsidmktempfileh;
@@ -94,3 +88,16 @@ getversion_mailfilter_c()
 	x++;
 }
 #endif
+
+/*
+ * $Log: mailfilter.c,v $
+ * Revision 1.3  2023-10-27 16:11:14+05:30  Cprogrammer
+ * replace hard-coded exit values with constants from qmail.h
+ *
+ * Revision 1.2  2022-10-17 19:43:40+05:30  Cprogrammer
+ * use exit codes defines from qmail.h
+ *
+ * Revision 1.1  2021-06-09 19:32:41+05:30  Cprogrammer
+ * Initial revision
+ *
+ */

--- a/indimail-mta-x/qmail-dkim.9
+++ b/indimail-mta-x/qmail-dkim.9
@@ -8,10 +8,21 @@ message for delivery
 \fBqmail-dkim\fR [ \fIqqf\fR [\fIarg1\fR] [\fIarg2\fR] [...] ]
 
 .SH DESCRIPTION
-\fBqmail-dkim\fR has the same interface as \fBqmail-queue\fR except that it
-inserts an appropriate DKIM header (rfc4871, rfc6376) before it queues the
-message. To invoke \fBqmail-dkim\fR, set QMAILQUEUE to full path of
-qmail-dkim in the environment, when you send or receive email.
+\fBqmail-dkim\fR(1) allows indimail to add DKIM signature in the message.
+It gets invoked by indimail programs using qmail-queue frontend when the
+\fBQMAILQUEUE\fR environment is set to \fBqmail-dkim\fR or when passed as a
+command line argument having \fBqmail-dkim\fR like below (which will have
+the message pass through \fBqmail-dkim\fR and \fBqmail-spamfilter\fR).
+
+.EX
+QMAILQUEUE="@prefix@/sbin/qmail-dkim @prefix@/sbin/qmail-spamfilter"
+.EE
+
+\fBqmail-dkim\fR has the
+same interface as \fBqmail-queue\fR except that it inserts an appropriate
+DKIM header (rfc4871, rfc6376) before it queues the message. To invoke
+\fBqmail-dkim\fR, set QMAILQUEUE to full path of qmail-dkim in the
+environment, when you send or receive email.
 
 After inserting the DKIM header, \fBqmail-dkim\fR will call
 \fBqmail-queue\fR as a default, to deposit message in the queue. If you

--- a/indimail-mta-x/qmail-inject.9
+++ b/indimail-mta-x/qmail-inject.9
@@ -1,3 +1,4 @@
+.\" vim: tw=75
 .TH qmail-inject 8
 .SH NAME
 qmail-inject \- preprocess and send a mail message
@@ -12,144 +13,91 @@ qmail-inject \- preprocess and send a mail message
 ]
 
 .SH DESCRIPTION
-.B qmail-inject
-reads a mail message from its standard input, adds appropriate information
-to the message header, and invokes
-.B qmail-queue
-to send the message to one or more recipients.
+\fBqmail-inject\fR reads a mail message from its standard input, adds
+appropriate information to the message header, and by default invokes
+\fBqmail-queue\fR(8) to send the message to one or more recipients. You can
+set \fBQMAILQUEUE\fR environment variable to call any other program that
+has the same interface as \fBqmail-queue\fR. \fBQMAILQUEUE\fR can be list
+of multiple programs separated by a white space. e.g. you can set
+QMAILQUEUE to insert DKIM header as well as filter spam as below.
 
-.B qmail-inject
-rewrites the sender using Sender Rewriting Scheme if \fISRS\fB has been configured. See
-.B indimail-srs(5)
-for information on how to do this
+.EX
+  QMAILQUEUE="PREFIX/sbin/qmail-dkim PREFIX/sbin/qmail-spamfilter"
+.EE
 
-See
-.B qmail-header(5)
-for information on how
-.B qmail-inject
+\fBqmail-inject\fR rewrites the sender using Sender Rewriting Scheme if
+\fISRS\fB has been configured. See \fBindimail-srs\fR(5) for information on
+how to do this.
+
+See \fBqmail-header\fR(5) for information on how \fBqmail-inject\fR
 rewrites header fields.
 
-.B qmail-inject
-normally exits 0. It exits 100 if it was invoked improperly or if there is
-a severe syntax error in the message.  It exits 111 for temporary errors.
+\fBqmail-inject\fR normally exits 0. It exits 100 if it was invoked
+improperly or if there is a severe syntax error in the message.  It exits
+111 for temporary errors.
 
 .SH "ENVIRONMENT VARIABLES"
-For the convenience of users who do not run
-.B qmail-inject
-directly,
-.B qmail-inject
-takes many options through environment variables.
+For the convenience of users who do not run \fBqmail-inject\fR directly,
+\fBqmail-inject\fR takes many options through environment variables.
 
-The user name in the
-.B From
-header field is set by
-.BR QMAILUSER ,
-.BR MAILUSER ,
-.BR USER ,
-or
-.BR LOGNAME ,
-whichever comes first.
+The user name in the \fBFrom\fR header field is set by \fBQMAILUSER\fR,
+\fBMAILUSER\fR, \fBUSER\fR, or \fBLOGNAME\fR, whichever comes first.
 
-The host name is normally set by the
-.I defaulthost
-control but can be overridden with
-.B QMAILHOST
-or
-.BR MAILHOST .
+The host name is normally set by the \fIdefaulthost\fR control but can be
+overridden with \fBQMAILHOST\fR or \fBMAILHOST\fR.
 
-The personal name is
-.BR QMAILNAME ,
-.BR MAILNAME ,
-or
-.BR NAME .
+The personal name is \fBQMAILNAME\fR, \fBMAILNAME\fR, or \fBNAME\fR.
 
-The default envelope sender address is the same as the default
-.B From
-address, but it can be overridden with
-.B QMAILSUSER
-and
-.BR QMAILSHOST .
-It may also be modified by the
-.B r
-and
-.B m
+The default envelope sender address is the same as the default \fBFrom\fR
+address, but it can be overridden with \fBQMAILSUSER\fR and
+\fBQMAILSHOST\fR. It may also be modified by the \fBr\fR and \fBm\fR
 letters described below. Bounces will be sent to this address.
 
-If
-.B QMAILMFTFILE
-is set,
-.B qmail-inject
-reads a list of mailing list addresses, one per line, from that file. If
-To+Cc includes one of those addresses (without regard to case),
-.B qmail-inject
-adds a Mail-Followup-To field with all the To+Cc addresses.
-.B qmail-inject
+If \fBQMAILMFTFILE\fR is set, \fBqmail-inject\fR reads a list of mailing
+list addresses, one per line, from that file. If To+Cc includes one of
+those addresses (without regard to case), \fBqmail-inject\fR adds a
+Mail-Followup-To field with all the To+Cc addresses.  \fBqmail-inject\fR
 does not add Mail-Followup-To to a message that already has one.
 
-If
-.B QMAILQUEUE
-environment variable is set to PREFIX/sbin/qmail-multi,
-.B qmail-inject
-gets the ability to multiplex queues and filter emails. See qmail-multi(8).
+If \fBQMAILQUEUE\fR environment variable is set to PREFIX/sbin/qmail-multi,
+\fBqmail-inject\fR gets the ability to multiplex queues and filter
+emails. See qmail-multi(8).
 
-The
-.B QMAILINJECT
-environment variable can contain any of the following letters:
+The \fBQMAILINJECT\fR environment variable can contain any of the following
+letters:
 
 .TP
 .B c
-Use address-comment style for the
-.B From
-field. Normally
-.B qmail-inject
-uses name-address style.
+Use address-comment style for the \fBFrom\fR field. Normally
+\fBqmail-inject\fR uses name-address style.
 
 .TP
 .B s
-Do not look at any incoming
-.B Return-Path
-field. Normally, if
-.B Return-Path
-is supplied, it sets the envelope sender address, overriding all
-environment variables.
-.B Return-Path
-is deleted in any case.
+Do not look at any incoming \fBReturn-Path\fR field. Normally, if
+\fBReturn-Path\fR is supplied, it sets the envelope sender address,
+overriding all environment variables. \fBReturn-Path\fR is deleted in any
+case.
 
 .TP
 .B f
-Delete any incoming
-.B From
-field.
-Normally, if
-.B From
-is supplied, it overrides the usual
-.B From
-field created by
-.BR qmail-inject .
+Delete any incoming \fBFrom\fR field. Normally, if \fBFrom\fR is supplied,
+it overrides the usual \fBFrom\fR field created by \fBqmail-inject\fR.
 
 .TP
 .B i
-Delete any incoming
-.B Message-ID
-field. Normally, if
-.B Message-ID
-is supplied, it overrides the usual
-.B Message-ID
-field created by
-.BR qmail-inject .
+Delete any incoming \fBMessage-ID\fR field. Normally, if \fBMessage-ID\fR
+is supplied, it overrides the usual \fBMessage-ID\fR field created by
+\fBqmail-inject\fR.
 
 .TP
 .B r
-Use a per-recipient VERP.
-.B qmail-inject
-will append each recipient address to the envelope sender of the copy going
-to that recipient.
+Use a per-recipient VERP. \fBqmail-inject\fR will append each recipient
+address to the envelope sender of the copy going to that recipient.
 
 .TP
 .B m
-Use a per-message VERP.
-.B qmail-inject
-will append the current date and process ID to the envelope sender.
+Use a per-message VERP. \fBqmail-inject\fR will append the current date and
+process ID to the envelope sender.
 
 .TP
 .B n
@@ -166,63 +114,42 @@ set, it additionally uses environment set according to files in
 
 .TP
 .B \-a
-Send the message to all addresses given as
-.I recip
-arguments; do not use header recipient addresses.
+Send the message to all addresses given as \fIrecip\fR arguments; do not
+use header recipient addresses.
 
 .TP
 .B \-h
 Send the message to all header recipient addresses. For non-forwarded
-messages, this means the addresses listed under
-.BR To ,
-.BR Cc ,
-.BR Bcc ,
-.BR Apparently-To .
-For forwarded messages, this means the addresses listed under
-.BR Resent-To ,
-.BR Resent-Cc ,
-.BR Resent-Bcc .
-Do not use any
-.I recip
-arguments.
+messages, this means the addresses listed under \fBTo\fR, \fBCc\fR,
+\fBBcc\fR, \fBApparently-To\fR. For forwarded messages, this means the
+addresses listed under \fBResent-To\fR, \fBResent-Cc\fR, \fBResent-Bcc\fR.
+Do not use any \fIrecip\fR arguments.
 
 .TP
 .B \-A
 (Default.)
-Send the message to all addresses given as
-.I recip
-arguments.
-If no
-.I recip
-arguments are supplied, send the message to all header recipient addresses.
+Send the message to all addresses given as \fIrecip\fR arguments. If no
+\fIrecip\fR arguments are supplied, send the message to all header
+recipient addresses.
 
 .TP
 .B \-H
 Send the message to all header recipient addresses, and to all addresses
-given as
-.I recip
-arguments.
+given as \fIrecip\fR arguments.
 
 .TP
 .B \-f\fIsender
-Pass
-.I sender
-to
-.B qmail-queue
-as the envelope sender address. This overrides
-.B Return-Path
-and all environment variables.
+Pass \fIsender\fR to \fBqmail-queue\fR as the envelope sender address. This
+overrides \fBReturn-Path\fR and all environment variables.
 
 .TP
 .B \-N
 (Default.)
-Feed the resulting message to
-.BR qmail-queue .
+Feed the resulting message to \fBqmail-queue\fR.
 
 .TP
 .B \-n
-Print the message rather than feeding it to
-.BR qmail-queue .
+Print the message rather than feeding it to \fBqmail-queue\fR.
 
 .SH "CONTROL FILES"
 
@@ -230,108 +157,64 @@ Print the message rather than feeding it to
 .I defaultdomain
 Default domain name.
 Default:
-.IR me ,
-if that is supplied;
-otherwise the literal name
-.BR defaultdomain ,
-which is probably not what you want.
-.B qmail-inject
-adds this name to any host name without dots, including
-.I defaulthost
-if
-.I defaulthost
-does not have dots. (Exception: see
-.IR plusdomain .)
+\fIme\fR, if that is supplied; otherwise the literal name
+\fBdefaultdomain\fR, which is probably not what you want.
+\fBqmail-inject\fR adds this name to any host name without dots, including
+\fIdefaulthost\fR if \fIdefaulthost\fR does not have dots. (Exception: see
+\fIplusdomain\fR.)
 
-The
-.B QMAILDEFAULTDOMAIN
-environment variable overrides
-.IR defaultdomain .
+The \fBQMAILDEFAULTDOMAIN\fR environment variable overrides \fIdefaultdomain\fR.
 
 .TP 5
 .I defaulthost
 Default host name.
-Default:
-.IR me ,
-if that is supplied; otherwise the literal name
-.BR defaulthost ,
-which is probably not what you want.
-.B qmail-inject
-adds this name to any address without a host name.
-.I defaulthost
-need not be the current host's name. For example, you may prefer that
-outgoing mail show just your domain name.
+Default: \fIme\fR, if that is supplied; otherwise the literal name
+\fBdefaulthost\fR, which is probably not what you want. \fBqmail-inject\fR
+adds this name to any address without a host name. \fIdefaulthost\fR need
+not be the current host's name. For example, you may prefer that outgoing
+mail show just your domain name.
 
-The
-.B QMAILDEFAULTHOST
-environment variable overrides
-.IR defaulthost .
+The \fBQMAILDEFAULTHOST\fR environment variable overrides
+\fIdefaulthost\fR.
 
 .TP 5
 .I idhost
 Host name for Message-IDs.
-Default:
-.IR me ,
-if that is supplied;
-otherwise the literal name
-.BR idhost ,
-which is certainly not what you want.
-.I idhost
-need not be the current host's name. For example, you may prefer to use
-fake host names in Message-IDs. However,
-.I idhost
-must be a fully-qualified name within your domain, and each host in your
-domain should use a different
-.IR idhost .
+Default: \fIme\fR, if that is supplied; otherwise the literal name
+\fBidhost\fR, which is certainly not what you want. \fIidhost\fR need not
+be the current host's name. For example, you may prefer to use fake host
+names in Message-IDs. However, \fIidhost\fR must be a fully-qualified name
+within your domain, and each host in your domain should use a different
+\fIidhost\fR.
 
-The
-.B QMAILIDHOST
-environment variable overrides
-.IR idhost .
+The \fBQMAILIDHOST\fR environment variable overrides \fIidhost\fR.
 
 .TP 5
 .I plusdomain
 Plus domain name.
-Default:
-.IR me ,
-if that is supplied;
-otherwise the literal name
-.BR plusdomain ,
-which is probably not what you want.
-.B qmail-inject
+Default: \fIme\fR, if that is supplied; otherwise the literal name
+\fBplusdomain\fR, which is probably not what you want. \fBqmail-inject\fR
 adds this name to any host name that ends with a plus sign, including
-.I defaulthost
-if
-.I defaulthost
-ends with a plus sign. If a host name does not have dots but ends with a
-plus sign,
-.B qmail-inject
-uses
-.IR plusdomain ,
-not
-.IR defaultdomain .
+\fIdefaulthost\fR if \fIdefaulthost\fR ends with a plus sign. If a host
+name does not have dots but ends with a plus sign, \fBqmail-inject\fR uses
+\fIplusdomain\fR, not \fIdefaultdomain\fR.
 
-The
-.B QMAILPLUSDOMAIN
-environment variable overrides
-.IR plusdomain .
+The \fBQMAILPLUSDOMAIN\fR environment variable overrides \fIplusdomain\fR.
 
 .TP 5
 .I maxrecipients 
-maxrecipients is the number of RCPT TO:'s
-.B qmail-inject
-will accept.
-Default: 0 which means no restriction.
-The environment variable 
-.B MAXRECIPIENTS
-overrides the value in this control file.
+maxrecipients is the number of RCPT TO:'s \fBqmail-inject\fR will accept.
+Default: 0 which means no restriction. The environment variable
+\fBMAXRECIPIENTS\fR overrides the value in this control file.
 
 .TP 5
 .I domainqueue
 Specific queue can be assigned to recipient domains. The format of this
 file is of the form
 
-domain:QUEUEDIR=queue_dir
+.EX
+  domain:QUEUEDIR=queue_dir
+.EE
 
 where domain is the recipient domain and queue_dir is any queue which is
 part of indimail's queue collection. You could also specify a set of queues
@@ -340,14 +223,20 @@ for a domain.
 domain:QUEUE_COUNT=5,QUEUE_START=6,QUEUE_BASE=/var/indimail/queue
 
 specifies that any emails to *@domain be queued in
-/var/indimail/queue/queue[6,7,8,9,10]. You can use \fIdomainqueue\fR to
+HOME/queue/queue[6,7,8,9,10]. You can use \fIdomainqueue\fR to
 queue mails for certain domains into specific domains and specify
 individual concurrencies for these queues (see qmail-send(8)). e.g. having
 
-yahoo.com:QUEUEDIR=/var/indimail/queue/queue6
+.EX
+  yahoo.com:QUEUEDIR=HOME/queue/queue6
+.EE
+
 in @controldir@/domainqueue and
 
-10
+.EX
+  10
+.EE
+
 in @controldir@/concurrencyr.queue6
 
 will set 10 as the remote concurrency for all emails sent to yahoo.com
@@ -357,14 +246,15 @@ will set 10 as the remote concurrency for all emails sent to yahoo.com
 Specific environment variables can be set for specific senders. The format
 of this file is of the form
 
-pat:envar1=val,envar2=val,...]
+.EX
+  pat:envar1=val,envar2=val,...]
+.EE
 
 where pat is a regular expression which matches a sender. envar1, envar2
 are list of environment variables to be set.
 
 The name of the control file can be overriden by the environment variable
-FROMRULES. The following environment variables used by
-.B qmail-queue
+FROMRULES. The following environment variables used by \fBqmail-queue\fR
 can be set by using envrules.
 
 .IR SCANCMD ,

--- a/indimail-mta-x/qmail-multi.9
+++ b/indimail-mta-x/qmail-multi.9
@@ -10,20 +10,20 @@ qmail-multi \- queue multiplexor and filter
 .SH DESCRIPTION
 \fBqmail-multi(8)\fR is a queue multiplexor and filter for
 \fBqmail-queue(8)\fR. The multiplexor can be turned on by defining
-environment variable \fBQMAILQUEUE\fR=PREFIX/sbin/qmail-multi. Following
+environment variable \fBQMAILQUEUE\fR=@prefix@/sbin/qmail-multi. Following
 programs use \fBqmail-multi\fR to deposit the mail to the queue - 
 \fBqmail-dkim(8)\fR, \fBqmail-qfilter(1)\fR, \fBqmail-spamfilter(8)\fR,
 \fBqscanq-stdin(8)\fR.
 
 \fBqmail-multi\fR invokes \fBqmail-queue\fR to deposit the mail. One can
 call any other program by passing command line arguments. If passed
-arguments, \fBqmail-queue\fR will call \fIqqf\fR and any arguments after
+arguments, \fBqmail-multi\fR will call \fIqqf\fR and any arguments after
 \fIqqf\fR will be passed as arguments to \fIqqf\fR. Without any command
 line arguments you can change the program that \fBqmail-multi\fR calls, by
 setting the environment variable \fBQUEUEPROG\fR, to the path of any
 qmail-queue frontend. \fBQUEUEPROG\fR is typically used when you want to
 use write your own queue frontend, with the queue path available in
-\fBQUEUEDIR\fR environment variable. if \fBQUEUEDIR\fB is set
+\fBQUEUEDIR\fR environment variable. if \fBQUEUEDIR\fR is set
 \fBqmail-multi\fR execs \fBqmail-queue\fR (or program defined by
 \fBQUEUEPROG\fR without any processing or setting up any environment
 variables.
@@ -34,21 +34,21 @@ by the following environment variables.
 .TP 5
 \fBQUEUE_BASE\fR The base directory having all the indimail queues. If this
 is not defined, the control file \fIqueue_base\fR is used. This is
-typically QMAILHOME/queue.
+typically @qmaildir@/queue.
 
 .TP 5
 \fBQUEUE_START\fR This is a number which defines the first queue that
 should be used.
 
-e.g. QUEUE_START=1 implies the first queue to be QMAILHOME/queue/queue1
+e.g. QUEUE_START=1 implies the first queue to be @qmaildir@/queue/queue1
 
 .TP 5
 \fBQUEUE_COUNT\fR This defines the number of queues that should be used for
 load balancing. \fBqmail-multi\fR used a random number to select a queue in
 a multi-queue setup.
 
-e.g. QUEUE_START=1, QUEUE_COUNT=5 implies 5 queues QMAILHOME/queue/queue1,
-QMAILHOME/queue/queue2, ..., QMAILHOME/queue/queue5
+e.g. QUEUE_START=1, QUEUE_COUNT=5 implies 5 queues @qmaildir@/queue/queue1,
+@qmaildir@/queue/queue2, ..., @qmaildir@/queue/queue5
 
 .TP 5
 .B MIN_FREE
@@ -80,7 +80,7 @@ with the lowest \fIC\fR / \fIM\fR ratio.
 
 .PP
 \fBqmail-multi\fR is actually a wrapper for \fBqmail-queue\fR to manage
-multiple queues. \fIN\fR queues can be set up in QMAILHOME as queue\fI1\fR,
+multiple queues. \fIN\fR queues can be set up in @qmaildir@ as queue\fI1\fR,
 queue\fI2\fR, ... queue\fIN\fR. \fBqmail-multi\fR does load balancing
 across these \fIN\fR queues by doing exec of \fB qmail-queue\fR with
 QUEUEDIR set to the path of one of these \fIN\fR queues. Each of these
@@ -130,7 +130,7 @@ temporary error.
 
 \fBqmail-multi\fR generates a random number and divides it by QUEUE_COUNT.
 This remainder is added to QUEUE_START to arrive at which queue to use. It
-then sets the QUEUEDIR=PREFIX/sbin/qmail-queue to queue the mail.
+then sets the QUEUEDIR=@prefix@/sbin/qmail-queue to queue the mail.
 
 .SH "EXIT CODES"
 \fBqmail-multi\fR does not print diagnostics. It exits 120 if it is not
@@ -141,7 +141,7 @@ It exits 51 if it cannot allocate memory
 It exits 55 if it is not able get the free space for the queue filesystem.
 It exits 53 if the free space is below MIN_FREE value.
 It exits 60 if it cannot create pipes or dup file descriptors.
-It exits 61 if cannot change directory to QMAILHOME
+It exits 61 if cannot change directory to @qmaildir@
 It exits 68 if it cannot create temporary files to make the input seekable.
 It exits 121 if fork fails
 It exits 31 if the program/script defined by \fBFILTERARGS\fR returns 100
@@ -152,7 +152,7 @@ If the program/script defined by \fBFILTERARGS\fR exits non-zero status,
 it exits 71 and a temporary error is issued.
 It exits 88 when the filter program exits with return value of 88 and also
 passes the error message printed by the filter program on fd2 to
-\fBqmail-queue\fER
+\fBqmail-queue\fR
 It exits 123 if the filter program crashes.
 For all other cases where no errors occur, it exits 0.
 .EE

--- a/indimail-mta-x/qmail-qfilter.1
+++ b/indimail-mta-x/qmail-qfilter.1
@@ -9,6 +9,17 @@ qmail-qfilter \- front end for qmail-queue that does filtering
 .I -- filter ...
 ]
 .SH DESCRIPTION
+\fBqmail-qfilter(1)\fR allows indimail to execute message filters. It
+gets invoked by indimail programs using qmail-queue frontend when the
+\fBQMAILQUEUE\fR environment is set to \fBqmail-qfilter\fR or when passed
+as a command line argument having \fBqmail-qfilter\fR like below (which
+will have the message pass through \fBqmail-dkim\fR and
+\fBqmail-qfilter\fR).
+
+.EX
+QMAILQUEUE="@prefix@/sbin/qmail-dkim @prefix@/sbin/qmail-qfilter"
+.EE
+
 \fBqmail-qfilter\fR sends the message text through each of the filter
 commands named on the command line. Each filter is run separately, with
 standard input opened to the input email, and standard output opened to a

--- a/indimail-mta-x/qmail-queue.9
+++ b/indimail-mta-x/qmail-queue.9
@@ -22,21 +22,21 @@ by the following environment variables.
 .TP 5
 \fBQUEUE_BASE\fR The base directory having all the indimail queues. If this
 is not defined, the control file \fIqueue_base\fR is used. This is
-typically QMAILHOME/queue.
+typically @qmaildir@/queue.
 
 .TP 5
 \fBQUEUE_START\fR This is a number which defines the first queue that
 should be used.
 
-e.g. QUEUE_START=1 implies the first queue to be QMAILHOME/queue/queue1
+e.g. QUEUE_START=1 implies the first queue to be @qmaildir@/queue/queue1
 
 .TP 5
 \fBQUEUE_COUNT\fR This defines the number of queues that should be used for
 load balancing. \fBqmail-queue\fR used a random number to select a queue in
 a multi-queue setup.
 
-e.g. QUEUE_START=1, QUEUE_COUNT=5 implies 5 queues QMAILHOME/queue/queue1,
-QMAILHOME/queue/queue2, ..., QMAILHOME/queue/queue5
+e.g. QUEUE_START=1, QUEUE_COUNT=5 implies 5 queues @qmaildir@/queue/queue1,
+@qmaildir@/queue/queue2, ..., @qmaildir@/queue/queue5
 
 .TP 5
 .B MIN_FREE
@@ -416,6 +416,59 @@ When QHPSI is enabled \fBqmail-queue\fR adds the header X-QHPSI, the value
 of which is either 'infected' or 'clean' (depending on whether the mail as
 identifed as infected or not).
 
+.SH PROGRAMS USING \fBQMAILQUEUE\fR
+
+All of the below programs use the setting of \fBQMAILQUEUE\fR environment
+variables to execute \fBqmail-queue\fR. They all can either take
+\fBQMAILQUEUE\fR set to the path of a single \fBqmail-queue\fR frontend or
+as command line chain of \fBqmail-queue\fR frontend programs. If you
+specify \fBqmail-queue\fR as one of the programs in \fBQMAILQUEUE\fR, the
+chain will stop at \fBqmail-queue\fR. Any programs listed after
+\fBqmail-queue\fR will not get executed. So it is important not to have
+\fBqmail-queue\fR in the list.
+
+\fBcondredirect\fR(1),
+\fBdot-forward\fR(1),
+\fBfastforward\fR(1),
+\fBfilterto\fR(1),
+\fBforward\fR(1),
+\fBmaildirserial\fR(1),
+\fBmini-smtpd\fR(8),
+\fBnew-inject\fR(1),
+\fBofmipd\fR(8),
+\fBqmail-inject\fR(8),
+\fBsendmail\fR(8),
+\fBqmail-local\fR(8),
+\fBqmail-qmqpd\fR(8),
+\fBqmail-qmtpd\fR(8),
+\fBqmail-send\fR(8),
+\fBqmta-send\fR(8),
+\fBqnotify\fR(1),
+\fBqreceipt\fR(1),
+\fBreplier\fR(1),
+\fBrrforward\fR(1),
+\fBrrt\fR(1),
+\fBslowq-send\fR(8),
+\fBqmail-smtpd\fR(8),
+\fBsrsfilter\fR(1),
+\fBqmail-spamfilter\fR(8),
+\fBqmail-multi\fR(8),
+\fBqmail-nullqueue\fR(8),
+\fBqmail-qfilter\fR(1),
+\fBqmail-dkim\fR(8),
+\fBqscanq-stdin\fR(8)
+
+The below programs also act as a \fBqmail-queue\fR frontend. They can be
+set in \fBQMAILQUEUE\fR environment variable and will ultimately execute
+\fBqmail-queue\fR in the end as a default.
+
+\fBqmail-spamfilter\fR(8),
+\fBqmail-multi\fR(8),
+\fBqmail-nullqueue\fR(8),
+\fBqmail-qfilter\fR(1),
+\fBqmail-dkim\fR(8),
+\fBqscanq-stdin\fR(8)
+
 .SH "EXIT CODES"
 \fBqmail-queue\fR does not print diagnostics. It exits 0 if it has
 successfully queued the message. It exits between 1 and 99 if it has failed
@@ -539,11 +592,11 @@ Comments:
 
 Sample with McAfee's uvscan:
 
- :allow,QHPSI='/usr/bin/uvscan --secure',QHPSIMAXSIZE='9000000',QHPSIRC='13'
+ :allow,QHPSI='@prefix@/bin/uvscan --secure',QHPSIMAXSIZE='9000000',QHPSIRC='13'
 
 Comments:
 
- - The path of 'uvscan' is '/usr/local/bin' and can be ommitted.
+ - The path of 'uvscan' is '@prefix@/bin' and can be ommitted.
  - 'uvscan' returns with RC=13 in case a virus is found,
    therefore, QHPSIRC has to provide this value.
  - The virus scanning is omitted, if the size of the message

--- a/indimail-mta-x/qmail-spamfilter.9
+++ b/indimail-mta-x/qmail-spamfilter.9
@@ -7,13 +7,15 @@ qmail-spamfilter \- spam filter for indimail
 \fBqmail-spamfilter\fR [ \fIqqf\fR] \fIarg1\fR] [\fIarg2\fR] ... ]
 
 .SH DESCRIPTION
-\fBqmail-spamfilter(8)\fR allows indimail to execute antispam filter. It
+\fBqmail-spamfilter\fR(1) allows indimail to execute antispam filter. It
 gets invoked by indimail programs using qmail-queue frontend when the
-\fBQMAILQUEUE\fR environment is defined or when passed as a command line
-argument to the qmail-queue frontend.
+\fBQMAILQUEUE\fR environment is set to \fBqmail-spamfilter\fR or when
+passed as a command line argument having \fBqmail-spamfilter\fR like below
+(which will have the message pass through \fBqmail-dkim\fR and
+\fBqmail-spamfilter\fR).
 
 .EX
-QMAILQUEUE=PREFIX/sbin/qmail-spamfilter
+QMAILQUEUE="@prefix@/sbin/qmail-dkim @prefix@/sbin/qmail-spamfilter"
 .EE
 
 \fBqmail-spamfilter\fR also calls \fBqscanq\fR(8) to perform virus scanning
@@ -40,10 +42,9 @@ filter program
 This gives the ability for the SPAMFILTER program to read the mail message
 from descriptor 0 before passing it to \fBqmail-queue\fR through the pipe.
 
-\fBqmail-spamfilter\fR will attempt to make the descriptor 0 seekable if
-the environment variable \fBMAKE_SEEKABLE\fR is defined. This may be
-necessary for certain filter programs like bogofilter which allocate memory
-for the mail message when lseek(2) fails.
+\fBqmail-spamfilter\fR will attempt to make the descriptor 0 seekable. This
+may be necessary for certain filter programs like bogofilter which allocate
+memory for the mail message when lseek(2) fails..
 
 \fBqmail-spamfilter\fR by default, interprets the exit status of spam
 filter program as below

--- a/indimail-mta-x/qscanq-stdin.8
+++ b/indimail-mta-x/qscanq-stdin.8
@@ -10,7 +10,7 @@ qscanq-stdin \- qmail virus scanner
 on stdin is seekable, extracts its MIME components to the current
 directory, and runs the virus / bad attachment scanner on them.
 
-Like \fBqscanq\fR and \fB qmail-queue\fR \fBqscanq-stdin\fR needs no
+Like \fBqscanq\fR and \fB qmail-queue\fR, \fBqscanq-stdin\fR needs no
 arguments. If arguments are supplied, they are used as the command to run
 instead of \fBqmail-queue\fR.  In this way, further qmail-queue
 wrappers--such as spam filters--can be chained with \fBqscanq\fR.

--- a/indimail-mta-x/qscanq.9
+++ b/indimail-mta-x/qscanq.9
@@ -1,3 +1,4 @@
+.\" vim: tw=75
 .TH qscanq 8
 .SH NAME
 qscanq \- qmail virus scanner
@@ -11,87 +12,65 @@ qscanq \- qmail virus scanner
 ]
 
 .SH DESCRIPTION
-.B qscanq
-replaces
-\fBqmail-multi\fR / \fBqmail-queue\fR.  It initiates a scan on an incoming email,
-and returns the exit status of the scanner or of \fBqmail-multi\fR / \fBqmail-queue\fR to the caller.
+\fBqscanq\fR(8) allows indimail to initiate a scan on an incoming mail. It
+gets invoked by indimail programs using qmail-queue frontend when the
+\fBQMAILQUEUE\fR environment is set to \fBqscanq\fR or when passed as a
+command line argument having \fBqscanq\fR like below (which will have the
+message pass through \fBqmail-dkim\fR and \fBqmail-qfilter\fR).
 
-.B qscanq
-needs no arguments. It may be called with optional arguments, which will then be treated as a
-program to be called instead of
-.BR qmail-multi .
-The arguments will be passed on to
-.BR qscanq-stdin ,
-which actually calls
-.B qmail-multi
-or
-.BR qmail-queue ,
-if no arguments are given.
+.EX
+QMAILQUEUE="@prefix@/sbin/qmail-dkim @prefix@/sbin/qscanq"
+.EE
 
-.B qscanq
-runs setuid to the
-.I qscand
-user. When invoked, it changes to the spool directory and creates a working directory based on a
-timestamp, the PID, and a counter, with the sticky bit set. It then changes to that directory and
-invokes
-.B qscanq-stdin.
-The spool directory is defined during compile time by the file
-.BR conf-scandir .
-This can be overriden at run time by the environment variable
-.BR SCANDIR.
+\fBqscanq\fR(8) initiates a scan on an incoming email, and returns the exit
+status of the scanner or of \fBqmail-queue\fR to the caller.
 
-After 
-.B qscanq-stdin
-returns, 
-.B qscanq
-unsets the sticky bit on its working directory, invokes
-.B run-cleanq
-and then returns the exit status of
-.B qscanq-stdin
-without waiting for
-.B run-cleanq
-to return.
-.B qscanq
-generates no output. The return codes are interpreted by the caller, which in
-turn generates any user output.
+\fBqscanq\fR needs no arguments. It may be called with optional arguments,
+which will then be treated as a program to be called instead of
+\fBqmail-queue\fR. The arguments will be passed on to \fBqscanq-stdin\fR,
+which actually calls \fBqmail-queue\fR, if no arguments are given.
+
+\fBqscanq\fR runs setuid to the \fIqscand\fR user. When invoked, it changes
+to the spool directory and creates a working directory based on a
+timestamp, the PID, and a counter, with the sticky bit set. It then changes
+to that directory and invokes \fBqscanq-stdin\fR. The spool directory is
+defined during compile time by the file \fBconf-scandir\fR. This can be
+overriden at run time by the environment variable \fBSCANDIR\fR.
+
+After \fBqscanq-stdin\fR returns, \fBqscanq\fR unsets the sticky bit on its
+working directory, invokes \fBrun-cleanq\fR and then returns the exit
+status of \fBqscanq-stdin\fR without waiting for \fBrun-cleanq\fR to
+return. \fBqscanq\fR generates no output. The return codes are interpreted
+by the caller, which in turn generates any user output.
 
 .SH Environment Variables
 
-.B qscanq
-sets no environment variables. It does pass its environment to
-.BR qscanq-stdin ,
-which in turn passes them to 
-.B qmail-multi
-(or \fIprog\fR, if supplied instead). This means that any qmail-queue wrapper called by
-.B qscanq
-must be able to handle its environment safely.
+\fBqscanq\fR sets no environment variables. It does pass its environment to
+\fBqscanq-stdin\fR, which in turn passes them to \fBqmail-queue\fR (or
+\fIprog\fR, if supplied instead). This means that any qmail-queue wrapper
+called by \fBqscanq\fR must be able to handle its environment safely.
 
 If the DEBUG environment variable is set to any value whatsoever, then
-.B qscanq
-will print diagnostic messages to stderr whenever an error occurs. This is for use in debugging a
-new configuration, and should never be used to capture "extra log information" during runtime.
+\fBqscanq\fR will print diagnostic messages to stderr whenever an error
+occurs. This is for use in debugging a new configuration, and should never
+be used to capture "extra log information" during runtime.
 
 The default scanner to be called is set during compilation in conf-scancmd. This can
 be overriden at run time by the environment variable SCANCMD. See qscanq-stdin(8)
 
 .SH Return Codes
 
-.B qscanq
-can return any code returned by
-.BR qmail-queue .
-In addition, it returns 71 (temporary refusal) if any runtime error occurs. The caller may also
-receive exit status 31 from
-.BR qscanq-stdin ,
-which is called by
-.BR qscanq .
+\fBqscanq\fR can return any code returned by \fBqmail-queue\fR. In
+addition, it returns 71 (temporary refusal) if any runtime error occurs.
+The caller may also receive exit status 31 from \fBqscanq-stdin\fR, which
+is called by \fBqscanq\fR.
 
 .SH NOTES
 
-In a default install, the
-.B clamscan
-configuration file will be found at @sysconfdir@/clamav.conf.
-Edit the file and follow the contained instructions, making sure that the following entries are set
-in their appropriate places:
+In a default install, the \fBclamscan\fR configuration file will be found
+at @sysconfdir@/clamav.conf. Edit the file and follow the contained
+instructions, making sure that the following entries are set in their
+appropriate places:
 
  * LogFile stderr
  * StreamSaveToDisk
@@ -100,24 +79,22 @@ in their appropriate places:
  * FixStaleSocket
 
 The FixStaleSocket setting is intended to address a problem with
-.BR clamdscan :
+\fBclamdscan\fR :
 
-if the daemon crashes,
-it can leave a stale communications socket lying around. When launched, it detects this socket and
-refuses to start. When this happens, email will be deferred because scanning will fail; if it is
-not corrected in time, messages will start to bounce. The startup script supplied below also checks
-for this condition.
+if the daemon crashes,it can leave a stale communications socket lying
+around. When launched, it detects this socket and refuses to start. When
+this happens, email will be deferred because scanning will fail; if it is
+not corrected in time, messages will start to bounce. The startup script
+supplied below also checks for this condition.
 
-Make sure you are running
-.B freshclam
-in order to get the latest virus definitions in a timely way.
+Make sure you are running \fBfreshclam\fR in order to get the latest virus
+definitions in a timely way.
 
-It is recommended that
-.B clamd
-be run as a daemontools service. If clamav was installed in the default manner, there should be a
-.I qscand
-user. You should not proceed until that user exists. Stop right now and install qscanq, or
-at least create the necessary users, and then come back to this step.
+It is recommended that \fBclamd\fR be run as a \fBsupervise\fR(8) service.
+If clamav was installed in the default manner, there should be a
+\fIqscand\fR user. You should not proceed until that user exists. Stop
+right now and install qscanq, or at least create the necessary users, and
+then come back to this step.
 
 That should be it. This daemon will be running as qscand, and will be logging to
 @logdir@/clamd.


### PR DESCRIPTION
1. do_scan.c, generic.c, getqueue.c, mailfilter.c, qhpsi.c, qmail-qmqpc.c: replace hard-coded exit values with constants from qmail.h
2. qmulti.c: unset env variables queue_env, QUEUEPROG to prevent recursion
3. qmulti.c: refactored code to handle qmail-queue consistently