### PR TITLE
bug - error in regexp treated as match

### DIFF
--- a/indimail-mta-x/doc/ChangeLog
+++ b/indimail-mta-x/doc/ChangeLog
@@ -24,6 +24,10 @@ Release 3.0.6-1.1 Start 25/10/2023 End XX/XX/XXXX
 - 27/10/2023
 15. indimail-mta.spec, Makefile, ETC: added backup.conf for svctool backups
 16. svctool: skip comments in backup.conf file
+- 29/10/2023
+17. filterit_sub.c, qmail-queue.c, smtpd.c, qregex.c, bug - error in regexp
+    treated as match
+18. test-indimail-mta: added test case to test invalid regex expression
 
 * Tue Oct 17 2023 18:34:04 +0000 Manvendra Bhangui <indimail-mta@indimail.org> 3.0.5-1.1%{?dist}
 Release 3.0.5-1.1 Start 11/09/2023 End 17/10/2023

--- a/indimail-mta-x/filterit_sub.c
+++ b/indimail-mta-x/filterit_sub.c
@@ -1,5 +1,5 @@
 /*
- * $Id: filterit_sub.c,v 1.4 2023-10-01 02:11:00+05:30 Cprogrammer Exp mbhangui $
+ * $Id: filterit_sub.c,v 1.5 2023-10-29 17:12:48+05:30 Cprogrammer Exp mbhangui $
  */
 #include <ctype.h>
 #include <unistd.h>
@@ -615,7 +615,8 @@ filterit_sub1(int argc, char **argv)
 		break;
 	case 5: /*- RegExp */
 		for (ptr = matched_header.s + tmp.len; isspace(*ptr); ptr++, tmp.len++);
-		match = matchregex(matched_header.s + tmp.len, keyword, 0);
+		if ((match = matchregex(matched_header.s + tmp.len, keyword, 0)) == -1)
+			break;
 		if (negate)
 			match = !match;
 		if (match)
@@ -652,6 +653,9 @@ getversion_filterit_c()
 
 /*
  * $Log: filterit_sub.c,v $
+ * Revision 1.5  2023-10-29 17:12:48+05:30  Cprogrammer
+ * bug - error in regexp treated as match
+ *
  * Revision 1.4  2023-10-01 02:11:00+05:30  Cprogrammer
  * removed setting of QQEH for X-FilterIT header
  *

--- a/indimail-mta-x/qmail-queue.9
+++ b/indimail-mta-x/qmail-queue.9
@@ -209,8 +209,8 @@ where \fItype\fR is \fBF\fR or \fBT\fR. If \fItype\fR is \fBF\fR, rule
 is appled on the sender. If \fItype\fR is \fBT\fR, the rule is applied on
 the recipient. \fItype\fR can be omitted to match all recipients (but not
 senders). \fIregexp\fR is an expression to match the address (sender or
-recipient as specfied by \fItype\fR) and \fIdest_mailbox\fR is a valid
-email address. \fIregexp\fR can be omitted to match any address. Remember
+recipient as specfied by \fItype\fR). \fIdest_mailbox\fR is a valid email
+address. \fIregexp\fR can be omitted to match any address. Remember
 that \fIregexp\fR is a real regular expression and not filename glob
 pattern as used by functions like \fBfnmatch\fR(3). Typically
 \fB.*@yourdomain\fR (and not \fB*@yourdomain\fR) is what you intend when
@@ -226,7 +226,7 @@ replaced as below
 .EE
 
 As stated above, the address used for matching \fIregexp\fR is the sender
-in case type is \fBF\fR. For bounces, you can use \fB<>\fR to match a null
+when type is \fBF\fR. For bounces, you can use \fB<>\fR to match a null
 sender. e.g.
 
 .EX
@@ -238,8 +238,8 @@ When a rule matches a sender or any one of the recipients, the
 recipient list. When a rule matches multiple recipients, only one email
 address will be added to recipient list to avoid duplicates.
 
-The below will make a copy all mails for domain \fIyourdomain\fR to
-\fIarchyourdomain\fR (for all senders - practically each and every mail).
+The below will make a copy all mails for domain \fIdomain\fR to
+arch\fIdomain\fR (for all recipients - practically each and every mail).
 
 .EX
   ::%u@arch%d
@@ -259,6 +259,8 @@ result of \fIregexp\fR match.
 .EX
   F:!.*@yourdomain:incoming@yourdomain
 .EE
+
+NOTE: Invalid \fIregexp\fR are silently discarded.
 
 .TP
 \fBoriginipfield\fR

--- a/indimail-mta-x/qmail-queue.c
+++ b/indimail-mta-x/qmail-queue.c
@@ -1,5 +1,5 @@
 /*
- * $Id: qmail-queue.c,v 1.88 2023-10-24 20:07:31+05:30 Cprogrammer Exp mbhangui $
+ * $Id: qmail-queue.c,v 1.89 2023-10-29 17:13:32+05:30 Cprogrammer Exp mbhangui $
  */
 #include <sys/types.h>
 #include <sys/stat.h>
@@ -584,10 +584,10 @@ set_archive(char *eaddr)
 			addr_ptr = 0;
 		else {
 			if (negate) {
-				if (!matchregex(addr, addr_ptr, &errStr))
+				if (matchregex(addr, addr_ptr, &errStr) == 0)
 					addr_ptr = 0;
 			} else {
-				if (matchregex(addr, addr_ptr, &errStr))
+				if (matchregex(addr, addr_ptr, &errStr) == 1)
 					addr_ptr = 0;
 			}
 		}
@@ -636,7 +636,7 @@ set_archive(char *eaddr)
 				}
 				ptr += (str_len(ptr) + 1);
 			}
-			if (!found && !stralloc_cat(&arch_email, &tmpe))
+			if (!found && !stralloc_cat(&arch_email, &tmpe)) /*- append if not duplicate */
 				return (1);
 		} else
 			*(dest - 1) = ':';
@@ -1188,7 +1188,7 @@ main()
 void
 getversion_qmail_queue_c()
 {
-	static char    *x = "$Id: qmail-queue.c,v 1.88 2023-10-24 20:07:31+05:30 Cprogrammer Exp mbhangui $";
+	static char    *x = "$Id: qmail-queue.c,v 1.89 2023-10-29 17:13:32+05:30 Cprogrammer Exp mbhangui $";
 
 	x = sccsidmakeargsh;
 	x++;
@@ -1196,6 +1196,9 @@ getversion_qmail_queue_c()
 #endif
 /*
  * $Log: qmail-queue.c,v $
+ * Revision 1.89  2023-10-29 17:13:32+05:30  Cprogrammer
+ * bug - error in regexp treated as match
+ *
  * Revision 1.88  2023-10-24 20:07:31+05:30  Cprogrammer
  * added feature to negate regexp match
  *

--- a/indimail-mta-x/qregex.c
+++ b/indimail-mta-x/qregex.c
@@ -1,11 +1,11 @@
 /*
- * $Id: qregex.c,v 1.34 2023-10-24 20:08:02+05:30 Cprogrammer Exp mbhangui $
+ * $Id: qregex.c,v 1.35 2023-10-29 17:13:39+05:30 Cprogrammer Exp mbhangui $
  *
  * qregex (v2)
  * Author  : Evan Borgstrom (evan at unixpimps dot org)
  * Created : 2001/12/14 23:08:16
- * Modified: $Date: 2023-10-24 20:08:02+05:30 $
- * Revision: $Revision: 1.34 $
+ * Modified: $Date: 2023-10-29 17:13:39+05:30 $
+ * Revision: $Revision: 1.35 $
  *
  * Do POSIX regex matching on addresses for anti-relay / spam control.
  * It logs to the maillog
@@ -223,11 +223,12 @@ regex_match(stralloc *addr, stralloc *map, char **errStr)
 				return (AM_MEMORY_ERR);
 			if (!stralloc_0(&curregex))
 				return (AM_MEMORY_ERR);
-			if ((k = matchregex(addr->s, curregex.s, errStr)) == 1) {
-				if (negate)
-					return (0);
+			if ((k = matchregex(addr->s, curregex.s, errStr)) == -1)
+				return AM_REGEX_ERR;
+			if (negate)
+				k = !k;
+			if (k)
 				match = 1;
-			}
 			j = i + 1;
 			negate = 0;
 		}
@@ -238,7 +239,7 @@ regex_match(stralloc *addr, stralloc *map, char **errStr)
 void
 getversion_qregex_c()
 {
-	static char    *x = "$Id: qregex.c,v 1.34 2023-10-24 20:08:02+05:30 Cprogrammer Exp mbhangui $";
+	static char    *x = "$Id: qregex.c,v 1.35 2023-10-29 17:13:39+05:30 Cprogrammer Exp mbhangui $";
 
 	x = sccsidwildmath;
 	x++;
@@ -246,6 +247,9 @@ getversion_qregex_c()
 
 /*
  * $Log: qregex.c,v $
+ * Revision 1.35  2023-10-29 17:13:39+05:30  Cprogrammer
+ * bug - error in regexp treated as match
+ *
  * Revision 1.34  2023-10-24 20:08:02+05:30  Cprogrammer
  * use matchregex.h from /usr/include/qmail
  *

--- a/indimail-mta-x/smtpd.c
+++ b/indimail-mta-x/smtpd.c
@@ -1,6 +1,6 @@
 /*
  * RCS log at bottom
- * $Id: smtpd.c,v 1.307 2023-10-24 20:08:07+05:30 Cprogrammer Exp mbhangui $
+ * $Id: smtpd.c,v 1.308 2023-10-29 17:13:43+05:30 Cprogrammer Exp mbhangui $
  */
 #include <unistd.h>
 #include <fcntl.h>
@@ -155,7 +155,7 @@ static SSL     *ssl = NULL;
 static struct strerr *se;
 #endif
 static int      tr_success = 0;
-static char    *revision = "$Revision: 1.307 $";
+static char    *revision = "$Revision: 1.308 $";
 static char    *protocol = "SMTP";
 static stralloc proto = { 0 };
 static stralloc Revision = { 0 };
@@ -2339,10 +2339,11 @@ badhostcheck()
 		if (!stralloc_copyb(&curregex, brh.s + j, (i - j)) ||
 				!stralloc_0(&curregex))
 			die_nomem();
-		x = matchregex(remotehost, curregex.s, NULL);
-		if ((negate) && (x == 0))
-			return 1;
-		if (!(negate) && (x > 0))
+		if ((x = matchregex(remotehost, curregex.s, NULL)) == -1)
+			die_regex();
+		if (negate)
+			x = !x;
+		if (x)
 			return 1;
 		j = i + 1;
 		negate = 0;
@@ -7190,6 +7191,9 @@ addrrelay()
 
 /*
  * $Log: smtpd.c,v $
+ * Revision 1.308  2023-10-29 17:13:43+05:30  Cprogrammer
+ * bug - error in regexp treated as match
+ *
  * Revision 1.307  2023-10-24 20:08:07+05:30  Cprogrammer
  * use matchregex.h from /usr/include/qmail
  *
@@ -7568,7 +7572,7 @@ addrrelay()
 char           *
 getversion_smtpd_c()
 {
-	static char    *x = "$Id: smtpd.c,v 1.307 2023-10-24 20:08:07+05:30 Cprogrammer Exp mbhangui $";
+	static char    *x = "$Id: smtpd.c,v 1.308 2023-10-29 17:13:43+05:30 Cprogrammer Exp mbhangui $";
 
 	x++;
 	return revision + 11;

--- a/indimail-mta-x/tests/test-indimail-mta
+++ b/indimail-mta-x/tests/test-indimail-mta
@@ -5026,27 +5026,9 @@ test_spf()
 
 test_qmail_queue()
 {
+	# sender rule
 	t1=$(date +"%s.%4N")
-	echo "F:!.*@$HOSTNAME:$incarchive@$HOSTNAME" > $cntrldir/mailarchive
-	do_qmail_inject $user@$vdomain $user@$HOSTNAME "Test Mail Archival" "Test Message for Mail Archival"
-	check_mail $testdir/$incarchive/Maildir
-	if [ $? -eq 0 ] ; then
-		t2=$(date +"%s.%4N")
-		secs=$(echo $t1 $t2 $sleep_secs | awk '{printf("%0.4f\n", $2-$1-$3)}')
-		tcount=$(expr $tcount + 1)
-		printf "\r  testing incoming mail archival with sender based rule succeeded %38s [%.4f sec]\n" " " $secs
-		print_pct
-	else
-		t2=$(date +"%s.%4N")
-		secs=$(echo $t1 $t2 $sleep_secs | awk '{printf("%0.4f\n", $2-$1-$3)}')
-		printf "\r%118s\n" " "
-		echo "  testing incoming mail archival with sender based rule failed [$secs sec]"
-		failed=1
-		exit 1
-	fi
-
-	t1=$(date +"%s.%4N")
-	echo "F:.*@$HOSTNAME:$outarchive@$HOSTNAME" > $cntrldir/mailarchive
+	echo "F:.*@$HOSTNAME$:$outarchive@$HOSTNAME" > $cntrldir/mailarchive
 	do_qmail_inject $user@$HOSTNAME $user@$HOSTNAME "Test outgoing Mail Archival" "Test Message to test outgoing Mail Archival"
 	check_mail $testdir/$outarchive/Maildir
 	if [ $? -eq 0 ] ; then
@@ -5064,8 +5046,29 @@ test_qmail_queue()
 		exit 1
 	fi
 
+	# sender negative rule
 	t1=$(date +"%s.%4N")
-	echo "T:.*@$HOSTNAME:$incarchive@$HOSTNAME" > $cntrldir/mailarchive
+	echo "F:!.*@$HOSTNAME$:$incarchive@$HOSTNAME" > $cntrldir/mailarchive
+	do_qmail_inject $user@$vdomain $user@$HOSTNAME "Test Mail Archival" "Test Message for Mail Archival"
+	check_mail $testdir/$incarchive/Maildir
+	if [ $? -eq 0 ] ; then
+		t2=$(date +"%s.%4N")
+		secs=$(echo $t1 $t2 $sleep_secs | awk '{printf("%0.4f\n", $2-$1-$3)}')
+		tcount=$(expr $tcount + 1)
+		printf "\r  testing incoming mail archival with sender based rule succeeded %38s [%.4f sec]\n" " " $secs
+		print_pct
+	else
+		t2=$(date +"%s.%4N")
+		secs=$(echo $t1 $t2 $sleep_secs | awk '{printf("%0.4f\n", $2-$1-$3)}')
+		printf "\r%118s\n" " "
+		echo "  testing incoming mail archival with sender based rule failed [$secs sec]"
+		failed=1
+		exit 1
+	fi
+
+	# recipient rule
+	t1=$(date +"%s.%4N")
+	echo "T:.*@$HOSTNAME$:$incarchive@$HOSTNAME" > $cntrldir/mailarchive
 	do_qmail_inject $user@$vdomain $user@$HOSTNAME "Test incoming Mail Archival" "Test Message to test incoming Mail Archival"
 	check_mail $testdir/$incarchive/Maildir
 	if [ $? -eq 0 ] ; then
@@ -5083,9 +5086,10 @@ test_qmail_queue()
 		exit 1
 	fi
 
+	# receipient negative rule
 	t1=$(date +"%s.%4N")
 	virtual_setup 1
-	echo "T:!.*@$HOSTNAME:$outarchive@$HOSTNAME" > $cntrldir/mailarchive
+	echo "T:!.*@$HOSTNAME$:$outarchive@$HOSTNAME" > $cntrldir/mailarchive
 	do_qmail_inject $user@$HOSTNAME $user@$vdomain "Testing outgoing Mail Archival" "Test Message to test outgoing Mail Archival"
 	check_mail $testdir/$outarchive/Maildir
 	if [ $? -eq 0 ] ; then
@@ -5106,6 +5110,27 @@ test_qmail_queue()
 	virtual_setup 0
 	/bin/rm -f $cntrldir/mailarchive
 
+	# invalid regex in mailarchive
+	t1=$(date +"%s.%4N")
+	echo "T:*@$vdomain$:$incarchive@$HOSTNAME" > $cntrldir/mailarchive
+	do_qmail_inject $user@$vdomain $user@$HOSTNAME "Test incoming Mail Archival" "Test Message to test incoming Mail Archival"
+	check_mail $testdir/$incarchive/Maildir 2>/dev/null
+	if [ $? -ne 0 ] ; then
+		t2=$(date +"%s.%4N")
+		secs=$(echo $t1 $t2 $sleep_secs | awk '{printf("%0.4f\n", $2-$1-$3)}')
+		tcount=$(expr $tcount + 1)
+		printf "\r  testing mail archival with invalid recipient based rule succeeded %36s [%.4f sec]\n" " " $secs
+		print_pct
+	else
+		t2=$(date +"%s.%4N")
+		secs=$(echo $t1 $t2 $sleep_secs | awk '{printf("%0.4f\n", $2-$1-$3)}')
+		printf "\r%118s\n" " "
+		echo "  testing mail archival with invalid recipient based rule failed [$secs sec]"
+		failed=1
+		exit 1
+	fi
+
+	# test extra queue
 	t1=$(date +"%s.%4N")
 	(
 	echo "$incarchive"
@@ -5135,6 +5160,7 @@ test_qmail_queue()
 	fi
 	/bin/rm -f $cntrldir/extraqueue
 
+	# test logheader
 	t1=$(date +"%s.%4N")
 	echo "X-Log-Test" > $cntrldir/logheaders
 	exec 45>/tmp/logheaderfd
@@ -5170,6 +5196,7 @@ test_qmail_queue()
 		ret1=1
 	fi
 
+	# test removeheaders
 	t1=$(date +"%s.%4N")
 	(
 	echo "X-Remove-Header1"
@@ -6705,7 +6732,7 @@ fi
 if [ -f $testdir/qtotal.count ] ; then
 	total_tests=$(cat $testdir/qtotal.count)
 else
-	total_tests=247
+	total_tests=248
 fi
 failed=0
 do_setup

--- a/indimail-mta-x/tests/test-indimail-mta
+++ b/indimail-mta-x/tests/test-indimail-mta
@@ -1,6 +1,6 @@
 #!/bin/sh
 #
-# $Id: test-indimail-mta,v 1.40 2023-10-28 20:46:14+05:30 Cprogrammer Exp mbhangui $
+# $Id: test-indimail-mta,v 1.41 2023-10-29 18:28:20+05:30 Cprogrammer Exp mbhangui $
 #
 start=$(date +'%s')
 user=$(whoami)
@@ -6793,6 +6793,9 @@ exit 0
 
 #
 # $Log: test-indimail-mta,v $
+# Revision 1.41  2023-10-29 18:28:20+05:30  Cprogrammer
+# added test case to test invalid regex expression
+#
 # Revision 1.40  2023-10-28 20:46:14+05:30  Cprogrammer
 # added qmail-multi test
 #


### PR DESCRIPTION
In few programs when matchregex() returns -1, it is being treated as a match. 