### PR TITLE
use do_match wrapper

### DIFF
--- a/indimail-mta-x/Makefile
+++ b/indimail-mta-x/Makefile
@@ -1065,10 +1065,10 @@ qlx.h
 
 qmail-inject: load qmail-inject.o headerbody.o hfield.o \
 newfield.o quote.o control.o qmail.o envrules.o wildmat.o \
-srs.o rcpthosts.o auto_control.o parse_env.o \
+srs.o rcpthosts.o auto_control.o parse_env.o do_match.o \
 variables.o set_environment.o auto_qmail.o auto_prefix.o srs.lib
 	./load qmail-inject headerbody.o hfield.o newfield.o \
-	quote.o control.o qmail.o envrules.o \
+	quote.o control.o qmail.o envrules.o do_match.o \
 	wildmat.o srs.o rcpthosts.o auto_control.o variables.o \
 	auto_qmail.o auto_prefix.o parse_env.o \
 	set_environment.o $(static_option) $(QMAILLIB) \
@@ -1089,8 +1089,12 @@ hassrs.h set_environment.h conf-srs
 
 envrules.o: \
 compile envrules.c envrules.h control.h \
-qregex.h wildmat.h parse_env.h
+wildmat.h parse_env.h
 	./compile envrules.c
+
+do_match.o: \
+compile do_match.c do_match.h wildmat.h
+	./compile do_match.c
 
 parse_env.o: \
 compile parse_env.c parse_env.h
@@ -1362,11 +1366,11 @@ compile mailfilter.c mailfilter.h qmulti.h qmail.h
 spawn-filter: \
 load spawn-filter.o variables.o report.o auto_qmail.o \
 auto_prefix.o control.o wildmat.o qregex.o parse_env.o \
-auto_control.o envrules.o getDomainToken.o \
+auto_control.o envrules.o getDomainToken.o do_match.o \
 socket.lib dns.lib
 	./load spawn-filter variables.o report.o auto_qmail.o \
 	auto_prefix.o control.o wildmat.o qregex.o auto_control.o \
-	getDomainToken.o envrules.o parse_env.o \
+	getDomainToken.o envrules.o parse_env.o do_match.o \
 	$(static_option) $(QMAILLIB) $(dynamic_option) \
 	`cat dns.lib socket.lib` -lm
 
@@ -1425,13 +1429,13 @@ qmail-direct.9 conf-sysconfdir
 
 qmail-queue: \
 load qmail-queue.o triggerpull.o fmtqfn.o get_uid.o auto_split.o \
-auto_uids.o variables.o auto_prefix.o auto_qmail.o \
+auto_uids.o variables.o auto_prefix.o auto_qmail.o do_match.o \
 control.o auto_control.o strsalloc.o custom_error.o getqueue.o \
-syncdir.o socket.lib rt.lib
+syncdir.o wildmat.o socket.lib rt.lib
 	./load qmail-queue triggerpull.o fmtqfn.o get_uid.o auto_split.o \
-	auto_uids.o auto_prefix.o variables.o auto_qmail.o \
+	auto_uids.o auto_prefix.o variables.o auto_qmail.o do_match.o \
 	control.o auto_control.o strsalloc.o custom_error.o getqueue.o \
-	syncdir.o $(static_option) $(QMAILLIB) $(dynamic_option) \
+	syncdir.o wildmat.o $(static_option) $(QMAILLIB) $(dynamic_option) \
 	`cat socket.lib rt.lib`
 
 qmail-queue.8: \
@@ -1446,7 +1450,7 @@ qmail-queue-clients.9 conf-prefix
 	> qmail-queue-clients.7
 
 qmail-queue.o: \
-compile qmail-queue.c triggerpull.h \
+compile qmail-queue.c triggerpull.h do_match.h \
 control.h auto_uids.h fmtqfn.h variables.h qmail.h \
 qscheduler.h syncdir.h haslibrt.h auto_prefix.h \
 auto_split.h conf-sync conf-qhpsi conf-ip conf-mailarch
@@ -1598,14 +1602,14 @@ varargs.h dossl.h hastlsa.h auto_control.h conf-tls
 
 qmail-send: \
 load qmail-send.o qsutil.o control.o newfield.o prioq.o parse_env.o \
-trigger.o fmtqfn.o quote.o readsubdir.o qmail.o \
+trigger.o fmtqfn.o quote.o readsubdir.o qmail.o do_match.o \
 auto_qmail.o srs.o rcpthosts.o auto_control.o auto_split.o \
 variables.o getDomainToken.o do_rate.o envrules.o qregex.o wildmat.o \
 auto_prefix.o delivery_rate.o syncdir.o srs.lib rt.lib
 	./load qmail-send qsutil.o control.o newfield.o \
 	prioq.o trigger.o fmtqfn.o quote.o readsubdir.o \
 	getDomainToken.o do_rate.o wildmat.o qmail.o auto_qmail.o \
-	auto_split.o variables.o envrules.o srs.o \
+	auto_split.o variables.o envrules.o srs.o do_match.o \
 	delivery_rate.o rcpthosts.o auto_control.o auto_prefix.o \
 	syncdir.o parse_env.o $(static_option) \
 	-L../libsrs2-x/libsrs2/.libs `cat srs.lib` $(QMAILLIB) \
@@ -1659,7 +1663,7 @@ compile set_queuedir.c set_queuedir.h auto_qmail.h control.h
 
 slowq-send: \
 load slowq-send.o qsutil.o control.o newfield.o prioq.o \
-trigger.o fmtqfn.o quote.o readsubdir.o qmail.o \
+trigger.o fmtqfn.o quote.o readsubdir.o qmail.o do_match.o \
 auto_qmail.o srs.o rcpthosts.o auto_control.o auto_split.o \
 variables.o envrules.o parse_env.o qregex.o wildmat.o \
 getDomainToken.o do_rate.o delivery_rate.o auto_prefix.o \
@@ -1667,7 +1671,7 @@ syncdir.o srs.lib
 	./load slowq-send qsutil.o control.o newfield.o \
 	prioq.o trigger.o fmtqfn.o quote.o readsubdir.o \
 	do_rate.o wildmat.o qmail.o auto_qmail.o auto_split.o \
-	variables.o envrules.o parse_env.o srs.o \
+	variables.o envrules.o parse_env.o srs.o do_match.o \
 	rcpthosts.o delivery_rate.o auto_control.o getDomainToken.o \
 	auto_prefix.o syncdir.o \
 	$(static_option) -L../libsrs2-x/libsrs2/.libs \
@@ -1844,7 +1848,7 @@ qmail_smtpd.so: \
 smtpd.o rcpthosts.o recipients.o indimail_stub.o ip.o ipme.o \
 ipalloc.o strsalloc.o control.o etrn.o atrn.o received.o \
 wildmat.o qmail.o variables.o envrules.o auto_qmail.o \
-bodycheck.o sqlmatch.o qcount_dir.o mail_acl.o \
+bodycheck.o sqlmatch.o qcount_dir.o mail_acl.o do_match.o \
 socket_ip4loopback.o socket_v6loopback.o socket_v4mappedprefix.o \
 socket_v6any.o spf.o dns.o auto_uids.o qregex_sql.o srs.o \
 tablematch.o greylist.o query_skt.o fn_handler.o load_mysql.o \
@@ -1857,7 +1861,7 @@ gsasl.lib mysql_config
 		qcount_dir.o ip.o ipme.o ipalloc.o strsalloc.o control.o \
 		etrn.o atrn.o received.o wildmat.o qmail.o auto_qmail.o \
 		variables.o envrules.o bodycheck.o spf.o dns.o srs.o \
-		sqlmatch.o socket_v4mappedprefix.o parse_env.o \
+		sqlmatch.o socket_v4mappedprefix.o parse_env.o do_match.o \
 		socket_ip4loopback.o socket_v6loopback.o socket_v6any.o \
 		mail_acl.o auto_uids.o qregex_sql.o tablematch.o greylist.o \
 		auto_break.o auto_control.o auto_assign.o query_skt.o fn_handler.o \
@@ -1870,7 +1874,7 @@ gsasl.lib mysql_config
 		smtpd.o rcpthosts.o recipients.o auto_control.o auto_assign.o \
 		qcount_dir.o ip.o ipme.o ipalloc.o strsalloc.o control.o etrn.o atrn.o \
 		received.o wildmat.o qmail.o variables.o envrules.o parse_env.o srs.o \
-		bodycheck.o spf.o dns.o sqlmatch.o auto_qmail.o \
+		bodycheck.o spf.o dns.o sqlmatch.o auto_qmail.o do_match.o \
 		socket_v4mappedprefix.o socket_ip4loopback.o socket_v6loopback.o \
 		socket_v6any.o mail_acl.o auto_uids.o qregex_sql.o tablematch.o \
 		greylist.o auto_break.o indimail_stub.o load_mysql.o query_skt.o \
@@ -1884,7 +1888,7 @@ qmail-smtpd: \
 load qmail-smtpd.o smtpd.o rcpthosts.o recipients.o parse_env.o \
 ip.o ipme.o ipalloc.o strsalloc.o control.o etrn.o atrn.o \
 received.o wildmat.o qmail.o variables.o auto_control.o \
-envrules.o bodycheck.o sqlmatch.o indimail_stub.o \
+envrules.o bodycheck.o sqlmatch.o indimail_stub.o do_match.o \
 socket_ip4loopback.o socket_v6loopback.o socket_v4mappedprefix.o \
 socket_v6any.o mail_acl.o spf.o dns.o auto_uids.o auto_qmail.o \
 qregex_sql.o tablematch.o greylist.o auto_assign.o qcount_dir.o \
@@ -1895,7 +1899,7 @@ tls.lib gsasl.lib srs.lib mysql_config conf-sql
 	ip.o ipme.o ipalloc.o strsalloc.o control.o etrn.o atrn.o \
 	qcount_dir.o received.o wildmat.o qmail.o variables.o \
 	envrules.o bodycheck.o spf.o dns.o sqlmatch.o auto_qmail.o \
-	socket_v4mappedprefix.o socket_ip4loopback.o \
+	socket_v4mappedprefix.o socket_ip4loopback.o do_match.o \
 	socket_v6loopback.o socket_v6any.o mail_acl.o auto_uids.o \
 	indimail_stub.o qregex_sql.o tablematch.o greylist.o auto_break.o \
 	auto_control.o auto_assign.o query_skt.o fn_handler.o \
@@ -3473,9 +3477,9 @@ batv.o: compile batv.c conf-batv batv.h
 
 uacl: \
 load uacl.o mail_acl.o wildmat.o control.o \
-variables.o qregex.o auto_control.o
+variables.o qregex.o do_match.o auto_control.o
 	./load uacl mail_acl.o wildmat.o control.o \
-	variables.o qregex.o auto_control.o $(QMAILLIB)
+	variables.o qregex.o do_match.o auto_control.o $(QMAILLIB)
 
 uacl.o: \
 compile uacl.c qregex.h mail_acl.h control.h \

--- a/indimail-mta-x/TARGETS
+++ b/indimail-mta-x/TARGETS
@@ -695,3 +695,4 @@ filterit
 filterit.o
 filterit_sub.o
 backup.conf
+do_match.o

--- a/indimail-mta-x/do_match.c
+++ b/indimail-mta-x/do_match.c
@@ -1,0 +1,46 @@
+/*
+ * $Id: $
+ */
+
+#include <matchregex.h>
+#include <env.h>
+#include "do_match.h"
+#include "wildmat.h"
+#include <fnmatch.h>
+
+int
+do_match(int use_regex, char *text, char *regex, char **errStr)
+{
+	int             i;
+
+	if (errStr)
+		*errStr = 0;
+	if (use_regex)
+		return (matchregex(text, regex, errStr));
+	else
+	if (env_get("USE_FNMATCH")) {
+#ifdef FNM_CASEFOLD
+		i = FNM_PATHNAME|FNM_CASEFOLD;
+#else
+		i = FNM_PATHNAME;
+#endif
+		switch(fnmatch(regex, text, i))
+		{
+		case 0:
+			return (1);
+		case FNM_NOMATCH:
+			return (0);
+		default:
+			return (AM_REGEX_ERR);
+		}
+	} else
+		return (wildmat_internal(text, regex));
+}
+
+void
+getversion_do_match_c()
+{
+	static char    *x = "$Id: $";
+	x = sccsidwildmath;
+	x++;
+}

--- a/indimail-mta-x/do_match.h
+++ b/indimail-mta-x/do_match.h
@@ -1,0 +1,8 @@
+/*
+ * $Id: $
+ */
+#ifndef _DO_MATCH_H
+#define _DO_MATCH_H
+
+int             do_match(int, char *, char *, char **);
+#endif

--- a/indimail-mta-x/doc/ChangeLog
+++ b/indimail-mta-x/doc/ChangeLog
@@ -29,6 +29,8 @@ Release 3.0.6-1.1 Start 25/10/2023 End XX/XX/XXXX
     treated as match
 18. test-indimail-mta: added test case to test invalid regex expression
 19. envrules.c, mail_acl.c, do_match.c: moved do_match to do_match.c
+20. use QREGEX to use regexp, else wildmat for control files accelist,
+    mailarchive (qmail-smtpd, qmail-queue)
 
 * Tue Oct 17 2023 18:34:04 +0000 Manvendra Bhangui <indimail-mta@indimail.org> 3.0.5-1.1%{?dist}
 Release 3.0.5-1.1 Start 11/09/2023 End 17/10/2023

--- a/indimail-mta-x/doc/ChangeLog
+++ b/indimail-mta-x/doc/ChangeLog
@@ -28,6 +28,7 @@ Release 3.0.6-1.1 Start 25/10/2023 End XX/XX/XXXX
 17. filterit_sub.c, qmail-queue.c, smtpd.c, qregex.c, bug - error in regexp
     treated as match
 18. test-indimail-mta: added test case to test invalid regex expression
+19. envrules.c, mail_acl.c, do_match.c: moved do_match to do_match.c
 
 * Tue Oct 17 2023 18:34:04 +0000 Manvendra Bhangui <indimail-mta@indimail.org> 3.0.5-1.1%{?dist}
 Release 3.0.5-1.1 Start 11/09/2023 End 17/10/2023

--- a/indimail-mta-x/envrules.c
+++ b/indimail-mta-x/envrules.c
@@ -1,5 +1,8 @@
 /*
  * $Log: envrules.c,v $
+ * Revision 1.22  2023-10-30 01:21:28+05:30  Cprogrammer
+ * use QREGEX to use regular expressions, else use wildmat
+ *
  * Revision 1.21  2023-01-13 12:09:25+05:30  Cprogrammer
  * moved parse_env function to parse_env.c
  *
@@ -160,7 +163,7 @@ domainqueue(char *email, char *domainqueue_f, char *domainqueue, char **errStr)
 void
 getversion_envrules_c()
 {
-	static char    *x = "$Id: envrules.c,v 1.21 2023-01-13 12:09:25+05:30 Cprogrammer Exp mbhangui $";
+	static char    *x = "$Id: envrules.c,v 1.22 2023-10-30 01:21:28+05:30 Cprogrammer Exp mbhangui $";
 
 	x++;
 }

--- a/indimail-mta-x/envrules.c
+++ b/indimail-mta-x/envrules.c
@@ -65,8 +65,6 @@
  * Initial revision
  *
  */
-#include <ctype.h>
-#include <fnmatch.h>
 #include <error.h>
 #include <stralloc.h>
 #include <env.h>
@@ -74,38 +72,7 @@
 #include "parse_env.h"
 #include "control.h"
 #include "envrules.h"
-#include "qregex.h"
-#include "matchregex.h"
-#include "wildmat.h"
-
-int
-do_match(int use_regex, char *text, char *regex, char **errStr)
-{
-	int             i;
-
-	if (errStr)
-		*errStr = 0;
-	if (use_regex)
-		return (matchregex(text, regex, errStr));
-	else
-	if (env_get("USE_FNMATCH")) {
-#ifdef FNM_CASEFOLD
-		i = FNM_PATHNAME|FNM_CASEFOLD;
-#else
-		i = FNM_PATHNAME;
-#endif
-		switch(fnmatch(regex, text, i))
-		{
-		case 0:
-			return (1);
-		case FNM_NOMATCH:
-			return (0);
-		default:
-			return (AM_REGEX_ERR);
-		}
-	} else
-		return (wildmat_internal(text, regex));
-}
+#include "do_match.h"
 
 int
 envrules(char *email, char *envrules_f, char *rulesfile, char **errStr)
@@ -195,6 +162,5 @@ getversion_envrules_c()
 {
 	static char    *x = "$Id: envrules.c,v 1.21 2023-01-13 12:09:25+05:30 Cprogrammer Exp mbhangui $";
 
-	x = sccsidwildmath;
 	x++;
 }

--- a/indimail-mta-x/mail_acl.c
+++ b/indimail-mta-x/mail_acl.c
@@ -1,5 +1,8 @@
 /*
  * $Log: mail_acl.c,v $
+ * Revision 1.8  2023-10-30 01:21:58+05:30  Cprogrammer
+ * use QREGEX to use regular expressions, else use wildmat
+ *
  * Revision 1.7  2023-10-24 20:06:40+05:30  Cprogrammer
  * use matchregex.h from /usr/include/qmail
  *
@@ -222,7 +225,7 @@ mail_acl(stralloc *acclist, int qregex, char *sender, char *recipient, char verb
 void
 getversion_mail_acl_c()
 {
-	static char    *x = "$Id: mail_acl.c,v 1.7 2023-10-24 20:06:40+05:30 Cprogrammer Exp mbhangui $";
+	static char    *x = "$Id: mail_acl.c,v 1.8 2023-10-30 01:21:58+05:30 Cprogrammer Exp mbhangui $";
 
 	x++;
 }

--- a/indimail-mta-x/mail_acl.c
+++ b/indimail-mta-x/mail_acl.c
@@ -27,8 +27,7 @@
 #include <str.h>
 #include <stralloc.h>
 #include <fmt.h>
-#include <matchregex.h>
-#include "wildmat.h"
+#include "do_match.h"
 #include "varargs.h"
 
 extern void     die_regex(char *);
@@ -42,7 +41,8 @@ extern void     flush();
 int
 mail_acl(stralloc *acclist, int qregex, char *sender, char *recipient, char verb)
 {
-	int             err, len, count, from_reject, rcpt_reject, rcpt_found, from_found;
+	int             err, len, count, from_reject, rcpt_reject, rcpt_found,
+					from_found;
 	char           *ptr, *cptr, *rcpt_match, *from_match, *err_str;
 	char            count_buf[FMT_ULONG];
 
@@ -90,17 +90,11 @@ mail_acl(stralloc *acclist, int qregex, char *sender, char *recipient, char verb
 			rcpt_found = 1;
 			rcpt_match = cptr + 1;
 		} else {
-			if (qregex) {
-				if ((err = matchregex(recipient, cptr + 1, &err_str)) < 0) {
-					*cptr = 0;
-					return (err);
-				} else
-				if (err == 1) {
-					rcpt_found = 1;
-					rcpt_match = cptr + 1;
-				}
+			if ((err = do_match(qregex, recipient, cptr + 1, &err_str)) < 0) {
+				*cptr = 0;
+				return (err);
 			} else
-			if (wildmat_internal(recipient, cptr + 1)) {
+			if (err == 1) {
 				rcpt_found = 1;
 				rcpt_match = cptr + 1;
 			}
@@ -129,16 +123,12 @@ mail_acl(stralloc *acclist, int qregex, char *sender, char *recipient, char verb
 		if (!str_diff(sender, ptr + 5)) /*- sender */
 			from_match = ptr + 5;
 		else {
-			if (qregex) {
-				if ((err = matchregex(sender, ptr + 5, &err_str)) < 0) {
-					*cptr = ':';
-					if (verb)
-						die_regex(err_str);
-					return (err);
-				} else
-					from_match = ptr + 5;
+			if ((err = do_match(qregex, sender, ptr + 5, &err_str)) < 0) {
+				*cptr = ':';
+				if (verb)
+					die_regex(err_str);
+				return (err);
 			} else
-			if (wildmat_internal(sender, ptr + 5))
 				from_match = ptr + 5;
 		}
 		if (rcpt_reject) {
@@ -171,18 +161,12 @@ mail_acl(stralloc *acclist, int qregex, char *sender, char *recipient, char verb
 			from_found = 1;
 			from_match = ptr + 5;
 		} else {
-			if (qregex) {
-				if ((err = matchregex(sender, ptr + 5, &err_str)) < 0) {
-					*cptr = ':';
-					if (verb)
-						die_regex(err_str);
-					return (err);
-				} else {
-					from_found = 1;
-					from_match = ptr + 5;
-				}
-			} else
-			if (wildmat_internal(sender, ptr + 5)) {
+			if ((err = do_match(qregex, sender, ptr + 5, &err_str)) < 0) {
+				*cptr = ':';
+				if (verb)
+					die_regex(err_str);
+				return (err);
+			} else {
 				from_found = 1;
 				from_match = ptr + 5;
 			}
@@ -211,16 +195,12 @@ mail_acl(stralloc *acclist, int qregex, char *sender, char *recipient, char verb
 		if (!str_diff(recipient, cptr + 1)) /*- recipient */
 			rcpt_match = cptr + 1;
 		else {
-			if (qregex) {
-				if ((err = matchregex(recipient, cptr + 1, &err_str)) < 0) {
-					*cptr = ':';
-					if (verb)
-						die_regex(err_str);
-					return (err);
-				} else
-					rcpt_match = cptr + 1;
+			if ((err = do_match(qregex, recipient, cptr + 1, &err_str)) < 0) {
+				*cptr = ':';
+				if (verb)
+					die_regex(err_str);
+				return (err);
 			} else
-			if (wildmat_internal(recipient, cptr + 1))
 				rcpt_match = cptr + 1;
 		}
 		if (from_reject) {
@@ -244,6 +224,5 @@ getversion_mail_acl_c()
 {
 	static char    *x = "$Id: mail_acl.c,v 1.7 2023-10-24 20:06:40+05:30 Cprogrammer Exp mbhangui $";
 
-	x = sccsidwildmath;
 	x++;
 }

--- a/indimail-mta-x/qmail-queue.9
+++ b/indimail-mta-x/qmail-queue.9
@@ -210,11 +210,9 @@ is appled on the sender. If \fItype\fR is \fBT\fR, the rule is applied on
 the recipient. \fItype\fR can be omitted to match all recipients (but not
 senders). \fIregexp\fR is an expression to match the address (sender or
 recipient as specfied by \fItype\fR). \fIdest_mailbox\fR is a valid email
-address. \fIregexp\fR can be omitted to match any address. Remember
-that \fIregexp\fR is a real regular expression and not filename glob
-pattern as used by functions like \fBfnmatch\fR(3). Typically
-\fB.*@yourdomain\fR (and not \fB*@yourdomain\fR) is what you intend when
-you want to use it to match all addresses from \fIyourdomain\fR.
+address. \fIregexp\fR can be omitted to match any address. You can set
+QREGEX environment variable if you want to use actual regex patterns. If
+\fBQREGEX\fR is not set, filename global pattern will be used for match.
 \fIregexp\fR can be preceded by a \fB!\fR sign to negate the expression. A
 \fB%\fR in \fIdest_mailbox\fR followed by \fBu\fR, \fBd\fR or \fBe\fR gets
 replaced as below

--- a/indimail-mta-x/qmail-queue.c
+++ b/indimail-mta-x/qmail-queue.c
@@ -34,7 +34,7 @@
 #include <makeargs.h>
 #include <getEnvConfig.h>
 #include <noreturn.h>
-#include <matchregex.h>
+#include "do_match.h"
 #include "control.h"
 #include "variables.h"
 #include "fmtqfn.h"
@@ -542,7 +542,7 @@ int
 set_archive(char *eaddr)
 {
 	char           *rule_ptr, *dest, *ptr, *errStr = 0, *addr, *addr_ptr;
-	int             len, at, type, found, negate = 0;
+	int             len, at, type, found, negate = 0, use_regex = 0;
 	static stralloc tmpe = {0};
 
 	/*
@@ -553,6 +553,8 @@ set_archive(char *eaddr)
 	 */
 	addr = eaddr + 1;
 	type = *eaddr;
+	if (env_get("QREGEX"))
+		use_regex = 1;
 	for (rule_ptr = ar_rules.s, len = 0;len < ar_rules.len;len++) {
 		if (((*rule_ptr == ':' || *rule_ptr == '*') && type == 'F')
 			|| ((*rule_ptr == 'F' || *rule_ptr == 'T') && *rule_ptr != type)) {
@@ -584,10 +586,10 @@ set_archive(char *eaddr)
 			addr_ptr = 0;
 		else {
 			if (negate) {
-				if (matchregex(addr, addr_ptr, &errStr) == 0)
+				if (do_match(use_regex, addr, addr_ptr, &errStr) == 0)
 					addr_ptr = 0;
 			} else {
-				if (matchregex(addr, addr_ptr, &errStr) == 1)
+				if (do_match(use_regex, addr, addr_ptr, &errStr) == 1)
 					addr_ptr = 0;
 			}
 		}

--- a/indimail-mta-x/qmail-queue.c
+++ b/indimail-mta-x/qmail-queue.c
@@ -1,5 +1,5 @@
 /*
- * $Id: qmail-queue.c,v 1.89 2023-10-29 17:13:32+05:30 Cprogrammer Exp mbhangui $
+ * $Id: qmail-queue.c,v 1.90 2023-10-30 01:22:25+05:30 Cprogrammer Exp mbhangui $
  */
 #include <sys/types.h>
 #include <sys/stat.h>
@@ -1190,7 +1190,7 @@ main()
 void
 getversion_qmail_queue_c()
 {
-	static char    *x = "$Id: qmail-queue.c,v 1.89 2023-10-29 17:13:32+05:30 Cprogrammer Exp mbhangui $";
+	static char    *x = "$Id: qmail-queue.c,v 1.90 2023-10-30 01:22:25+05:30 Cprogrammer Exp mbhangui $";
 
 	x = sccsidmakeargsh;
 	x++;
@@ -1198,6 +1198,9 @@ getversion_qmail_queue_c()
 #endif
 /*
  * $Log: qmail-queue.c,v $
+ * Revision 1.90  2023-10-30 01:22:25+05:30  Cprogrammer
+ * use QREGEX to use regular expressions, else use wildmat
+ *
  * Revision 1.89  2023-10-29 17:13:32+05:30  Cprogrammer
  * bug - error in regexp treated as match
  *

--- a/indimail-mta-x/tests/test-indimail-mta
+++ b/indimail-mta-x/tests/test-indimail-mta
@@ -5032,7 +5032,7 @@ test_qmail_queue()
 		if [ $1 -eq 0 ] ; then
 		printf "\r  testing outgoing mail archival with sender based wildmat rule succeeded %30s [%.4f sec]\n" " " $secs
 		else
-		printf "\r  testing outgoing mail archival with sender based QREGEX rule succeeded %31s [%.4f sec]\n" " " $secs
+		printf "\r  testing outgoing mail archival with sender based REGEXP rule succeeded %31s [%.4f sec]\n" " " $secs
 		fi
 		print_pct
 	else
@@ -5042,7 +5042,7 @@ test_qmail_queue()
 		if [ $1 -eq 0 ] ; then
 		echo "  testing outgoing mail archival with sender based wildmat rule failed [$secs sec]"
 		else
-		echo "  testing outgoing mail archival with sender based QREGEX rule failed [$secs sec]"
+		echo "  testing outgoing mail archival with sender based REGEXP rule failed [$secs sec]"
 		fi
 		failed=1
 		exit 1
@@ -5064,7 +5064,7 @@ test_qmail_queue()
 		if [ $1 -eq 0 ] ; then
 		printf "\r  testing incoming mail archival with sender based wildmat rule succeeded %30s [%.4f sec]\n" " " $secs
 		else
-		printf "\r  testing incoming mail archival with sender based QREGEX rule succeeded %31s [%.4f sec]\n" " " $secs
+		printf "\r  testing incoming mail archival with sender based REGEXP rule succeeded %31s [%.4f sec]\n" " " $secs
 		fi
 		print_pct
 	else
@@ -5074,7 +5074,7 @@ test_qmail_queue()
 		if [ $1 -eq 0 ] ; then
 		echo "  testing incoming mail archival with sender based wildmat rule failed [$secs sec]"
 		else
-		echo "  testing incoming mail archival with sender based QREGEX rule failed [$secs sec]"
+		echo "  testing incoming mail archival with sender based REGEXP rule failed [$secs sec]"
 		fi
 		failed=1
 		exit 1
@@ -5106,7 +5106,7 @@ test_qmail_queue()
 		if [ $1 -eq 0 ] ; then
 		echo "  testing incoming mail archival with recipient based wildmat rule failed [$secs sec]"
 		else
-		echo "  testing incoming mail archival with recipient based QREGEX rule failed [$secs sec]"
+		echo "  testing incoming mail archival with recipient based REGEXP rule failed [$secs sec]"
 		fi
 		failed=1
 		exit 1
@@ -5129,7 +5129,7 @@ test_qmail_queue()
 		if [ $1 -eq 0 ] ; then
 		printf "\r  testing outgoing mail archival with recipient based wildmat rule succeeded %27s [%.4f sec]\n" " " $secs
 		else
-		printf "\r  testing outgoing mail archival with recipient based QREGEX rule succeeded %28s [%.4f sec]\n" " " $secs
+		printf "\r  testing outgoing mail archival with recipient based REGEXP rule succeeded %28s [%.4f sec]\n" " " $secs
 		fi
 		print_pct
 	else
@@ -5139,7 +5139,7 @@ test_qmail_queue()
 		if [ $1 -eq 0 ] ; then
 		echo "  testing outgoing mail archival with recipient based wilmat rule failed [$secs sec]"
 		else
-		echo "  testing outgoing mail archival with recipient based QREGEX rule failed [$secs sec]"
+		echo "  testing outgoing mail archival with recipient based REGEXP rule failed [$secs sec]"
 		fi
 		failed=1
 		virtual_setup 0

--- a/indimail-mta-x/tests/test-indimail-mta
+++ b/indimail-mta-x/tests/test-indimail-mta
@@ -1,6 +1,6 @@
 #!/bin/sh
 #
-# $Id: test-indimail-mta,v 1.41 2023-10-29 18:28:20+05:30 Cprogrammer Exp mbhangui $
+# $Id: test-indimail-mta,v 1.42 2023-10-30 01:27:19+05:30 Cprogrammer Exp mbhangui $
 #
 start=$(date +'%s')
 user=$(whoami)
@@ -119,6 +119,7 @@ do_cleanup_failed()
 	sudo /bin/rm -rf $qmaildir/alias/virtual/new/* $qmaildir/alias/virtual/cur/*
 	sudo /bin/rm -rf $sysconfdir/users
 	sudo /bin/rm -rf $cntrldir/mailarch
+	sudo /bin/rm -rf $testdir/variables
 }
 
 check_mail_count()
@@ -711,18 +712,6 @@ do_qmail_inject()
 	# $2 : To
 	# $3 : Subject
 	# $4 : Body
-	# $5 : QMAILQUEUE
-	# $6 : FILTERARGS
-	if [ $# -gt 4 ] ; then
-		qq=$5
-	else
-		qq=$qmail_queue
-	fi
-	if [ $# -eq 6 ] ; then
-		ff=$6
-	else
-		ff=""
-	fi
 	(
 	echo "From: $1"
 	echo "To: $2"
@@ -734,26 +723,7 @@ do_qmail_inject()
 	echo
 	echo "$4"
 	) > $testdir/tmp/mail.txt
-	if [ -n "$ff" ] ; then
-		env - \
-			LOGHEADERFD=45 \
-			QUEUEDIR=$testdir/queue \
-			QMAILQUEUE=$qq \
-			CONTROLDIR=$cntrldir \
-			BIGTODO=0 \
-			CONFSPLIT=23 \
-			FILTERARGS="$ff" \
-		$qmail_inject -f$1 $2 <$testdir/tmp/mail.txt
-	else
-		env - \
-			LOGHEADERFD=45 \
-			QUEUEDIR=$testdir/queue \
-			QMAILQUEUE=$qq \
-			CONTROLDIR=$cntrldir \
-			BIGTODO=0 \
-			CONFSPLIT=23 \
-		$qmail_inject -f$1 $2 <$testdir/tmp/mail.txt
-	fi
+	envdir -c $testdir/variables $qmail_inject -f$1 $2 <$testdir/tmp/mail.txt
 	/bin/rm -f $testdir/tmp/mail.txt
 }
 
@@ -4308,7 +4278,13 @@ test_spawn_filter()
 test_qmail_multi()
 {
 	t1=$(date +"%s.%4N")
-	do_qmail_inject $user@$HOSTNAME $user@$HOSTNAME "Test qmail-multi" "Test Message for qmail-multi" $qmail_multi
+	mkdir -p $testdir/variables
+	echo $testdir/queue > $testdir/variables/QUEUEDIR
+	echo $cntrldir      > $testdir/variables/CONTROLDIR
+	echo 0              > $testdir/variables/BIGTODO
+	echo 23             > $testdir/variables/CONFSPLIT
+	echo $qmail_multi   > $testdir/variables/QMAILQUEUE
+	do_qmail_inject $user@$HOSTNAME $user@$HOSTNAME "Test qmail-multi" "Test Message for qmail-multi"
 	check_mail
 	if [ $? -eq 0 ] ; then
 		t2=$(date +"%s.%4N")
@@ -4331,7 +4307,9 @@ test_qmail_multi()
 	echo "sed -e 's{I am a{I am not a{'"
 	) > $testdir/bin/filter
 	chmod +x $testdir/bin/filter
-	do_qmail_inject $user@$HOSTNAME $user@$HOSTNAME "Test qmail-multi" "I am a fool" $qmail_multi $testdir/bin/filter
+	echo $qmail_multi        > $testdir/variables/QMAILQUEUE
+	echo $testdir/bin/filter > $testdir/variables/FILTERARGS
+	do_qmail_inject $user@$HOSTNAME $user@$HOSTNAME "Test qmail-multi" "I am a fool"
 	check_mail $maildir 1
 	if [ -n "$mail_file" ] ; then
 		body=$($e822body < $maildir/new/$mail_file)
@@ -4354,6 +4332,7 @@ test_qmail_multi()
 		exit 1
 	fi
 	/bin/rm -f $testdir/bin/filter
+	/bin/rm -rf $testdir/variables
 }
 
 do_without_svscan()
@@ -4405,7 +4384,8 @@ do_without_svscan()
 	test_spamfilter
 	test_qhpsi
 	test_qqeh
-	test_qmail_queue
+	test_qmail_queue 0
+	test_qmail_queue 1
 	test_qmail_multi
 
 	srs_setup 1
@@ -5028,60 +5008,106 @@ test_qmail_queue()
 {
 	# sender rule
 	t1=$(date +"%s.%4N")
+	if [ $1 -eq 0 ] ; then
+	echo "F:*@$HOSTNAME:$outarchive@$HOSTNAME" > $cntrldir/mailarchive
+	else
 	echo "F:.*@$HOSTNAME$:$outarchive@$HOSTNAME" > $cntrldir/mailarchive
+	fi
+	mkdir -p $testdir/variables
+	echo $testdir/queue > $testdir/variables/QUEUEDIR
+	echo $cntrldir      > $testdir/variables/CONTROLDIR
+	echo 0              > $testdir/variables/BIGTODO
+	echo 23             > $testdir/variables/CONFSPLIT
+	if [ $1 -eq 0 ] ; then
+	                    > $testdir/variables/QREGEX
+	else
+	echo 1              > $testdir/variables/QREGEX
+	fi
 	do_qmail_inject $user@$HOSTNAME $user@$HOSTNAME "Test outgoing Mail Archival" "Test Message to test outgoing Mail Archival"
 	check_mail $testdir/$outarchive/Maildir
 	if [ $? -eq 0 ] ; then
 		t2=$(date +"%s.%4N")
 		secs=$(echo $t1 $t2 $sleep_secs | awk '{printf("%0.4f\n", $2-$1-$3)}')
 		tcount=$(expr $tcount + 1)
-		printf "\r  testing outgoing mail archival with sender based rule succeeded %38s [%.4f sec]\n" " " $secs
+		if [ $1 -eq 0 ] ; then
+		printf "\r  testing outgoing mail archival with sender based wildmat rule succeeded %30s [%.4f sec]\n" " " $secs
+		else
+		printf "\r  testing outgoing mail archival with sender based QREGEX rule succeeded %31s [%.4f sec]\n" " " $secs
+		fi
 		print_pct
 	else
 		t2=$(date +"%s.%4N")
 		secs=$(echo $t1 $t2 $sleep_secs | awk '{printf("%0.4f\n", $2-$1-$3)}')
 		printf "\r%118s\n" " "
-		echo "  testing outgoing mail archival with sender based rule failed [$secs sec]"
+		if [ $1 -eq 0 ] ; then
+		echo "  testing outgoing mail archival with sender based wildmat rule failed [$secs sec]"
+		else
+		echo "  testing outgoing mail archival with sender based QREGEX rule failed [$secs sec]"
+		fi
 		failed=1
 		exit 1
 	fi
 
 	# sender negative rule
 	t1=$(date +"%s.%4N")
+	if [ $1 -eq 0 ] ; then
+	echo "F:!*@$HOSTNAME:$incarchive@$HOSTNAME" > $cntrldir/mailarchive
+	else
 	echo "F:!.*@$HOSTNAME$:$incarchive@$HOSTNAME" > $cntrldir/mailarchive
+	fi
 	do_qmail_inject $user@$vdomain $user@$HOSTNAME "Test Mail Archival" "Test Message for Mail Archival"
 	check_mail $testdir/$incarchive/Maildir
 	if [ $? -eq 0 ] ; then
 		t2=$(date +"%s.%4N")
 		secs=$(echo $t1 $t2 $sleep_secs | awk '{printf("%0.4f\n", $2-$1-$3)}')
 		tcount=$(expr $tcount + 1)
-		printf "\r  testing incoming mail archival with sender based rule succeeded %38s [%.4f sec]\n" " " $secs
+		if [ $1 -eq 0 ] ; then
+		printf "\r  testing incoming mail archival with sender based wildmat rule succeeded %30s [%.4f sec]\n" " " $secs
+		else
+		printf "\r  testing incoming mail archival with sender based QREGEX rule succeeded %31s [%.4f sec]\n" " " $secs
+		fi
 		print_pct
 	else
 		t2=$(date +"%s.%4N")
 		secs=$(echo $t1 $t2 $sleep_secs | awk '{printf("%0.4f\n", $2-$1-$3)}')
 		printf "\r%118s\n" " "
-		echo "  testing incoming mail archival with sender based rule failed [$secs sec]"
+		if [ $1 -eq 0 ] ; then
+		echo "  testing incoming mail archival with sender based wildmat rule failed [$secs sec]"
+		else
+		echo "  testing incoming mail archival with sender based QREGEX rule failed [$secs sec]"
+		fi
 		failed=1
 		exit 1
 	fi
 
 	# recipient rule
 	t1=$(date +"%s.%4N")
+	if [ $1 -eq 0 ] ; then
+	echo "T:*@$HOSTNAME:$incarchive@$HOSTNAME" > $cntrldir/mailarchive
+	else
 	echo "T:.*@$HOSTNAME$:$incarchive@$HOSTNAME" > $cntrldir/mailarchive
+	fi
 	do_qmail_inject $user@$vdomain $user@$HOSTNAME "Test incoming Mail Archival" "Test Message to test incoming Mail Archival"
 	check_mail $testdir/$incarchive/Maildir
 	if [ $? -eq 0 ] ; then
 		t2=$(date +"%s.%4N")
 		secs=$(echo $t1 $t2 $sleep_secs | awk '{printf("%0.4f\n", $2-$1-$3)}')
 		tcount=$(expr $tcount + 1)
-		printf "\r  testing incoming mail archival with recipient based rule succeeded %35s [%.4f sec]\n" " " $secs
+		if [ $1 -eq 0 ] ; then
+		printf "\r  testing incoming mail archival with recipient based wildmat rule succeeded %27s [%.4f sec]\n" " " $secs
+		else
+		printf "\r  testing incoming mail archival with recipient based REGEXP rule succeeded %28s [%.4f sec]\n" " " $secs
+		fi
 		print_pct
 	else
 		t2=$(date +"%s.%4N")
 		secs=$(echo $t1 $t2 $sleep_secs | awk '{printf("%0.4f\n", $2-$1-$3)}')
 		printf "\r%118s\n" " "
-		echo "  testing incoming mail archival with recipient based rule failed [$secs sec]"
+		if [ $1 -eq 0 ] ; then
+		echo "  testing incoming mail archival with recipient based wildmat rule failed [$secs sec]"
+		else
+		echo "  testing incoming mail archival with recipient based QREGEX rule failed [$secs sec]"
+		fi
 		failed=1
 		exit 1
 	fi
@@ -5089,20 +5115,32 @@ test_qmail_queue()
 	# receipient negative rule
 	t1=$(date +"%s.%4N")
 	virtual_setup 1
+	if [ $1 -eq 0 ] ; then
+	echo "T:!*@$HOSTNAME:$outarchive@$HOSTNAME" > $cntrldir/mailarchive
+	else
 	echo "T:!.*@$HOSTNAME$:$outarchive@$HOSTNAME" > $cntrldir/mailarchive
+	fi
 	do_qmail_inject $user@$HOSTNAME $user@$vdomain "Testing outgoing Mail Archival" "Test Message to test outgoing Mail Archival"
 	check_mail $testdir/$outarchive/Maildir
 	if [ $? -eq 0 ] ; then
 		t2=$(date +"%s.%4N")
 		secs=$(echo $t1 $t2 $sleep_secs | awk '{printf("%0.4f\n", $2-$1-$3)}')
 		tcount=$(expr $tcount + 1)
-		printf "\r  testing outgoing mail archival with recipient based rule succeeded %35s [%.4f sec]\n" " " $secs
+		if [ $1 -eq 0 ] ; then
+		printf "\r  testing outgoing mail archival with recipient based wildmat rule succeeded %27s [%.4f sec]\n" " " $secs
+		else
+		printf "\r  testing outgoing mail archival with recipient based QREGEX rule succeeded %28s [%.4f sec]\n" " " $secs
+		fi
 		print_pct
 	else
 		t2=$(date +"%s.%4N")
 		secs=$(echo $t1 $t2 $sleep_secs | awk '{printf("%0.4f\n", $2-$1-$3)}')
 		printf "\r%118s\n" " "
-		echo "  testing outgoing mail archival with recipient based rule failed [$secs sec]"
+		if [ $1 -eq 0 ] ; then
+		echo "  testing outgoing mail archival with recipient based wilmat rule failed [$secs sec]"
+		else
+		echo "  testing outgoing mail archival with recipient based QREGEX rule failed [$secs sec]"
+		fi
 		failed=1
 		virtual_setup 0
 		exit 1
@@ -5110,6 +5148,9 @@ test_qmail_queue()
 	virtual_setup 0
 	/bin/rm -f $cntrldir/mailarchive
 
+	if [ $1 -eq 0 ] ; then
+		return 0
+	fi
 	# invalid regex in mailarchive
 	t1=$(date +"%s.%4N")
 	echo "T:*@$vdomain$:$incarchive@$HOSTNAME" > $cntrldir/mailarchive
@@ -5164,6 +5205,7 @@ test_qmail_queue()
 	t1=$(date +"%s.%4N")
 	echo "X-Log-Test" > $cntrldir/logheaders
 	exec 45>/tmp/logheaderfd
+	echo 45             > $testdir/variables/LOGHEADERFD
 	do_qmail_inject $user@$HOSTNAME $user@$HOSTNAME "Testing logheader" "Test Message for logheader"
 	check_mail_header $maildir X-Remove-Header1 0
 	h4=$header
@@ -5202,6 +5244,7 @@ test_qmail_queue()
 	echo "X-Remove-Header1"
 	echo "X-Remove-Header2"
 	) > $cntrldir/removeheaders
+	/bin/rm -f $testdir/variables/LOGHEADERFD
 	do_qmail_inject $user@$HOSTNAME $user@$HOSTNAME "Testing removeheaders" "Test Message for removeheaders"
 	check_mail_header $maildir X-Remove-Header1 0
 	s1=$sleep_secs
@@ -5230,6 +5273,7 @@ test_qmail_queue()
 	fi
 	check_mail
 	/bin/rm -f $cntrldir/removeheaders
+	/bin/rm -rf $testdir/variables
 }
 
 test_dkim()
@@ -6732,7 +6776,7 @@ fi
 if [ -f $testdir/qtotal.count ] ; then
 	total_tests=$(cat $testdir/qtotal.count)
 else
-	total_tests=248
+	total_tests=252
 fi
 failed=0
 do_setup
@@ -6793,6 +6837,9 @@ exit 0
 
 #
 # $Log: test-indimail-mta,v $
+# Revision 1.42  2023-10-30 01:27:19+05:30  Cprogrammer
+# added test to use wildmat instead of regexp for mailarchival
+#
 # Revision 1.41  2023-10-29 18:28:20+05:30  Cprogrammer
 # added test case to test invalid regex expression
 #


### PR DESCRIPTION
use do_match wrapper instead of calling matchregex directly. This allows one to use regular expression if QREGEX env variable is set and use wildmat_internal() if not set.