### PR TITLE
make DEATH, OSSIFIED values configurable

### DIFF
--- a/indimail-mta-x/doc/ChangeLog
+++ b/indimail-mta-x/doc/ChangeLog
@@ -135,6 +135,8 @@ o - New program printass to print entries in users/cdb, users/assign file
     qmail-nullqueue.c, qmail-queue.c, qmail-send.c, qmail-spamfilter.c,
     qmta-send.c, slowq-send.c: Made value of DEATH and OSSIFIED configurable
 76. qmail.h: Added compile time definitions for DEATH, OSSIFIED
+77. svctool: added --death argument to configure max time in secs that
+    qmail-queue can run
 
 * Tue Oct 17 2023 18:34:04 +0000 Manvendra Bhangui <indimail-mta@indimail.org> 3.0.5-1.1%{?dist}
 Release 3.0.5-1.1 Start 11/09/2023 End 17/10/2023

--- a/indimail-mta-x/doc/ChangeLog
+++ b/indimail-mta-x/doc/ChangeLog
@@ -134,6 +134,7 @@ o - New program printass to print entries in users/cdb, users/assign file
 75. qmail-clean.c, qmail-direct.c, qmail-dkim.c, qmail-multi.c,
     qmail-nullqueue.c, qmail-queue.c, qmail-send.c, qmail-spamfilter.c,
     qmta-send.c, slowq-send.c: Made value of DEATH and OSSIFIED configurable
+76. qmail.h: Added compile time definitions for DEATH, OSSIFIED
 
 * Tue Oct 17 2023 18:34:04 +0000 Manvendra Bhangui <indimail-mta@indimail.org> 3.0.5-1.1%{?dist}
 Release 3.0.5-1.1 Start 11/09/2023 End 17/10/2023

--- a/indimail-mta-x/doc/ChangeLog
+++ b/indimail-mta-x/doc/ChangeLog
@@ -130,6 +130,10 @@ o - New program printass to print entries in users/cdb, users/assign file
 73. todo-proc.c: handle qmail-clean termination
 - 24/12/2023
 74. qscheduler.c: Handle EINTR for mq_receive().
+- 25/12/2023
+75. qmail-clean.c, qmail-direct.c, qmail-dkim.c, qmail-multi.c,
+    qmail-nullqueue.c, qmail-queue.c, qmail-send.c, qmail-spamfilter.c,
+    qmta-send.c, slowq-send.c: Made value of DEATH and OSSIFIED configurable
 
 * Tue Oct 17 2023 18:34:04 +0000 Manvendra Bhangui <indimail-mta@indimail.org> 3.0.5-1.1%{?dist}
 Release 3.0.5-1.1 Start 11/09/2023 End 17/10/2023

--- a/indimail-mta-x/indimail-mta-internals.7
+++ b/indimail-mta-x/indimail-mta-internals.7
@@ -153,6 +153,18 @@ assume the worst and send the message again. The usual solutions in the
 database literature---e.g., keeping log files---amount to saying that
 it's the recipient's computer's job to discard duplicate messages.)
 
+\fBqmail-queue\fR sets an alarm of 86400 seconds to quit if it doesn't
+complete. This can be changed by setting \fBDEATH\fR environment variable.
+This should be less than 1296000 seconds or the value of \fBOSSIFIED\fR
+environment variable used by \fBqmail-clean\fR, \fBqmail-send\fR,
+\fBslowq-send\fR, \fBqmta-send\fR. These four programs delete any left over
+files that have not been accessed for more than \fBOSSIFIED\fR seconds in
+the \fIintd\fR, \fImess\fR and \fItodo\fR queue subdirectories. Any file in
+the \fIintd\fR and \fImess\fR sub directory that do not have a
+corresponding file in the \fIinfo\fR and the \fItodo\fR sub directory are
+files probably left due to a situation where \fBqmail-clean\fR didn't
+complete.
+
 
 .SH Further notes
 

--- a/indimail-mta-x/indimail-mta.spec.in
+++ b/indimail-mta-x/indimail-mta.spec.in
@@ -1,6 +1,6 @@
 #
 #
-# $Id: indimail-mta.spec.in,v 1.394 2023-12-23 00:15:40+05:30 Cprogrammer Exp mbhangui $
+# $Id: indimail-mta.spec.in,v 1.395 2023-12-24 23:54:33+05:30 Cprogrammer Exp mbhangui $
 %undefine _missing_build_ids_terminate_build
 %global _unpackaged_files_terminate_build 1
 

--- a/indimail-mta-x/qmail-clean.9
+++ b/indimail-mta-x/qmail-clean.9
@@ -33,12 +33,11 @@ directory for \fBslowq-send\fR(8).
 \fBqmail-clean\fR cleans up files in \fIpid\fR directory accessed more than
 36 hours ago. You can change the default 36 hours by setting \fBOSSIFIED\fR
 environment variable to a value in seconds. This should be greater than the
-value 86400 seconds which the time which is the maximum time
-\fBqmail-queue\fR will run if it doesn't complete. This can be changed by
-setting \fBDEATH\fR environment variable in seconds used by qmail-queue.
-Best is to not to set these variables unless you know what you are doing.
-See the man pages for \fBqmail-queue\fR(8) and indimail-mta-internals(7)
-for more details.
+value 86400 seconds which is the maximum time \fBqmail-queue\fR will run if
+it doesn't complete. This can be changed by setting \fBDEATH\fR environment
+variable in seconds used by qmail-queue.  Best is to not to set these
+variables unless you know what you are doing.  See the man pages for
+\fBqmail-queue\fR(8) and indimail-mta-internals(7) for more details.
 
 .SH "SEE ALSO"
 qmail-send(8),

--- a/indimail-mta-x/qmail-clean.9
+++ b/indimail-mta-x/qmail-clean.9
@@ -1,22 +1,48 @@
+.\" vim: tw=75
 .TH qmail-clean 8
 
 .SH NAME
 qmail-clean \- clean up the queue directory
 
 .SH SYNOPSIS
-.B qmail-clean
+\fBqmail-clean\fR
 
 .SH DESCRIPTION
 \fBqmail-clean\fR reads a cleanup command from descriptor 0, performs the
-cleanup, prints the results to descriptor 1, and repeats. \fBqmail-clean\fR
-uses the enivronment \fBCONFSPLIT\fR as the run time directory split value.
-If not set it uses the value DIRSPLIT. A value larger than DIRSPLIT for
-\fBCONFSPLIT\fR is silently ignored.
+cleanup, prints the results to descriptor 1, and repeats. The response is a
+single character 'x' for invalid cleanup command, '!' if it was not able to
+cleanup and '+' if it was successful in cleanup.
+
+\fBqmail-clean\fR uses the enivronment \fBCONFSPLIT\fR as the run time
+directory split value. If not set it uses the value DIRSPLIT. A value
+larger than DIRSPLIT for \fBCONFSPLIT\fR is silently ignored.
 
 \fBqmail-clean\fR can process a queue created with \fItodo\fR and
 \fIintd\fR with subdirectory split by setting the \fBBIGTODO\fR environment
 variable.
 
+\fBqmail-clean\fR cleans up files in \fIintd\fR and \fImess sub directory
+of the queue for \fBqmail-send\fR(8).
+
+\fBqmail-clean\fR cleans up files in \fIintd\fR and \fItodo directory for
+\fBtodo-proc\fR(8).
+
+\fBqmail-clean\fR cleans up files in \fIintd\fR, \fImess\fR and \fItodo\fR
+directory for \fBslowq-send\fR(8).
+
+\fBqmail-clean\fR cleans up files in \fIpid\fR directory accessed more than
+36 hours ago. You can change the default 36 hours by setting \fBOSSIFIED\fR
+environment variable to a value in seconds. This should be greater than the
+value 86400 seconds which the time which is the maximum time
+\fBqmail-queue\fR will run if it doesn't complete. This can be changed by
+setting \fBDEATH\fR environment variable in seconds used by qmail-queue.
+Best is to not to set these variables unless you know what you are doing.
+See the man pages for \fBqmail-queue\fR(8) and indimail-mta-internals(7)
+for more details.
+
 .SH "SEE ALSO"
-qmail-send(8)
-todo-proc(8)
+qmail-send(8),
+todo-proc(8),
+slowq-send(8),
+qmta-send(8),
+indimail-mta-internals(7)

--- a/indimail-mta-x/qmail-clean.c
+++ b/indimail-mta-x/qmail-clean.c
@@ -1,5 +1,5 @@
 /*
- * $Id: qmail-clean.c,v 1.15 2023-12-25 09:28:53+05:30 Cprogrammer Exp mbhangui $
+ * $Id: qmail-clean.c,v 1.15 2023-12-25 10:03:23+05:30 Cprogrammer Exp mbhangui $
  */
 #include <sys/types.h>
 #include <unistd.h>
@@ -16,9 +16,9 @@
 #include <scan.h>
 #include <fmt.h>
 #include <error.h>
-#include <fmtqfn.h>
 #include <env.h>
 #include <getEnvConfig.h>
+#include "fmtqfn.h"
 #include "qmail.h"
 #include "variables.h"
 #include "auto_split.h"
@@ -140,14 +140,14 @@ if (unlink(fnbuf) == -1) if (errno != error_noent) { respond("!"); continue; }
 void
 getversion_qmail_clean_c()
 {
-	static char    *x = "$Id: qmail-clean.c,v 1.15 2023-12-25 09:28:53+05:30 Cprogrammer Exp mbhangui $";
+	static char    *x = "$Id: qmail-clean.c,v 1.15 2023-12-25 10:03:23+05:30 Cprogrammer Exp mbhangui $";
 
 	x++;
 }
 
 /*
  * $Log: qmail-clean.c,v $
- * Revision 1.15  2023-12-25 09:28:53+05:30  Cprogrammer
+ * Revision 1.15  2023-12-25 10:03:23+05:30  Cprogrammer
  * made OSSIFIED configurable
  *
  * Revision 1.14  2022-01-30 08:37:53+05:30  Cprogrammer

--- a/indimail-mta-x/qmail-clean.c
+++ b/indimail-mta-x/qmail-clean.c
@@ -1,60 +1,30 @@
 /*
- * $Log: qmail-clean.c,v $
- * Revision 1.14  2022-01-30 08:37:53+05:30  Cprogrammer
- * made bigtodo configurable
- *
- * Revision 1.13  2021-06-27 10:45:02+05:30  Cprogrammer
- * moved conf_split variable to fmtqfn.c
- *
- * Revision 1.12  2021-06-14 01:03:48+05:30  Cprogrammer
- * removed chdir(auto_qmail)
- *
- * Revision 1.11  2021-05-16 00:40:21+05:30  Cprogrammer
- * use configurable conf_split instead of auto_split variable
- *
- * Revision 1.10  2020-11-24 13:46:37+05:30  Cprogrammer
- * removed exit.h
- *
- * Revision 1.9  2010-02-10 08:58:19+05:30  Cprogrammer
- * removed dependency on indimail
- *
- * Revision 1.8  2007-12-20 12:46:57+05:30  Cprogrammer
- * removed compiler warnings
- *
- * Revision 1.7  2004-10-22 20:28:12+05:30  Cprogrammer
- * added RCS id
- *
- * Revision 1.6  2004-10-22 15:36:35+05:30  Cprogrammer
- * removed readwrite.h
- *
- * Revision 1.5  2004-07-17 21:20:36+05:30  Cprogrammer
- * added RCS log
- *
+ * $Id: qmail-clean.c,v 1.15 2023-12-25 09:28:53+05:30 Cprogrammer Exp mbhangui $
  */
 #include <sys/types.h>
 #include <unistd.h>
 #include <sys/stat.h>
-#include "sig.h"
-#include "now.h"
-#include "str.h"
-#include "direntry.h"
-#include "getln.h"
-#include "stralloc.h"
-#include "substdio.h"
-#include "subfd.h"
-#include "byte.h"
-#include "scan.h"
-#include "fmt.h"
-#include "error.h"
-#include "fmtqfn.h"
-#include "env.h"
+#include <sig.h>
+#include <now.h>
+#include <str.h>
+#include <direntry.h>
+#include <getln.h>
+#include <stralloc.h>
+#include <substdio.h>
+#include <subfd.h>
+#include <byte.h>
+#include <scan.h>
+#include <fmt.h>
+#include <error.h>
+#include <fmtqfn.h>
+#include <env.h>
+#include <getEnvConfig.h>
+#include "qmail.h"
 #include "variables.h"
 #include "auto_split.h"
-#include "getEnvConfig.h"
 
-#define OSSIFIED 129600	/*- see qmail-send.c */
-
-stralloc        line = { 0 };
+static stralloc line = { 0 };
+static char     fnbuf[FMTQFN];
 
 void
 cleanuppid()
@@ -62,11 +32,11 @@ cleanuppid()
 	DIR            *dir;
 	direntry       *d;
 	struct stat     st;
-	datetime_sec    time;
+	datetime_sec    tm;
+	unsigned long   ossified;
 
-	time = now();
-	dir = opendir("pid");
-	if (!dir)
+	tm = now();
+	if (!(dir = opendir("pid")))
 		return;
 	while ((d = readdir(dir))) {
 		if (str_equal(d->d_name, ".") ||
@@ -78,18 +48,16 @@ cleanuppid()
 			continue;
 		if (stat(line.s, &st) == -1)
 			continue;
-		if (time < st.st_atime + OSSIFIED)
+		getEnvConfiguLong(&ossified, "OSSIFIED", OSSIFIED);
+		if (tm < st.st_atime + ossified)
 			continue;
 		unlink(line.s);
 	}
 	closedir(dir);
 }
 
-char            fnbuf[FMTQFN];
-
 void
-respond(s)
-	char           *s;
+respond(char *s)
 {
 	if (substdio_putflush(subfdoutsmall, s, 1) == -1)
 		_exit(100);
@@ -172,7 +140,44 @@ if (unlink(fnbuf) == -1) if (errno != error_noent) { respond("!"); continue; }
 void
 getversion_qmail_clean_c()
 {
-	static char    *x = "$Id: qmail-clean.c,v 1.14 2022-01-30 08:37:53+05:30 Cprogrammer Exp mbhangui $";
+	static char    *x = "$Id: qmail-clean.c,v 1.15 2023-12-25 09:28:53+05:30 Cprogrammer Exp mbhangui $";
 
 	x++;
 }
+
+/*
+ * $Log: qmail-clean.c,v $
+ * Revision 1.15  2023-12-25 09:28:53+05:30  Cprogrammer
+ * made OSSIFIED configurable
+ *
+ * Revision 1.14  2022-01-30 08:37:53+05:30  Cprogrammer
+ * made bigtodo configurable
+ *
+ * Revision 1.13  2021-06-27 10:45:02+05:30  Cprogrammer
+ * moved conf_split variable to fmtqfn.c
+ *
+ * Revision 1.12  2021-06-14 01:03:48+05:30  Cprogrammer
+ * removed chdir(auto_qmail)
+ *
+ * Revision 1.11  2021-05-16 00:40:21+05:30  Cprogrammer
+ * use configurable conf_split instead of auto_split variable
+ *
+ * Revision 1.10  2020-11-24 13:46:37+05:30  Cprogrammer
+ * removed exit.h
+ *
+ * Revision 1.9  2010-02-10 08:58:19+05:30  Cprogrammer
+ * removed dependency on indimail
+ *
+ * Revision 1.8  2007-12-20 12:46:57+05:30  Cprogrammer
+ * removed compiler warnings
+ *
+ * Revision 1.7  2004-10-22 20:28:12+05:30  Cprogrammer
+ * added RCS id
+ *
+ * Revision 1.6  2004-10-22 15:36:35+05:30  Cprogrammer
+ * removed readwrite.h
+ *
+ * Revision 1.5  2004-07-17 21:20:36+05:30  Cprogrammer
+ * added RCS log
+ *
+ */

--- a/indimail-mta-x/qmail-direct.9
+++ b/indimail-mta-x/qmail-direct.9
@@ -1,3 +1,4 @@
+.\" vim: tw=75
 .TH qmail-direct 8
 .SH NAME
 qmail-direct \- deliver mail message directly to Maildir
@@ -44,6 +45,11 @@ users.
 \fBqmail-direct\fR can deliver to any user for the root user. For any
 other user to deposit mails, the setuid bit needs to be set to root
 for \fBqmail-direct\fR executable.
+
+\fBqmail-direct\fR sets an alarm of 86400 seconds to quit if it doesn't
+complete. This can be changed by setting \fBDEATH\fR environment variable.
+See the man pages for \fBqmail-queue\fR(8) and indimail-mta-internals(7)
+for more details.
 
 .SH "EXIT CODES"
 \fBqmail-direct\fR does not print diagnostics. It exits 0 if it has
@@ -113,4 +119,5 @@ qmail-inject(8),
 qmail-queue(8),
 qmail-qmqpc(8),
 qmail-nullqueue(8),
-qmail-multi(8)
+qmail-multi(8),
+indimail-mta-internals(7)

--- a/indimail-mta-x/qmail-direct.c
+++ b/indimail-mta-x/qmail-direct.c
@@ -1,42 +1,5 @@
 /*
- * $Log: qmail-direct.c,v $
- * Revision 1.12  2022-04-04 14:23:27+05:30  Cprogrammer
- * refactored fastqueue and added setting of fdatasync()
- *
- * Revision 1.11  2022-04-03 18:41:49+05:30  Cprogrammer
- * use custom_error() for error messages
- *
- * Revision 1.10  2021-09-11 19:00:55+05:30  Cprogrammer
- * replace qmail with indimail-mta in received header
- *
- * Revision 1.9  2021-08-29 23:27:08+05:30  Cprogrammer
- * define functions as noreturn
- *
- * Revision 1.8  2021-07-05 21:23:10+05:30  Cprogrammer
- * use qgetpw interface from libqmail if USE_QPWGR is set
- *
- * Revision 1.7  2021-06-24 12:16:56+05:30  Cprogrammer
- * use uidinit function proto from auto_uids.h
- *
- * Revision 1.6  2021-06-15 21:51:31+05:30  Cprogrammer
- * pass local Maildir/tmp as argument to pidopen
- *
- * Revision 1.5  2021-06-12 18:16:49+05:30  Cprogrammer
- * moved pidopen out to its own file
- *
- * Revision 1.4  2021-05-01 22:31:32+05:30  Cprogrammer
- * use standard Maildir for queue operation
- * removed control file direct_mail_users
- *
- * Revision 1.3  2021-05-01 18:37:30+05:30  Cprogrammer
- * use modified Maildir as queue
- *
- * Revision 1.2  2021-05-01 14:50:33+05:30  Cprogrammer
- * removed uidinit() and auto_uids to run on a minimal system
- *
- * Revision 1.1  2021-04-29 21:16:22+05:30  Cprogrammer
- * Initial revision
- *
+ * $Id: qmail-direct.c,v 1.13 2023-12-25 09:29:13+05:30 Cprogrammer Exp mbhangui $
  */
 #include <unistd.h>
 #include <sys/types.h>
@@ -65,8 +28,8 @@
 #ifdef USE_FSYNC
 #include "syncdir.h"
 #endif
+#include "qmail.h"
 
-#define DEATH 86400				/* 24 hours; _must_ be below q-s's OSSIFIED (36 hours) */
 #define ADDR   1003
 
 static char     inbuf[2048];
@@ -331,6 +294,7 @@ int
 main(int argc, char **argv)
 {
 	unsigned int    ret, len, rcptcount, use_pwgr, fastqueue;
+	unsigned long   death;
 	uid_t           uid;
 	gid_t           gid;
 	char           *ptr, *home;
@@ -386,7 +350,8 @@ main(int argc, char **argv)
 	sig_miscignore();
 	sig_alarmcatch(sigalrm);
 	sig_bugcatch(sigbug);
-	alarm(DEATH);
+	getEnvConfiguLong(&death, "DEATH", DEATH);
+	alarm(death);
 
 	/*- set pidfn and open with fd = messfd */
 	if ((ret = pidopen(starttime, "tmp"))) {
@@ -571,9 +536,53 @@ main(int argc, char **argv)
 void
 getversion_qmail_direct_c()
 {
-	static char    *x = "$Id: qmail-direct.c,v 1.12 2022-04-04 14:23:27+05:30 Cprogrammer Exp mbhangui $";
+	static char    *x = "$Id: qmail-direct.c,v 1.13 2023-12-25 09:29:13+05:30 Cprogrammer Exp mbhangui $";
 
 	x = sccsidpidopenh;
 	if (x)
 		x++;
 }
+
+/*
+ * $Log: qmail-direct.c,v $
+ * Revision 1.13  2023-12-25 09:29:13+05:30  Cprogrammer
+ * made DEATH configurable
+ *
+ * Revision 1.12  2022-04-04 14:23:27+05:30  Cprogrammer
+ * refactored fastqueue and added setting of fdatasync()
+ *
+ * Revision 1.11  2022-04-03 18:41:49+05:30  Cprogrammer
+ * use custom_error() for error messages
+ *
+ * Revision 1.10  2021-09-11 19:00:55+05:30  Cprogrammer
+ * replace qmail with indimail-mta in received header
+ *
+ * Revision 1.9  2021-08-29 23:27:08+05:30  Cprogrammer
+ * define functions as noreturn
+ *
+ * Revision 1.8  2021-07-05 21:23:10+05:30  Cprogrammer
+ * use qgetpw interface from libqmail if USE_QPWGR is set
+ *
+ * Revision 1.7  2021-06-24 12:16:56+05:30  Cprogrammer
+ * use uidinit function proto from auto_uids.h
+ *
+ * Revision 1.6  2021-06-15 21:51:31+05:30  Cprogrammer
+ * pass local Maildir/tmp as argument to pidopen
+ *
+ * Revision 1.5  2021-06-12 18:16:49+05:30  Cprogrammer
+ * moved pidopen out to its own file
+ *
+ * Revision 1.4  2021-05-01 22:31:32+05:30  Cprogrammer
+ * use standard Maildir for queue operation
+ * removed control file direct_mail_users
+ *
+ * Revision 1.3  2021-05-01 18:37:30+05:30  Cprogrammer
+ * use modified Maildir as queue
+ *
+ * Revision 1.2  2021-05-01 14:50:33+05:30  Cprogrammer
+ * removed uidinit() and auto_uids to run on a minimal system
+ *
+ * Revision 1.1  2021-04-29 21:16:22+05:30  Cprogrammer
+ * Initial revision
+ *
+ */

--- a/indimail-mta-x/qmail-direct.c
+++ b/indimail-mta-x/qmail-direct.c
@@ -1,5 +1,5 @@
 /*
- * $Id: qmail-direct.c,v 1.13 2023-12-25 09:29:13+05:30 Cprogrammer Exp mbhangui $
+ * $Id: qmail-direct.c,v 1.13 2023-12-25 09:40:23+05:30 Cprogrammer Exp mbhangui $
  */
 #include <unistd.h>
 #include <sys/types.h>
@@ -11,6 +11,7 @@
 #include <open.h>
 #include <sig.h>
 #include <env.h>
+#include <getEnvConfig.h>
 #include <stralloc.h>
 #include <seek.h>
 #include <str.h>
@@ -536,7 +537,7 @@ main(int argc, char **argv)
 void
 getversion_qmail_direct_c()
 {
-	static char    *x = "$Id: qmail-direct.c,v 1.13 2023-12-25 09:29:13+05:30 Cprogrammer Exp mbhangui $";
+	static char    *x = "$Id: qmail-direct.c,v 1.13 2023-12-25 09:40:23+05:30 Cprogrammer Exp mbhangui $";
 
 	x = sccsidpidopenh;
 	if (x)
@@ -545,7 +546,7 @@ getversion_qmail_direct_c()
 
 /*
  * $Log: qmail-direct.c,v $
- * Revision 1.13  2023-12-25 09:29:13+05:30  Cprogrammer
+ * Revision 1.13  2023-12-25 09:40:23+05:30  Cprogrammer
  * made DEATH configurable
  *
  * Revision 1.12  2022-04-04 14:23:27+05:30  Cprogrammer

--- a/indimail-mta-x/qmail-dkim.9
+++ b/indimail-mta-x/qmail-dkim.9
@@ -309,6 +309,11 @@ By default \fBqmail-dkim\fR will use all of the headers when signing a
 message. You an exclude headers from gettng signed by setting a colon
 separated list of headers in \fBEXCLUDE_DKIMSIGN\fR environment variable.
 
+\fBqmail-dkim\fR sets an alarm of 86400 seconds to quit if it doesn't
+complete. This can be changed by setting \fBDEATH\fR environment variable.
+See the man pages for \fBqmail-queue\fR(8) and indimail-mta-internals(7)
+for more details.
+
 .SH NOTES
 If the environment variable \fBCONTROLDIR\fR is set, \fBqmail-dkim\fR uses
 that instead of @controldir@ to read control files and the private key.
@@ -347,4 +352,5 @@ qmail-inject(8),
 qmail-qmqpc(8),
 qmail-queue(8),
 qmail-send(8),
-qmail-smtpd(8)
+qmail-smtpd(8),
+indimail-mta-internals(7)

--- a/indimail-mta-x/qmail-dkim.c
+++ b/indimail-mta-x/qmail-dkim.c
@@ -1,5 +1,5 @@
 /*
- * $Id: qmail-dkim.c,v 1.76 2023-11-20 11:03:04+05:30 Cprogrammer Exp mbhangui $
+ * $Id: qmail-dkim.c,v 1.77 2023-12-25 09:30:05+05:30 Cprogrammer Exp mbhangui $
  */
 #include "hasdkim.h"
 #ifdef HASDKIM
@@ -24,6 +24,7 @@
 #include <now.h>
 #include <wait.h>
 #include <env.h>
+#include <getEnvConfig.h>
 #include <error.h>
 #include <dkim.h>
 #include <makeargs.h>
@@ -41,7 +42,6 @@
 
 #define DKIM_MALLOC(n)     OPENSSL_malloc(n)
 #define DKIM_MFREE(s)      OPENSSL_free(s); s = NULL;
-#define DEATH 86400	/*- 24 hours; _must_ be below q-s's OSSIFIED (36 hours) */
 #define ADDR 1003
 #define HAVE_EVP_SHA256
 #define strncasecmp(x,y,z) case_diffb((x), (z), (y))
@@ -938,7 +938,7 @@ main(int argc, char *argv[])
 	int             resDKIMSSP = -1, resDKIMADSP = -1, useSSP = 0, useADSP = 0, accept3ps = 0;
 	int             sCount = 0, sSize = 0, verbose = 0;
 	int             ret = 0, origRet = DKIM_MAX_ERROR, i, nSigCount = 0, len, token_len;
-	unsigned long   pid;
+	unsigned long   pid, death;
 	char           *selector = NULL, *ptr;
 	stralloc        dkimfn = {0};
 	DKIMVerifyDetails *pDetails;
@@ -1034,7 +1034,8 @@ main(int argc, char *argv[])
 	sig_miscignore();
 	sig_alarmcatch(sigalrm);
 	sig_bugcatch(sigbug);
-	alarm(DEATH);
+	getEnvConfiguLong(&death, "DEATH", DEATH);
+	alarm(death);
 	if (!(ptr = env_get("TMPDIR")))
 		ptr = "/tmp";
 	if ((ret = pidopen(starttime, ptr))) /*- set pidfn and open with fd = messfd */
@@ -1268,7 +1269,7 @@ main(int argc, char **argv)
 void
 getversion_qmail_dkim_c()
 {
-	static char    *x = "$Id: qmail-dkim.c,v 1.76 2023-11-20 11:03:04+05:30 Cprogrammer Exp mbhangui $";
+	static char    *x = "$Id: qmail-dkim.c,v 1.77 2023-12-25 09:30:05+05:30 Cprogrammer Exp mbhangui $";
 
 #ifdef HASDKIM
 	x = sccsidmakeargsh;
@@ -1282,6 +1283,9 @@ getversion_qmail_dkim_c()
 
 /*
  * $Log: qmail-dkim.c,v $
+ * Revision 1.77  2023-12-25 09:30:05+05:30  Cprogrammer
+ * made DEATH configurable
+ *
  * Revision 1.76  2023-11-20 11:03:04+05:30  Cprogrammer
  * Added env variable EXCLUDE_DKIMSIGN to exclude headers from DKIM signing
  * exclude Arc-Authentication-Results header from DKIM signing

--- a/indimail-mta-x/qmail-multi.9
+++ b/indimail-mta-x/qmail-multi.9
@@ -139,7 +139,8 @@ for more details.
 
 .SH "EXIT CODES"
 \fBqmail-multi\fR does not print diagnostics. It exits 120 if it is not
-able to exec \fBqmail-queue\fR
+able to exec \fBqmail-queue\fR. Apart from this it has the following exit
+codes.
 
 .EX
 It exits 51 if it cannot allocate memory

--- a/indimail-mta-x/qmail-multi.9
+++ b/indimail-mta-x/qmail-multi.9
@@ -132,6 +132,11 @@ temporary error.
 This remainder is added to QUEUE_START to arrive at which queue to use. It
 then sets the QUEUEDIR=@prefix@/sbin/qmail-queue to queue the mail.
 
+\fBqmail-multi\fR sets an alarm of 86400 seconds to quit if it doesn't
+complete. This can be changed by setting \fBDEATH\fR environment variable.
+See the man pages for \fBqmail-queue\fR(8) and indimail-mta-internals(7)
+for more details.
+
 .SH "EXIT CODES"
 \fBqmail-multi\fR does not print diagnostics. It exits 120 if it is not
 able to exec \fBqmail-queue\fR
@@ -176,7 +181,8 @@ bogofilter(1),
 queue-fix(8),
 spawn-filter(8),
 qscheduler(8),
-multi-queue(7)
+multi-queue(7),
+indimail-mta-internals(7)
 
 .SH "AUTHORS"
 

--- a/indimail-mta-x/qmail-multi.c
+++ b/indimail-mta-x/qmail-multi.c
@@ -1,24 +1,14 @@
 /*
- * $Log: qmail-multi.c,v $
- * Revision 1.3  2022-10-17 19:44:45+05:30  Cprogrammer
- * use exit codes defines from qmail.h
- *
- * Revision 1.2  2021-08-29 23:27:08+05:30  Cprogrammer
- * define functions as noreturn
- *
- * Revision 1.1  2021-06-12 18:21:28+05:30  Cprogrammer
- * Initial revision
- *
+ * $Id: qmail-multi.c,v 1.4 2023-12-25 09:30:34+05:30 Cprogrammer Exp mbhangui $
  */
 #include <unistd.h>
 #include <sig.h>
 #include <env.h>
+#include <getEnvConfig.h>
 #include <noreturn.h>
 #include "qmulti.h"
 #include "mailfilter.h"
 #include "qmail.h"
-
-#define DEATH 86400	/*- 24 hours; _must_ be below q-s's OSSIFIED (36 hours) */
 
 no_return void
 sigalrm()
@@ -37,12 +27,14 @@ int
 main(int argc, char **argv)
 {
 	char           *filterargs;
+	unsigned long   death;
 
 	sig_pipeignore();
 	sig_miscignore();
 	sig_alarmcatch(sigalrm);
 	sig_bugcatch(sigbug);
-	alarm(DEATH);
+	getEnvConfiguLong(&death, "DEATH", DEATH);
+	alarm(death);
 	filterargs = env_get("FILTERARGS");
 	return (filterargs ? mailfilter(argc, argv, filterargs) : qmulti(0, argc, argv));
 }
@@ -51,10 +43,26 @@ main(int argc, char **argv)
 void
 getversion_qmail_multi_c()
 {
-	static char    *x = "$Id: qmail-multi.c,v 1.3 2022-10-17 19:44:45+05:30 Cprogrammer Exp mbhangui $";
+	static char    *x = "$Id: qmail-multi.c,v 1.4 2023-12-25 09:30:34+05:30 Cprogrammer Exp mbhangui $";
 
 	x = sccsidqmultih;
 	x = sccsidmailfilterh;
 	x++;
 }
 #endif
+
+/*
+ * $Log: qmail-multi.c,v $
+ * Revision 1.4  2023-12-25 09:30:34+05:30  Cprogrammer
+ * made DEATH configurable
+ *
+ * Revision 1.3  2022-10-17 19:44:45+05:30  Cprogrammer
+ * use exit codes defines from qmail.h
+ *
+ * Revision 1.2  2021-08-29 23:27:08+05:30  Cprogrammer
+ * define functions as noreturn
+ *
+ * Revision 1.1  2021-06-12 18:21:28+05:30  Cprogrammer
+ * Initial revision
+ *
+ */

--- a/indimail-mta-x/qmail-nullqueue.8
+++ b/indimail-mta-x/qmail-nullqueue.8
@@ -1,16 +1,21 @@
+.\" vim: tw=75
 .TH qmail-nullqueue 8
+
 .SH NAME
 qmail-nullqueue - dissapear a message
+
 .SH SYNOPSIS
-.B qmail-nullqueue
+\fBqmail-nullqueue\fR
+
 .SH DESCRIPTION
-.B qmail-nullqueue
-reads a mail message from descriptor 0.
-It then reads envelope information from descriptor 1.
-It places the message for discarding instead of future delivery by \fBqmail-send\fR.
-\fBqmail-nullqueue\fR sets an alarm of 300 seconds after which it exits with code 52. This
-timeout can be changed by setting the environment variable \fBDEATH\fR. You should never be using
-this program unless you know what you are doing.
+\fBqmail-nullqueue\fR reads a mail message from descriptor 0. It then reads
+envelope information from descriptor 1. It places the message for
+discarding instead of future delivery by \fBqmail-send\fR.
+\fBqmail-nullqueue\fR sets an alarm of 86400 seconds after which it exits
+with code 52. This timeout can be changed by setting the environment
+variable \fBDEATH\fR. You should never be using this program unless you
+know what you are doing. See the man pages for \fBqmail-queue\fR(8) and
+indimail-mta-internals(7)for more details.
 
 .SH "SEE ALSO"
 addresses(5),

--- a/indimail-mta-x/qmail-nullqueue.c
+++ b/indimail-mta-x/qmail-nullqueue.c
@@ -1,30 +1,13 @@
 /*
- * $Log: qmail-nullqueue.c,v $
- * Revision 1.5  2021-08-29 23:27:08+05:30  Cprogrammer
- * define functions as noreturn
- *
- * Revision 1.4  2011-05-17 21:21:11+05:30  Cprogrammer
- * added timeout
- *
- * Revision 1.3  2004-10-22 20:28:35+05:30  Cprogrammer
- * added RCS id
- *
- * Revision 1.2  2004-07-15 23:32:39+05:30  Cprogrammer
- * fixed compilation warning
- *
- * Revision 1.1  2003-10-11 00:04:43+05:30  Cprogrammer
- * Initial revision
- *
- *
- * Send Mails to Trash
+ * $Id: qmail-nullqueue.c,v 1.6 2023-12-25 09:30:39+05:30 Cprogrammer Exp mbhangui $
  */
 #include <unistd.h>
 #include <sig.h>
 #include <scan.h>
 #include <env.h>
+#include <getEnvConfig.h>
 #include <noreturn.h>
-
-#define DEATH 300	/*- 24 hours; _must_ be below q-s's OSSIFIED (36 hours) */
+#include "qmail.h"
 
 no_return void
 sigalrm()
@@ -43,25 +26,20 @@ int
 main()
 {
 	int             n;
-	char           *x;
+	unsigned long   death;
 	char            buf[2048];
 
 	sig_alarmcatch(sigalrm);
 	sig_bugcatch(sigbug);
-	if (!(x = env_get("DEATH")))
-		n = DEATH;
-	else
-		scan_int(x, &n);
-	alarm(n);
-	for (;;)
-	{
+	getEnvConfiguLong(&death, "DEATH", DEATH);
+	alarm(death);
+	for (;;) {
 		if ((n = read(0, buf, sizeof(buf))) == -1)
 			_exit(54);
 		if (!n)
 			break;
 	}
-	for (;;)
-	{
+	for (;;) {
 		if ((n = read(1, buf, sizeof(buf))) == -1)
 			_exit(54);
 		if (!n)
@@ -75,7 +53,31 @@ main()
 void
 getversion_qmail_nullqueue_c()
 {
-	static char    *x = "$Id: qmail-nullqueue.c,v 1.5 2021-08-29 23:27:08+05:30 Cprogrammer Exp mbhangui $";
+	static char    *x = "$Id: qmail-nullqueue.c,v 1.6 2023-12-25 09:30:39+05:30 Cprogrammer Exp mbhangui $";
 
 	x++;
 }
+
+/*
+ * $Log: qmail-nullqueue.c,v $
+ * Revision 1.6  2023-12-25 09:30:39+05:30  Cprogrammer
+ * made DEATH configurable
+ *
+ * Revision 1.5  2021-08-29 23:27:08+05:30  Cprogrammer
+ * define functions as noreturn
+ *
+ * Revision 1.4  2011-05-17 21:21:11+05:30  Cprogrammer
+ * added timeout
+ *
+ * Revision 1.3  2004-10-22 20:28:35+05:30  Cprogrammer
+ * added RCS id
+ *
+ * Revision 1.2  2004-07-15 23:32:39+05:30  Cprogrammer
+ * fixed compilation warning
+ *
+ * Revision 1.1  2003-10-11 00:04:43+05:30  Cprogrammer
+ * Initial revision
+ *
+ *
+ * Send Mails to Trash
+ */

--- a/indimail-mta-x/qmail-queue.9
+++ b/indimail-mta-x/qmail-queue.9
@@ -114,6 +114,18 @@ If the environment variable \fBFASTQUEUE\fR is set, qmail-queue will bypass
 QHPSI, ORIGINIPFIELD, extraqueue, removeheaders, envheaders, logheaders,
 mailarchive control files
 
+\fBqmail-queue\fR sets an alarm of 86400 seconds to quit if it doesn't
+complete. This can be changed by setting \fBDEATH\fR environment variable.
+This should be less than 1296000 seconds or the value of \fBOSSIFIED\fR
+environment variable used by \fBqmail-clean\fR, \fBqmail-send\fR,
+\fBslowq-send\fR, \fBqmta-send\fR. These four programs delete any left over
+files that have not been accessed for more than \fBOSSIFIED\fR seconds in
+the \fIintd\fR, \fImess\fR and \fItodo\fR queue subdirectories. Any file in
+the \fIintd\fR and \fImess\fR sub directory that do not have a
+corresponding file in the \fIinfo\fR and the \fItodo\fR sub directory are
+files probably left due to a situation where \fBqmail-clean\fR didn't
+complete.
+
 .SH CONTROL FILES
 \fBqmail-queue\fR use many control files to provide various features.
 

--- a/indimail-mta-x/qmail-queue.9
+++ b/indimail-mta-x/qmail-queue.9
@@ -123,7 +123,7 @@ files that have not been accessed for more than \fBOSSIFIED\fR seconds in
 the \fIintd\fR, \fImess\fR and \fItodo\fR queue subdirectories. Any file in
 the \fIintd\fR and \fImess\fR sub directory that do not have a
 corresponding file in the \fIinfo\fR and the \fItodo\fR sub directory are
-files probably left due to a situation where \fBqmail-clean\fR didn't
+files probably left due to a situation where \fBqmail-queue\fR didn't
 complete.
 
 .SH CONTROL FILES
@@ -482,9 +482,9 @@ set in \fBQMAILQUEUE\fR environment variable and will ultimately execute
 \fBqscanq-stdin\fR(8)
 
 .SH "EXIT CODES"
-\fBqmail-queue\fR does not print diagnostics. It exits 0 if it has
-successfully queued the message. It exits between 1 and 99 if it has failed
-to queue the message.
+\fBqmail-queue\fR does not print diagnostics. It exits with various exit
+codes detailed below. It exits 0 if it has successfully queued the message.
+It exits between 1 and 99 if it has failed to queue the message.
 
 All \fBqmail-queue\fR error codes between 11 and 40 indicate permanent errors:
 .TP 5

--- a/indimail-mta-x/qmail-queue.c
+++ b/indimail-mta-x/qmail-queue.c
@@ -1,5 +1,5 @@
 /*
- * $Id: qmail-queue.c,v 1.91 2023-10-30 10:28:40+05:30 Cprogrammer Exp mbhangui $
+ * $Id: qmail-queue.c,v 1.92 2023-12-25 09:30:45+05:30 Cprogrammer Exp mbhangui $
  */
 #include <sys/types.h>
 #include <sys/stat.h>
@@ -53,7 +53,6 @@
 #include "custom_error.h"
 #include "qmail.h"
 
-#define DEATH 86400	/*- 24 hours; _must_ be below q-s's OSSIFIED (36 hours) */
 #define ADDR  1003
 #ifndef INET_ADDRSTRLEN
 #define INET_ADDRSTRLEN 16
@@ -728,6 +727,7 @@ main()
 #endif
 	static stralloc Queuedir = { 0 }, QueueBase = { 0 };
 	unsigned int    len, originipfield = 0;
+	unsigned long   death;
 	char            tmp[FMT_ULONG];
 	char            ch;
 	char           *ptr, *qqeh, *tmp_ptr, *qbase;
@@ -832,7 +832,8 @@ main()
 	sig_miscignore();
 	sig_alarmcatch(sigalrm);
 	sig_bugcatch(sigbug);
-	alarm(DEATH);
+	getEnvConfiguLong(&death, "DEATH", DEATH);
+	alarm(death);
 	pidopen();
 	if (fstat(messfd, &pidst) == -1)
 		die(QQ_MESS_FILE, 0, "unable to stat messfn");
@@ -1190,7 +1191,7 @@ main()
 void
 getversion_qmail_queue_c()
 {
-	static char    *x = "$Id: qmail-queue.c,v 1.91 2023-10-30 10:28:40+05:30 Cprogrammer Exp mbhangui $";
+	static char    *x = "$Id: qmail-queue.c,v 1.92 2023-12-25 09:30:45+05:30 Cprogrammer Exp mbhangui $";
 
 	x = sccsidmakeargsh;
 	x++;
@@ -1198,6 +1199,9 @@ getversion_qmail_queue_c()
 #endif
 /*
  * $Log: qmail-queue.c,v $
+ * Revision 1.92  2023-12-25 09:30:45+05:30  Cprogrammer
+ * made DEATH configurable
+ *
  * Revision 1.91  2023-10-30 10:28:40+05:30  Cprogrammer
  * use value of QREGEX to use matchregex()
  *

--- a/indimail-mta-x/qmail-send.9
+++ b/indimail-mta-x/qmail-send.9
@@ -96,7 +96,15 @@ If a message is temporarily undeliverable to one or more addresses,
 \fBqmail-clean\fR on descriptors 1, 3, and 5, and reads responses from
 descriptors 2, 4, and 6. \fBqmail-send\fR is responsible for avoiding
 deadlock. These descriptors are actually pipes setup by
-\fBqmail-start\fR(8).
+\fBqmail-start\fR(8). \fBqmail-send\fR uses \fBqmail-clean\fR(8) to cleanup
+message in \fIintd\fR, \fImess\fR queue subdirectory after a successful
+delivery. \fBqmail-send\fR also does cleanup of files left in case of a
+crash. See the section on \fBCleanups\fR in
+\fBindimail-mta-internals(7)\fR. Any left over file not accessed for more
+than 1296000 seconds are removed. The default of 129600 seconds can be
+changed by setting \fBOSSIFIED\fR environment variable. If setting
+\fBOSSIFIED\fR, ensure that it is larger than the value of \fBDEATH\fR
+environment variable used by \fBqmail-queue\fR.
 
 \fBqmail-send\fR uses \fBqmail-queue\fR to queue aliases, forwards and
 bounces. This can be changed by using \fBQMAILQUEUE\fR environment
@@ -657,6 +665,7 @@ nice(1),
 addresses(5),
 envelopes(5),
 indimail-control(5),
+indimail-mta-internals(7),
 indimail-srs(5),
 qmail-log(5),
 qmail-queue(8),

--- a/indimail-mta-x/qmail-send.c
+++ b/indimail-mta-x/qmail-send.c
@@ -1,5 +1,5 @@
 /*
- * $Id: qmail-send.c,v 1.112 2023-12-23 23:58:18+05:30 Cprogrammer Exp mbhangui $
+ * $Id: qmail-send.c,v 1.113 2023-12-25 09:30:51+05:30 Cprogrammer Exp mbhangui $
  */
 #include <sys/types.h>
 #include <unistd.h>
@@ -66,7 +66,6 @@
 #define SLEEP_FOREVER  86400 /*- absolute maximum time spent in select() */
 #define SLEEP_CLEANUP  76431 /*- time between cleanups */
 #define SLEEP_SYSFAIL    123
-#define OSSIFIED      129600 /*- 36 hours; _must_ exceed q-q's DEATH (24 hours) */
 
 static int      lifetime = 604800;
 static int      bouncemaxbytes = 50000;
@@ -531,7 +530,7 @@ cleanup_do()
 {
 	char            ch;
 	struct stat     st;
-	unsigned long   id;
+	unsigned long   id, ossified;
 
 	if (!flagcleanup) {
 		if (recent < cleanuptime)
@@ -552,7 +551,8 @@ cleanup_do()
 	fnmake_mess(id);
 	if (stat(fn1.s, &st) == -1)
 		return;	/*- probably qmail-queue deleted it */
-	if (recent <= st.st_atime + OSSIFIED)
+	getEnvConfiguLong(&ossified, "OSSIFIED", OSSIFIED);
+	if (recent <= st.st_atime + ossified)
 		return;
 	fnmake_info(id);
 	if (stat(fn1.s, &st) == 0)
@@ -2715,7 +2715,7 @@ main(int argc, char **argv)
 void
 getversion_qmail_send_c()
 {
-	static char    *x = "$Id: qmail-send.c,v 1.112 2023-12-23 23:58:18+05:30 Cprogrammer Exp mbhangui $";
+	static char    *x = "$Id: qmail-send.c,v 1.113 2023-12-25 09:30:51+05:30 Cprogrammer Exp mbhangui $";
 
 	x = sccsiddelivery_rateh;
 	x = sccsidgetdomainth;
@@ -2725,6 +2725,9 @@ getversion_qmail_send_c()
 
 /*
  * $Log: qmail-send.c,v $
+ * Revision 1.113  2023-12-25 09:30:51+05:30  Cprogrammer
+ * made OSSIFIED configurable
+ *
  * Revision 1.112  2023-12-23 23:58:18+05:30  Cprogrammer
  * log pid during startup
  *

--- a/indimail-mta-x/qmail-spamfilter.9
+++ b/indimail-mta-x/qmail-spamfilter.9
@@ -87,8 +87,14 @@ changed by passing the path of any qmail-queue frontend (along with
 arguments to the qmail-queue frontend) on the command line. Passing command
 line arguments takes precedence over environment variable.
 
+\fBqmail-spamfilter\fR sets an alarm of 86400 seconds to quit if it doesn't
+complete. This can be changed by setting \fBDEATH\fR environment variable.
+See the man pages for \fBqmail-queue\fR(8) and indimail-mta-internals(7)
+for more details.
+
 .SH "EXIT CODES"
-\fBqmail-spamfilter\fR does not print diagnostics.
+\fBqmail-spamfilter\fR does not print diagnostics. It uses the following
+exit codes indicating the problem.
 .EX
 .\" These codes should be taken from qmail.h
 It exits 51 if it cannot allocate memory
@@ -117,7 +123,8 @@ qscanq(8),
 cleanq(8),
 bogofilter(1),
 queue-fix(8),
-spawn-filter(8)
+spawn-filter(8),
+indimail-mta-internals(7)
 
 .SH "AUTHORS"
 

--- a/indimail-mta-x/qmail-spamfilter.c
+++ b/indimail-mta-x/qmail-spamfilter.c
@@ -1,5 +1,5 @@
 /*
- * $Id: qmail-spamfilter.c,v 1.8 2023-10-26 23:14:32+05:30 Cprogrammer Exp mbhangui $
+ * $Id: qmail-spamfilter.c,v 1.9 2023-12-25 09:31:02+05:30 Cprogrammer Exp mbhangui $
  */
 #include <unistd.h>
 #include <fcntl.h>
@@ -7,6 +7,7 @@
 #include <stralloc.h>
 #include <sig.h>
 #include <env.h>
+#include <getEnvConfig.h>
 #include <scan.h>
 #include <fmt.h>
 #include <wait.h>
@@ -17,8 +18,6 @@
 #include "auto_prefix.h"
 #include "qmulti.h"
 #include "qmail.h"
-
-#define DEATH 86400	/*- 24 hours; _must_ be below q-s's OSSIFIED (36 hours) */
 
 no_return void
 sigalrm()
@@ -38,6 +37,7 @@ main(int argc, char **argv)
 {
 	int             wstat, filt_exitcode, queueexitcode, n, ham_code = 1,
 					spam_code = 0, unsure_code = 2;
+	unsigned long   death;
 	int             pipefd[2], recpfd[2];
 	pid_t           filt_pid, queuepid;
 	struct substdio ssin, ssout;
@@ -52,7 +52,8 @@ main(int argc, char **argv)
 	sig_miscignore();
 	sig_alarmcatch(sigalrm);
 	sig_bugcatch(sigbug);
-	alarm(DEATH);
+	getEnvConfiguLong(&death, "DEATH", DEATH);
+	alarm(death);
 	if ((ptr = env_get("VIRUSCHECK")) && *ptr) {
 		scan_int(ptr, &n);
 		if (1 < n && 8 > n) {
@@ -233,7 +234,7 @@ finish:
 void
 getversion_qmail_spamfilter_c()
 {
-	static char    *x = "$Id: qmail-spamfilter.c,v 1.8 2023-10-26 23:14:32+05:30 Cprogrammer Exp mbhangui $";
+	static char    *x = "$Id: qmail-spamfilter.c,v 1.9 2023-12-25 09:31:02+05:30 Cprogrammer Exp mbhangui $";
 
 	x = sccsidqmultih;
 	x = sccsidmakeargsh;
@@ -244,6 +245,9 @@ getversion_qmail_spamfilter_c()
 
 /*
  * $Log: qmail-spamfilter.c,v $
+ * Revision 1.9  2023-12-25 09:31:02+05:30  Cprogrammer
+ * made DEATH configurable
+ *
  * Revision 1.8  2023-10-26 23:14:32+05:30  Cprogrammer
  * added HAMEXITCODE, UNSUREEXITCODE
  *

--- a/indimail-mta-x/qmail.h
+++ b/indimail-mta-x/qmail.h
@@ -1,29 +1,5 @@
 /*
- * $Log: qmail.h,v $
- * Revision 1.9  2023-02-08 18:47:31+05:30  Cprogrammer
- * added perm_error, temp_error macro to evaluate perm/temp errors
- *
- * Revision 1.8  2022-10-17 19:44:36+05:30  Cprogrammer
- * define qmail-queue exit codes
- *
- * Revision 1.7  2022-10-04 23:43:51+05:30  Cprogrammer
- * added comments
- *
- * Revision 1.6  2020-05-12 12:14:13+05:30  Cprogrammer
- * fix integer signedness error in qmail_put() (CVE-2005-1515)
- *
- * Revision 1.5  2009-04-21 14:27:24+05:30  Cprogrammer
- * define CUSTOM_ERR_FD
- *
- * Revision 1.4  2005-05-31 15:45:23+05:30  Cprogrammer
- * added fdc for passing custom error message to qmail-queue
- *
- * Revision 1.3  2004-10-11 13:57:51+05:30  Cprogrammer
- * added function prototypes
- *
- * Revision 1.2  2004-06-18 23:01:26+05:30  Cprogrammer
- * added RCS log
- *
+ * $Id: qmail.h,v 1.10 2023-12-25 09:30:13+05:30 Cprogrammer Exp mbhangui $
  */
 #ifndef QMAIL_H
 #define QMAIL_H
@@ -34,6 +10,8 @@
 #define CUSTOM_ERR_FD 2
 #endif
 
+#define DEATH         86400  /*- 24 hours; must be below qmail-send's OSSIFIED (36 hours) */
+#define OSSIFIED      129600 /*- 36 hours; must exceed   qmail-queue's DEATH   (24 hours) */
 
 struct qmail
 {
@@ -119,3 +97,34 @@ unsigned long   qmail_qp(struct qmail *);
 #define QQ_CRASHED           123
 
 #endif
+
+/*
+ * $Log: qmail.h,v $
+ * Revision 1.10  2023-12-25 09:30:13+05:30  Cprogrammer
+ * added defintion for DEATH and OSSIFIED
+ *
+ * Revision 1.9  2023-02-08 18:47:31+05:30  Cprogrammer
+ * added perm_error, temp_error macro to evaluate perm/temp errors
+ *
+ * Revision 1.8  2022-10-17 19:44:36+05:30  Cprogrammer
+ * define qmail-queue exit codes
+ *
+ * Revision 1.7  2022-10-04 23:43:51+05:30  Cprogrammer
+ * added comments
+ *
+ * Revision 1.6  2020-05-12 12:14:13+05:30  Cprogrammer
+ * fix integer signedness error in qmail_put() (CVE-2005-1515)
+ *
+ * Revision 1.5  2009-04-21 14:27:24+05:30  Cprogrammer
+ * define CUSTOM_ERR_FD
+ *
+ * Revision 1.4  2005-05-31 15:45:23+05:30  Cprogrammer
+ * added fdc for passing custom error message to qmail-queue
+ *
+ * Revision 1.3  2004-10-11 13:57:51+05:30  Cprogrammer
+ * added function prototypes
+ *
+ * Revision 1.2  2004-06-18 23:01:26+05:30  Cprogrammer
+ * added RCS log
+ *
+ */

--- a/indimail-mta-x/qmta-send.9
+++ b/indimail-mta-x/qmta-send.9
@@ -34,9 +34,20 @@ permissions for the queue, which can be created/fixed by running
 startup.
 
 If used with the \fB\-c\fR option, where \fBqmta-send\fR runs
-\fBqmail-clean\fR(8) to handle cleanup job, \fBqmta-send\fR doesn't require
-any special permission for the queue. The same queue permission as required
-for \fBqmail-send\fR or \fBslowq-send\fR will work for \fBqmta-send\fR.
+\fBqmail-clean\fR(8) to handle cleanup job. The cleanup is done in
+\fIintd\fR, \fImess\fR queue subdirectory The cleanup is done after a
+successful delivery. \fBqmta-send\fR also does cleanup of files left in
+case of a crash.  Without the \fB\-c\fR option, \fBqmta-send\fR does the
+clean itself. See the section on \fBCleanups\fR in
+\fBindimail-mta-internals(7)\fR. Any left over file not accessed for more
+than 1296000 seconds are removed. The default of 129600 seconds can be
+changed by setting \fBOSSIFIED\fR environment variable. If setting
+\fBOSSIFIED\fR, ensure that it is larger than the value of \fBDEATH\fR
+environment variable used by \fBqmail-queue\fR.
+
+\fBqmta-send\fR doesn't require any special permission for the queue. The
+same queue permission as required for \fBqmail-send\fR or \fBslowq-send\fR
+will work for \fBqmta-send\fR.
 
 .EX
 1. Setup a queue for qmta-send
@@ -688,6 +699,7 @@ nice(1),
 addresses(5),
 envelopes(5),
 indimail-control(5),
+indimail-mta-internals(7),
 indimail-srs(5),
 qmail-log(5),
 qmail-queue(8),

--- a/indimail-mta-x/qmta-send.c
+++ b/indimail-mta-x/qmta-send.c
@@ -1,5 +1,5 @@
 /*
- * $Id: qmta-send.c,v 1.28 2023-12-23 23:24:35+05:30 Cprogrammer Exp mbhangui $
+ * $Id: qmta-send.c,v 1.29 2023-12-25 09:31:23+05:30 Cprogrammer Exp mbhangui $
  */
 #include <unistd.h>
 #include <ctype.h>
@@ -51,7 +51,6 @@
 #include "set_environment.h"
 #include "set_queuedir.h"
 
-#define OSSIFIED      129600 /*- 36 hours; _must_ exceed q-q's DEATH (24 hours) */
 #define SLEEP_CLEANUP 76431 /*- time between cleanups */
 #define SLEEP_SYSFAIL 123
 #define SLEEP_FUZZ    1 /*- slop a bit on sleeps to avoid zeno effect */
@@ -274,7 +273,7 @@ cleanup_do(fd_set *wfds)
 {
 	char            ch;
 	struct stat     st;
-	unsigned long   id;
+	unsigned long   id, ossified;
 
 	if (!flagcleanup) {
 		if (recent < cleanuptime)
@@ -296,7 +295,8 @@ cleanup_do(fd_set *wfds)
 	fnmake_mess(id);
 	if (stat(fn1.s, &st) == -1)
 		return;	/*- probably qmail-queue deleted it */
-	if (recent <= st.st_atime + OSSIFIED)
+	getEnvConfiguLong(&ossified, "OSSIFIED", OSSIFIED);
+	if (recent <= st.st_atime + ossified)
 		return;
 	fnmake_info(id);
 	if (stat(fn1.s, &st) == 0)
@@ -2770,7 +2770,7 @@ main(int argc, char **argv)
 void
 getversion_qmta_send_c()
 {
-	static char    *x = "$Id: qmta-send.c,v 1.28 2023-12-23 23:24:35+05:30 Cprogrammer Exp mbhangui $";
+	static char    *x = "$Id: qmta-send.c,v 1.29 2023-12-25 09:31:23+05:30 Cprogrammer Exp mbhangui $";
 
 	if (x)
 		x++;
@@ -2778,6 +2778,9 @@ getversion_qmta_send_c()
 
 /*
  * $Log: qmta-send.c,v $
+ * Revision 1.29  2023-12-25 09:31:23+05:30  Cprogrammer
+ * made OSSIFIED configurable
+ *
  * Revision 1.28  2023-12-23 23:24:35+05:30  Cprogrammer
  * log pid during startup
  *

--- a/indimail-mta-x/slowq-send.9
+++ b/indimail-mta-x/slowq-send.9
@@ -84,7 +84,15 @@ If a message is temporarily undeliverable to one or more addresses,
 \fBqmail-clean\fR(8) on descriptors 1, 3, and 5, and reads responses from
 descriptors 2, 4, and 6. \fBslowq-send\fR is responsible for avoiding
 deadlock. These descriptors are actually pipes setup by
-\fBqmail-start\fR(8).
+\fBqmail-start\fR(8). \fBslowq-send\fR uses \fBqmail-clean\fR(8) to cleanup
+message in \fIintd\fR, \fItodo\fR, \fImess\fR queue subdirectory after a
+successful delivery. \fBslowq-send\fR also does cleanup of files left in
+case of a crash. See the section on \fBCleanups\fR in
+\fBindimail-mta-internals(7)\fR. Any left over file not accessed for more
+than 1296000 seconds are removed. The default of 129600 seconds can be
+changed by setting \fBOSSIFIED\fR environment variable. If setting
+\fBOSSIFIED\fR, ensure that it is larger than the value of \fBDEATH\fR
+environment variable used by \fBqmail-queue\fR.
 
 \fBslowq-send\fR uses \fBqmail-queue\fR to queue aliases, forwards and
 bounces. This can be changed by setting \fBQMAILQUEUE\fR environment
@@ -624,6 +632,7 @@ nice(1),
 addresses(5),
 envelopes(5),
 indimail-control(5),
+indimail-mta-internals(7),
 indimail-srs(5),
 qmail-log(5),
 qmail-queue(8),

--- a/indimail-mta-x/slowq-send.c
+++ b/indimail-mta-x/slowq-send.c
@@ -1,5 +1,5 @@
 /*
- * $Id: slowq-send.c,v 1.35 2023-12-23 23:25:37+05:30 Cprogrammer Exp mbhangui $
+ * $Id: slowq-send.c,v 1.36 2023-12-25 09:31:28+05:30 Cprogrammer Exp mbhangui $
  */
 #include <sys/types.h>
 #include <unistd.h>
@@ -62,7 +62,6 @@
 #define SLEEP_FOREVER  86400 /*- absolute maximum time spent in select() */
 #define SLEEP_CLEANUP  76431 /*- time between cleanups */
 #define SLEEP_SYSFAIL    123
-#define OSSIFIED      129600 /*- 36 hours; _must_ exceed q-q's DEATH (24 hours) */
 #ifndef TODO_INTERVAL
 #define SLEEP_TODO      1500 /*- check todo/ every 25 minutes in any case */
 #define ONCEEVERY         10 /*- Run todo maximal once every N seconds */
@@ -852,7 +851,7 @@ cleanup_do()
 {
 	char            ch;
 	struct stat     st;
-	unsigned long   id;
+	unsigned long   id, ossified;
 
 	if (!flagcleanup) {
 		if (recent < cleanuptime)
@@ -873,7 +872,8 @@ cleanup_do()
 	fnmake_mess(id);
 	if (stat(fn1.s, &st) == -1)
 		return;	/*- probably qmail-queue deleted it */
-	if (recent <= st.st_atime + OSSIFIED)
+	getEnvConfiguLong(&ossified, "OSSIFIED", OSSIFIED);
+	if (recent <= st.st_atime + ossified)
 		return;
 	fnmake_info(id);
 	if (stat(fn1.s, &st) == 0)
@@ -3808,7 +3808,7 @@ main(int argc, char **argv)
 void
 getversion_slowq_send_c()
 {
-	static char    *x = "$Id: slowq-send.c,v 1.35 2023-12-23 23:25:37+05:30 Cprogrammer Exp mbhangui $";
+	static char    *x = "$Id: slowq-send.c,v 1.36 2023-12-25 09:31:28+05:30 Cprogrammer Exp mbhangui $";
 
 	x = sccsiddelivery_rateh;
 	x = sccsidgetdomainth;
@@ -3818,6 +3818,9 @@ getversion_slowq_send_c()
 
 /*
  * $Log: slowq-send.c,v $
+ * Revision 1.36  2023-12-25 09:31:28+05:30  Cprogrammer
+ * made OSSIFIED configurable
+ *
  * Revision 1.35  2023-12-23 23:25:37+05:30  Cprogrammer
  * log pid during startup
  *

--- a/indimail-mta-x/svctool.9
+++ b/indimail-mta-x/svctool.9
@@ -308,6 +308,7 @@ Known values for OPTION are:
   [--setgroups]
   [--utf8]
   [--hide-host]
+  [--death=death]
   --default-domain=domain
 
  Installs a new queue with a delivery daemon
@@ -367,6 +368,8 @@ Known values for OPTION are:
   setgroups      - Add addition supplementary groups
   utf8           - Enable Email Address Internationalization Support (SMTPUTF8)
   hide-host      - Skip host names and IP addresses in received headers
+  death          - Value in seconds maximum time qmail-queue will run after
+                   which it will self terminate
 
 --slowq --qbase=queue_path
   --servicedir=service_path
@@ -391,6 +394,7 @@ Known values for OPTION are:
   [--setgroups]
   [--utf8]
   [--hide-host]
+  [--death=death]
   --default-domain=domain
 
  Installs a new queue with a delivery daemon
@@ -435,6 +439,8 @@ Known values for OPTION are:
   setgroups      - Add addition supplementary groups
   utf8           - Enable Email Address Internationalization Support (SMTPUTF8)
   hide-host      - Skip host names and IP addresses in received headers
+  death          - Value in seconds maximum time qmail-queue will run after
+                   which it will self terminate
 
 --queueParam=dir --qbase=queue_path --qcount=N --qstart=I
   [--cntrldir=cntrl_path]

--- a/indimail-mta-x/svctool.in
+++ b/indimail-mta-x/svctool.in
@@ -1,5 +1,5 @@
 #
-# $Id: svctool.in,v 2.712 2023-12-03 12:30:01+05:30 Cprogrammer Exp mbhangui $
+# $Id: svctool.in,v 2.713 2023-12-25 09:54:55+05:30 Cprogrammer Exp mbhangui $
 #
 
 #
@@ -27,7 +27,7 @@ host=@HOST@
 shared_objects=0
 use_dlmopen=0
 skip_sendmail_check=0
-RCSID="# \$Id: svctool.in,v 2.712 2023-12-03 12:30:01+05:30 Cprogrammer Exp mbhangui $"
+RCSID="# \$Id: svctool.in,v 2.713 2023-12-25 09:54:55+05:30 Cprogrammer Exp mbhangui $"
 
 #
 # End of User Configuration
@@ -233,6 +233,7 @@ Known values for OPTION are:
   [--setgroups]
   [--utf8]
   [--hide-host]
+  [--death=death]
   --default-domain=domain
 
  Installs a new queue with a delivery daemon
@@ -292,6 +293,8 @@ Known values for OPTION are:
   setgroups      - Add addition supplementary groups
   utf8           - Enable Email Address Internationalization Support (SMTPUTF8)
   hide-host      - Skip host names and IP addresses in received headers
+  death          - Value in seconds maximum time qmail-queue will run after
+                   which it will self terminate
 
 --slowq --qbase=queue_path
   --servicedir=service_path
@@ -316,6 +319,7 @@ Known values for OPTION are:
   [--setgroups]
   [--utf8]
   [--hide-host]
+  [--death=death]
   --default-domain=domain
 
  Installs a new queue with a delivery daemon
@@ -360,6 +364,8 @@ Known values for OPTION are:
   setgroups      - Add addition supplementary groups
   utf8           - Enable Email Address Internationalization Support (SMTPUTF8)
   hide-host      - Skip host names and IP addresses in received headers
+  death          - Value in seconds maximum time qmail-queue will run after
+                   which it will self terminate
 
 --queueParam=dir --qbase=queue_path --qcount=N --qstart=I
   [--cntrldir=cntrl_path]
@@ -6951,6 +6957,11 @@ if [ ! " $dmemory" = " " ] ; then
 else
 	echo 83886080 > $conf_dir/SOFT_MEM
 fi
+if [ $death != 86400 ] ; then
+	echo $death > $conf_dir/DEATH
+	ossified=$(echo $death | awk '{printf("%.0f\n", $1 + $1 * 0.5)}')
+	echo $ossified > $conf_dir/OSSIFIED
+fi
 if [ " $persistdb" = " 1" ] ; then
 	echo postmaster > $conf_dir/ROUTE_NULL_USER
 	echo > $conf_dir/AUTHSELF
@@ -7250,6 +7261,11 @@ if [ $todo_proc -eq 1 ] ; then
 	echo "1" > $conf_dir/TODO_PROCESSOR
 else
 	> $conf_dir/TODO_PROCESSOR
+fi
+if [ $death != 86400 ] ; then
+	echo $death > $conf_dir/DEATH
+	ossified=$(echo $death | awk '{printf("%.0f\n", $1 + $1 * 0.5)}')
+	echo $ossified > $conf_dir/OSSIFIED
 fi
 #
 # DEFAULT_DOMAIN will be used by vdelivermail for bounces
@@ -10425,6 +10441,7 @@ chksender=0
 chkrelay=0
 hidehost=0
 secureauth=0
+death=86400
 if [ " $CONTROLDIR" = " " ] ; then
 	cntrldir=$sysconfdir/control
 else
@@ -11090,6 +11107,10 @@ while test $# -gt 0; do
 
 	--resolvconf)
 	mount_resolvconf=1
+	;;
+
+	--death=*)
+	death=$optarg
 	;;
 
 	--initcmd=*)

--- a/indimail-mta-x/todo-proc.9
+++ b/indimail-mta-x/todo-proc.9
@@ -123,6 +123,15 @@ process a queue created with \fItodo\fR, \fIintd\fR with subdirectory split
 instead of without any split. This can be done by setting the \fBBIGTODO\fR
 environment variable.
 
+\fBtodo-proc\fR uses \fBqmail-clean\fR(8) to cleanup message in \fIintd\fR,
+\fItodo\fR queue subdirectory after a successful delivery. \fBtodo-proc\fR
+also does cleanup of files left in case of a crash. See the section on
+\fBCleanups\fR in \fBindimail-mta-internals(7)\fR. Any left over file not
+accessed for more than 1296000 seconds are removed. The default of 129600
+seconds can be changed by setting \fBOSSIFIED\fR environment variable. If
+setting \fBOSSIFIED\fR, ensure that it is larger than the value of
+\fBDEATH\fR environment variable used by \fBqmail-queue\fR.
+
 The control files conf-syncdir, conf-fsync take precedence over the
 environment variable counterparts. If the control conf-fsync, conf-syncdir
 are present, \fBqmail-send\fR will additionally set or unset the


### PR DESCRIPTION
1. Update the following files to make DEATH, OSSIFIED configurable qmail-clean.c, qmail-direct.c, qmail-dkim.c, qmail-multi.c, qmail-nullqueue.c, qmail-queue.c, qmail-send.c, qmail-spamfilter.c, qmta-send.c, slowq-send.c
2. Add compile time definition for DEATH, OSSIFIED in qmail.h
3. Updated the following man pages qmail-clean.9, qmail-direct.9, qmail-dkim.9, qmail-multi.9, qmail-nullqueue.8, qmail-queue.9, qmail-spamfilter.9, qmail-send.9, qmta-send.9, slowq-send.9, todo-proc.9
